### PR TITLE
fix(test): determinize agent drain test, restore reliable 98% coverage

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -171,21 +171,41 @@ func TestAgentLogReturnsConfiguredLogger(t *testing.T) {
 }
 
 func TestAgentDrainReturnsOnInboundChannelClose(t *testing.T) {
+	// drain's select races between two ready branches when CloseInbound
+	// AND cancel() fire back-to-back: closed-channel-recv and ctx.Done
+	// are both selectable, and Go picks pseudo-randomly. Earlier this
+	// test cancelled before drain could observe the close, so coverage
+	// of the `if !ok { return nil }` branch was non-deterministic — it
+	// passed locally and on most CI runs, then failed on main after a
+	// merge with unlucky scheduling.
+	//
+	// Sequence here forces drain through the !ok branch: close the
+	// inbox while ctx is still live, give drain a tick to observe the
+	// close and return, then cancel to unwind the connector's Run loop.
 	a := agent.New(nil)
 	c := fakeconn.New("closer")
 	a.AddConnector(c)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan error, 1)
 	go func() { done <- a.Run(ctx) }()
 
-	// Close the inbound channel — drain must return cleanly without
-	// blocking ctx cancellation.
 	require.Eventually(t, func() bool { return c.Started() },
 		time.Second, 10*time.Millisecond)
+
+	// Step 1: close the inbox. ctx is still live, so drain's select
+	// has exactly one ready case — the closed channel — and reads !ok
+	// deterministically.
 	c.CloseInbound()
 
+	// Step 2: give drain a beat to observe the close. A closed-channel
+	// select wakes up in microseconds; 50ms is overkill on any runner.
+	time.Sleep(50 * time.Millisecond)
+
+	// Step 3: unwind the connector's Run (which blocks on ctx.Done).
 	cancel()
+
 	select {
 	case err := <-done:
 		if err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
## Why main went red after #9 merged

**The CI workflow on PRs and main is already identical** — see \`.github/workflows/ci.yml\`:

\`\`\`yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
\`\`\`

Same jobs, same gate command, same artifacts. Branch protection requires those checks pass before merge. There is no PR-vs-main gap.

What did differ: **goroutine scheduling between two test runs**. \`TestAgentDrainReturnsOnInboundChannelClose\` (added in #8) called \`CloseInbound()\` and \`cancel()\` back-to-back. By the time \`drain\` ran its next \`select\` iteration, BOTH the closed-channel case AND \`ctx.Done\` were selectable, and Go's select picks pseudo-randomly. Coverage of \`if !ok { return nil }\` flipped 0/1 between runs:

- !ok path hit  → agent package = 98.4%
- ctx.Done path → agent package = 97.7%

The gate is set to 98 for that package. The PR run got the lucky scheduling; the post-merge main run got the unlucky one.

## The fix

Sequence the test so drain has exactly one selectable branch at the moment it matters:

1. \`CloseInbound\` while ctx is **still live** → drain's select has only the closed-recv case ready, reads \`!ok\`, returns nil.
2. Sleep 50ms so drain actually runs before we cancel. (Closed-channel selects wake in microseconds; 50ms is generous.)
3. \`cancel()\` to unwind the connector's blocked \`Run\` loop so \`Agent.Run\` returns.

Stress-tested at \`-count=50\` locally — every run reproduces 98.4% on the nose. \`make cover-gate\` now passes locally with the gate unchanged.

## Test plan

- [x] \`go test -race -count=50 ./internal/agent/...\` — all green, coverage always 98.4%
- [x] \`make cover-gate\` — passes locally (total 95.0%, every package above gate)
- [ ] CI green on this PR (both Go versions)