### PR TITLE
fix(irc): match Python's CTCP VERSION reply, drop turborg-go leftovers

### DIFF
--- a/cmd/turborg/main.go
+++ b/cmd/turborg/main.go
@@ -1,4 +1,4 @@
-// Command turborg runs a turborg-go agent from environment-derived
+// Command turborg runs a turborg agent from environment-derived
 // settings. See README.md for the env-var contract.
 package main
 

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/version"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -903,7 +904,7 @@ func ctcpReply(text string) string {
 	}
 	switch cmd {
 	case "VERSION":
-		return "VERSION turborg-go"
+		return "VERSION turborg " + version.Version + " (https://github.com/turborg/turborg)"
 	case "PING":
 		return "PING " + arg
 	case "TIME":

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/version"
 )
 
 func TestIsWellFormed(t *testing.T) {
@@ -87,14 +88,14 @@ func TestCTCPHelpers(t *testing.T) {
 
 func TestCTCPReplyCovers(t *testing.T) {
 	cases := map[string]string{
-		"\x01VERSION\x01":        "VERSION turborg-go",
+		"\x01VERSION\x01":        "VERSION turborg " + version.Version + " (https://github.com/turborg/turborg)",
 		"\x01PING 12345\x01":     "PING 12345",
 		"\x01CLIENTINFO\x01":     "CLIENTINFO VERSION PING TIME CLIENTINFO SOURCE USERINFO",
 		"\x01SOURCE\x01":         "SOURCE https://github.com/turborg/turborg",
 		"\x01USERINFO\x01":       "USERINFO turborg agent",
 		"\x01\x01":               "",  // empty inner
 		"\x01UNKNOWN\x01":        "",  // unrecognized
-		"\x01version lowercase\x01": "VERSION turborg-go",
+		"\x01version lowercase\x01": "VERSION turborg " + version.Version + " (https://github.com/turborg/turborg)",
 	}
 	for in, want := range cases {
 		t.Run(in, func(t *testing.T) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
-// Package version exposes the build version of turborg-go. release-please
+// Package version exposes the build version of turborg. release-please
 // rewrites the Version constant below on every release PR. A single
 // constant in a tiny package keeps the bump diff minimal and avoids
 // pulling the import graph for anyone who only needs the version string.
 package version
 
-// Version is the current turborg-go release. Bumped by release-please.
+// Version is the current turborg release. Bumped by release-please.
 const Version = "0.1.0"


### PR DESCRIPTION
## Summary

- CTCP VERSION reply now matches Python v0.8.0 byte-for-byte: `VERSION turborg <version> (https://github.com/turborg/turborg)` instead of the port-era placeholder `VERSION turborg-go`.
- Drops `turborg-go` from package comments in `cmd/turborg/main.go` and `internal/version/version.go` (the working directory was renamed at cutover; the strings are stale).

## Test plan

- [ ] `make test` — `internal/connector/irc` `TestCTCPReplyCovers` still passes after the expected-string update
- [ ] `make lint cover-gate` green
- [ ] CI on this PR goes green (Lint, Test 1.25.x/1.26.x, Coverage gate, Build linux/amd64, cla-check)