### PR TITLE
docs: simplify README, add runnable example + coverage badge + docker quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,91 +7,33 @@
 [![CI](https://github.com/turborg/turborg/actions/workflows/ci.yml/badge.svg)](https://github.com/turborg/turborg/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/turborg/turborg)](https://goreportcard.com/report/github.com/turborg/turborg)
 
-```go
-package main
+## What it does
 
-import (
-    "context"
-    "os"
-    "os/signal"
-    "syscall"
+turborg connects an IRC nick to a network, joins channels, runs commands you register, and (optionally) lets a real human attach a HexChat / irssi / mIRC client through a built-in bouncer or use a browser-based reference UI through a built-in WebSocket gateway. All in one ~5 MB static binary.
 
-    "github.com/turborg/turborg/internal/agent"
-    "github.com/turborg/turborg/internal/connector/irc"
-)
-
-func main() {
-    a := agent.New(nil)
-    a.AddConnector(irc.New(&irc.Settings{
-        Hostname: "irc.libera.chat",
-        Nick:     "myturborg",
-        Channels: []string{"#turborg-test"},
-    }, nil, a.Events))
-
-    a.Commands.Register("ping", func(_ context.Context, env *agent.InboundEnvelope, _ []string) (*agent.OutboundEnvelope, error) {
-        return agent.ReplyTo(env, "pong"), nil
-    }, nil)
-
-    ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-    defer stop()
-    _ = a.Run(ctx)
-}
-```
-
-That's a working IRC bot — no LLM required. Add the WebGateway and the Bouncer and you've also got a browser-side IRC client and a HexChat/irssi tunnel through the same process — all in a single ~5 MB static binary.
-
----
-
-## What turborg gives you
-
-- **A real IRC connector**, not a toy — TLS, SASL PLAIN, NickServ identify, IRCv3 `server-time` + `account-tag`, full PRIVMSG / JOIN / PART / KICK / NICK / TOPIC tracking, and per-channel state cached from the wire. See [docs/connectors/irc.md](docs/connectors/irc.md).
-- **A built-in IRC bouncer.** Local clients (HexChat, irssi, mIRC) connect to the bot's loopback port, authenticate with a password, and tunnel through the bot's upstream session. The bot stays in control while a human can lurk and chat from their own client.
-- **A WebSocket gateway + reference web UI.** A vanilla-JS single-page client at `/` with channel sidebar, member list, slash commands, autocomplete, IndexedDB-backed per-channel scrollback that survives reloads, browser notifications, and clear UX for kicks/bans. SaaS deployments can swap in their own polished UI; the protocol is stable and documented.
-- **A normalized `Envelope`** so the same handler that runs on IRC will also run on Discord / Telegram / Web when those connectors land.
-- **Optional LLM**, not the centerpiece. If you set an API key, `!ask` is wired in (Anthropic Claude with prompt caching by default). If you don't, the rest of the bot doesn't care.
+- **A real IRC connector** — TLS, SASL PLAIN, NickServ identify, IRCv3 `server-time` + `account-tag`, full PRIVMSG / JOIN / PART / KICK / NICK / TOPIC tracking, per-channel state cached from the wire.
+- **A built-in IRC bouncer** — local clients connect to the bot's loopback port, authenticate with a password, and tunnel through the bot's upstream session. The bot stays in control while a human can lurk and chat from their own client.
+- **A WebSocket gateway + reference web UI** — vanilla-JS single-page client at `/` with channel sidebar, member list, slash commands, IndexedDB-backed scrollback, browser notifications. The protocol is stable and documented so SaaS deployments can swap in their own UI.
+- **A normalized `Envelope`** — the same handler that runs on IRC will also run on Discord / Telegram / Web when those connectors land.
+- **Optional LLM, not the centerpiece** — set an API key and `!ask` is wired in (Anthropic Claude with prompt caching). Leave it unset and the rest of the bot doesn't care.
 
 The design separates **how the bot talks to a network** (the connector) from **how it thinks** (any LLM, or none) from **what it does** (your handlers).
 
-For the long-term vision — **hive.xshellz.com**, a shared-intelligence cloud any turborg instance can attach to — see [docs/hive.md](docs/hive.md).
+## Quickstart: run the binary
 
-## Status
-
-**v0.1.0** — first Go release. Ported byte-for-byte from the Python `turborg` (now archived at [`turborg/turborg-python`](https://github.com/turborg/turborg-python)) with full feature parity. Same TURBORG_* env-var contract, same WS protocol JSON, same reference UI. The Python implementation is frozen at v0.8.0; new work happens here.
-
-| Connector  | Status     | Notes                                  |
-|------------|------------|----------------------------------------|
-| IRC        | Stable     | with bouncer + WS gateway              |
-| Discord    | Roadmap    | hopper                                 |
-| Telegram   | Roadmap    | hopper                                 |
-| WhatsApp   | Roadmap    | hopper                                 |
-
-LLM providers are **optional**. turborg runs perfectly fine as a pure command-driven bot without any LLM. When you do want one, Anthropic (default, with prompt caching) ships in-tree.
-
-## Install
+The bot ships as a single binary. Install it, set three env vars, run.
 
 ```bash
 go install github.com/turborg/turborg/cmd/turborg@latest
 ```
 
-Or grab a pre-built binary from the [releases page](https://github.com/turborg/turborg/releases), or pull the container image:
+Or grab a release from the [releases page](https://github.com/turborg/turborg/releases), or pull the container:
 
 ```bash
-docker pull ghcr.io/turborg/turborg:latest
+docker pull ghcr.io/turborg/turborg:latest   # ~10 MB, multi-arch
 ```
 
-The container is ~10 MB (distroless/static, multi-arch linux/amd64 + linux/arm64).
-
-Configure via environment variables (everything is `TURBORG_*`-prefixed) or a `.env` file. The most common minimum:
-
-```bash
-TURBORG_IRC_HOSTNAME=irc.libera.chat
-TURBORG_IRC_NICK=myturborg
-TURBORG_IRC_CHANNELS=#turborg-test
-```
-
-See [docs/configuration.md](docs/configuration.md) for the full list — SASL, NickServ identify, the bouncer, the web gateway, idle-shutdown, rate limits, logging.
-
-## Quickstart
+Minimum config — three env vars and you're online:
 
 ```bash
 export TURBORG_IRC_HOSTNAME=irc.libera.chat
@@ -100,7 +42,66 @@ export TURBORG_IRC_CHANNELS=#turborg-test
 turborg run
 ```
 
-You're online. To enable the AI command, also set `TURBORG_ANTHROPIC_API_KEY`. To attach HexChat through the built-in bouncer, set `TURBORG_IRC_BOUNCER_PASSWORD`. To open the reference web UI at `http://127.0.0.1:8765/`, set `TURBORG_WEB_PASSWORD`. Each is independent — pick what you need.
+In `#turborg-test`, type `!ping` — the bot replies `pong`. That's it.
+
+### Optional extras (each independent)
+
+| Want to…                                | Set this                                          |
+|------------------------------------------|---------------------------------------------------|
+| Enable the `!ask` AI command             | `TURBORG_ANTHROPIC_API_KEY=sk-...`                |
+| Attach HexChat through the bouncer       | `TURBORG_IRC_BOUNCER_PASSWORD=…`                  |
+| Open the web UI at `http://127.0.0.1:8765/` | `TURBORG_WEB_PASSWORD=…`                       |
+
+See `docs/configuration.md` for the full env-var reference — SASL, NickServ identify, rate limits, idle-shutdown, logging.
+
+## Quickstart: a minimal bot in Go
+
+If you want to read the code end-to-end or hack on it, a runnable ~40-line example lives in [`examples/turborg_irc/main.go`](examples/turborg_irc/main.go):
+
+```go
+package main
+
+import (
+    "context"
+    "log"
+    "os/signal"
+    "strings"
+    "syscall"
+
+    "github.com/turborg/turborg/internal/agent"
+    "github.com/turborg/turborg/internal/connector/irc"
+)
+
+func main() {
+    ircCfg, err := irc.LoadSettings()
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = ircCfg.Validate()
+
+    a := agent.New(nil)
+    a.AddConnector(irc.New(ircCfg, nil, a.Events))
+
+    a.Commands.Register("echo", func(_ context.Context, env *agent.InboundEnvelope, args []string) (*agent.OutboundEnvelope, error) {
+        return agent.ReplyTo(env, strings.Join(args, " ")), nil
+    }, nil)
+
+    ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+    defer stop()
+    _ = a.Run(ctx)
+}
+```
+
+Same env vars as the CLI quickstart:
+
+```bash
+export TURBORG_IRC_HOSTNAME=irc.libera.chat
+export TURBORG_IRC_NICK=myturborg
+export TURBORG_IRC_CHANNELS=#turborg-test
+go run ./examples/turborg_irc
+```
+
+`!ping`, `!help`, `!version` are pre-registered builtins. `!echo hello world` is the custom command this example adds. Ctrl-C unwinds cleanly within ~500ms.
 
 ## Run with Docker
 
@@ -115,37 +116,35 @@ Or without compose:
 docker run --env-file .env ghcr.io/turborg/turborg:latest
 ```
 
-## Documentation
+## Connectors
 
-- [Quickstart](docs/quickstart.md) — get a bot online in 5 minutes
-- [Architecture](docs/architecture.md) — the agent / connector / LLM / Envelope model
-- [IRC connector](docs/connectors/irc.md) — bouncer, SASL, web gateway, channel state
-- [Configuration](docs/configuration.md) — every environment variable, every default
-- [LLM providers (optional)](docs/llm-providers.md) — Anthropic (default) with streaming + prompt caching
-- [Writing a connector](docs/writing-a-connector.md) — add Discord, Telegram, your own
-- [Hive](docs/hive.md) — the future shared-intelligence cloud
+| Connector  | Status     | Notes                                  |
+|------------|------------|----------------------------------------|
+| IRC        | Stable     | with bouncer + WS gateway              |
+| Discord    | Roadmap    | hopper                                 |
+| Telegram   | Roadmap    | hopper                                 |
+| WhatsApp   | Roadmap    | hopper                                 |
+
+LLM providers are **optional**. turborg runs perfectly fine as a pure command-driven bot without any LLM. When you want one, Anthropic (default, with prompt caching) ships in-tree.
 
 ## Project layout
 
 ```
 turborg/
 ├── cmd/turborg/                 entry point — wires cobra + config + runtime
+├── examples/turborg_irc/        minimal embeddable example (runnable)
 ├── internal/
 │   ├── agent/                   Agent, EventBus, CommandRegistry, Envelope
-│   ├── connector/
-│   │   └── irc/                 IRC connector + bouncer + protocol + state
-│   ├── llm/
-│   │   └── anthropic/           Anthropic Claude with streaming + prompt caching
+│   ├── connector/irc/           IRC connector + bouncer + protocol + state
+│   ├── llm/anthropic/           Anthropic Claude with streaming + prompt caching
 │   ├── web/                     WebSocket gateway + embedded reference UI
 │   ├── config/                  TURBORG_* settings (env-driven)
 │   ├── runtime/                 build the wired agent from settings
 │   ├── hive/                    Hive client (noop stub today)
 │   ├── logging/                 slog handler factory
-│   └── version/                 single Version constant (release-please bumps)
+│   └── version/                 single Version constant
 ├── tests/fixtures/              FakeIRCServer + FakeConnector for tests
-├── .github/workflows/           ci + release + cla
-├── Dockerfile                   multi-stage → distroless/static-debian12
-└── docs/                        full documentation
+└── .github/workflows/           ci + release + cla
 ```
 
 ## Testing
@@ -157,11 +156,16 @@ make cover-gate            # enforce per-package + total thresholds (.testcovera
 make lint                  # golangci-lint run ./...
 ```
 
-CI runs the same gates plus a Go 1.25/1.26 test matrix and a build smoke test (`turborg --version`).
+CI runs the same gates plus a Go 1.25/1.26 test matrix and a build smoke test. **Total coverage gate: ≥ 95%.**
 
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup, branching strategy, and PR rules. By submitting a contribution you agree to the [Contributor License Agreement](CLA.md) — the cla-assistant bot will guide you on first PR.
+
+- Conventional Commits for PR titles (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
+- Squash-merge to `main`; linear history
+- gofmt-formatted, golangci-lint clean
+- `go test -race` green, coverage gate green
 
 ## License
 
@@ -170,13 +174,6 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev se
 ## Security
 
 Found a vulnerability? Please **do not** open a public issue. See [SECURITY.md](SECURITY.md) for the responsible-disclosure process.
-
-## Style
-
-- Conventional Commits for PR titles (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`)
-- Squash-merge to `main`; linear history
-- gofmt-formatted, golangci-lint clean
-- `go test -race` with coverage; **fail under 90% total**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go ≥1.25](https://img.shields.io/badge/go-%E2%89%A51.25-00ADD8.svg)](https://go.dev/dl/)
 [![CI](https://github.com/turborg/turborg/actions/workflows/ci.yml/badge.svg)](https://github.com/turborg/turborg/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)](.testcoverage.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/turborg/turborg)](https://goreportcard.com/report/github.com/turborg/turborg)
 
 ## What it does
@@ -105,15 +106,42 @@ go run ./examples/turborg_irc
 
 ## Run with Docker
 
+The published image is `ghcr.io/turborg/turborg:latest` (multi-arch `linux/amd64` + `linux/arm64`, ~10 MB, distroless/static).
+
+**Inline env vars — fastest path:**
+
 ```bash
-cp .env.example .env       # fill in TURBORG_IRC_* (and optionally LLM / web / bouncer)
-docker compose up
+docker run --rm \
+  -e TURBORG_IRC_HOSTNAME=irc.libera.chat \
+  -e TURBORG_IRC_NICK=myturborg \
+  -e TURBORG_IRC_CHANNELS=#turborg-test \
+  ghcr.io/turborg/turborg:latest
 ```
 
-Or without compose:
+**With an .env file:**
 
 ```bash
-docker run --env-file .env ghcr.io/turborg/turborg:latest
+cp .env.example .env       # fill in TURBORG_IRC_* (+ optional LLM / web / bouncer)
+docker run --rm --env-file .env ghcr.io/turborg/turborg:latest
+```
+
+**docker compose:**
+
+```bash
+docker compose up          # same .env file, plus port mappings if you enabled the web UI
+```
+
+Pin a specific version in production — `ghcr.io/turborg/turborg:v0.1.0` rather than `:latest`. Tags follow the GitHub releases.
+
+To expose the web UI to the host, also publish the port:
+
+```bash
+docker run --rm \
+  -e TURBORG_WEB_PASSWORD=changeme \
+  -e TURBORG_WEB_HOST=0.0.0.0 \
+  -p 8765:8765 \
+  --env-file .env \
+  ghcr.io/turborg/turborg:latest
 ```
 
 ## Connectors

--- a/examples/turborg_irc/main.go
+++ b/examples/turborg_irc/main.go
@@ -1,0 +1,55 @@
+// A minimal turborg IRC bot in ~40 lines.
+//
+// Run it:
+//
+//	export TURBORG_IRC_HOSTNAME=irc.libera.chat
+//	export TURBORG_IRC_NICK=myturborg
+//	export TURBORG_IRC_CHANNELS=#turborg-test
+//	go run ./examples/turborg_irc
+//
+// In #turborg-test, type `!ping` or `!echo hello` — the bot replies.
+// Ctrl-C unwinds cleanly within ~500ms.
+//
+// Same wiring the production `turborg` binary uses internally (see
+// cmd/turborg/main.go); this file just trims it down to the smallest
+// thing you can read end-to-end.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+func main() {
+	ircCfg, err := irc.LoadSettings()
+	if err != nil {
+		log.Fatalf("config: %v (set TURBORG_IRC_HOSTNAME and TURBORG_IRC_NICK)", err)
+	}
+	if err := ircCfg.Validate(); err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	a := agent.New(nil)
+	a.AddConnector(irc.New(ircCfg, nil, a.Events))
+
+	// Built-in commands (ping, help, version) are already registered.
+	// Add your own — the handler returns an outbound envelope or nil.
+	a.Commands.Register("echo", func(_ context.Context, env *agent.InboundEnvelope, args []string) (*agent.OutboundEnvelope, error) {
+		return agent.ReplyTo(env, strings.Join(args, " ")), nil
+	}, nil)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := a.Run(ctx); err != nil {
+		log.Printf("agent: %v", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

- Drop the v0.1.0 Python-port framing — turborg stands on its own; a new reader doesn't need archeology about where it came from.
- Restructure into two quickstarts: (1) install the binary + 3 env vars, (2) embed in Go via a small example file. Optional extras (bouncer, web UI, LLM) are a clear table, each independent.
- Add `examples/turborg_irc/main.go` — a runnable ~40-line single-file bot that loads `TURBORG_IRC_*` env, registers a custom `!echo` command on top of the builtins, and exits cleanly on SIGTERM. Lives inside the repo so the `internal/` imports work, and the README points to it as the canonical "embed me" reference.
- Add a static coverage badge (`95%`) linking to `.testcoverage.yml`. Bump it when the gate threshold changes; upgrade to codecov.io or a CI-committed SVG later if auto-update becomes worth it.
- Expand the Docker section with three paths (inline env, `--env-file`, `docker compose`), a port-publish example for the web UI, and a note to pin a release tag in prod.
- Bump the documented total coverage gate from 90 → 95 to match `.testcoverage.yml` (PR #8).

## Test plan

- [ ] `go build ./...` clean
- [ ] `go run ./examples/turborg_irc` against a real IRC network responds to `!ping` and `!echo hi`
- [ ] `make lint` green