### PR TITLE
fix(version): make Version a var so -X injection actually works

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker run --rm --env-file .env ghcr.io/turborg/turborg:latest
 docker compose up          # same .env file, plus port mappings if you enabled the web UI
 ```
 
-Pin a specific version in production — `ghcr.io/turborg/turborg:v0.1.0` rather than `:latest`. Tags follow the GitHub releases.
+Pin a specific version in production — `ghcr.io/turborg/turborg:0.1.1` rather than `:latest`. Image tags drop the `v` prefix from the git tag (`v0.1.1` → `:0.1.1`); see the [releases page](https://github.com/turborg/turborg/releases) for available versions.
 
 To expose the web UI to the host, also publish the port:
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,13 @@
 // Package version exposes the build version of turborg. release-please
-// rewrites the Version constant below on every release PR. A single
-// constant in a tiny package keeps the bump diff minimal and avoids
-// pulling the import graph for anyone who only needs the version string.
+// rewrites the Version literal below on every release PR (driven by the
+// `x-release-please-version` marker comment); local + CI builds may
+// override it via `-ldflags="-X .../version.Version=<value>"`. A single
+// var in a tiny package keeps the bump diff minimal and avoids pulling
+// the import graph for anyone who only needs the version string.
 package version
 
-// Version is the current turborg release. Bumped by release-please.
-const Version = "0.1.0"
+// Version is the current turborg release. Must be a `var` (not `const`)
+// so the linker can override it with `-X` at build time — `-X` is a
+// no-op on consts. Source-of-truth value here is bumped by release-please
+// on the marker line.
+var Version = "0.1.1" // x-release-please-version


### PR DESCRIPTION
## Why v0.1.1 reports itself as 0.1.0

Two compounding bugs in the version-string pipeline:

1. **\`internal/version/version.go\` declared \`Version\` as a \`const\`.** Go's \`-ldflags \"-X path.Var=value\"\` only works on \`var\` — the linker can't relocate immutable values. Both the Makefile's \`-X .../Version=dev\` and GoReleaser's \`-X .../Version={{.Version}}\` were silently no-ops. The binary always reported whatever literal was in the source file.

2. **\`release-please-config.json\` listed \`version.go\` as an \`extra-files\` target** but the file lacked the \`x-release-please-version\` marker comment that the \"generic\" updater needs to know which line to substitute. release-please's \"bump version.go\" step did nothing on the v0.1.1 release PR — the source literal stayed at \`0.1.0\`.

## Fix

- Convert \`const Version\` → \`var Version\` so \`-X\` can override it.
- Add the marker comment so release-please bumps the literal on the next release.
- Set the source default to \`0.1.1\` (matches the currently-shipped tag).
- Update README's docker-tag example to \`:0.1.1\` and document that GoReleaser drops the \`v\` prefix from image tags (so the canonical pin form is \`ghcr.io/turborg/turborg:0.1.1\`, not \`:v0.1.1\`).

## What this changes for future releases

After this lands and the next release PR is cut:

1. release-please rewrites the marker line: \`var Version = \"0.1.1\"\` → \`var Version = \"0.1.2\"\`.
2. GoReleaser's \`-X .../Version={{.Version}}\` correctly overrides any drift between source and tag at build time.
3. \`./turborg --version\` matches the tag from v0.1.2 onwards.

v0.1.1 itself can't be retroactively fixed (image already shipped) but the bug stops here.

## Test plan

- [x] \`go build -ldflags=\"-X .../Version=test123\" ...\` → \`--version\` prints \`test123\` (verified locally with no-injection + injected paths)
- [x] \`make build && ./bin/turborg --version\` → prints \`dev\` (the Makefile's injected value), proving \`-X\` now works
- [ ] CI green