### PR TITLE
refactor(gateway)!: move WS gateway env to TURBORG_GATEWAY_*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,13 @@
 #
 # Variable layout:
 #   TURBORG_*                  cross-cutting bot settings (config.Settings)
+#   TURBORG_GATEWAY_*          control-plane gateway (WS protocol + reference UI)
 #   TURBORG_<CONNECTOR>_*      per-connector settings (e.g. irc.Settings)
 #
 # Per-connector vars further group by sub-feature, e.g. for IRC:
 #   TURBORG_IRC_*              connection, auth, timing
 #   TURBORG_IRC_SASL_*         SASL PLAIN credentials
 #   TURBORG_IRC_BOUNCER_*      local TCP bouncer for HexChat/irssi/mIRC
-#   TURBORG_IRC_WEB_*          WebSocket gateway + reference UI for the IRC connector
 #   TURBORG_IRC_CTCP_*         CTCP auto-reply + throttle
 #
 # Defaults are shown after `=`; commented lines preserve the documented
@@ -54,6 +54,32 @@
 # --- Hive (placeholder — not yet shipping in v0.x) ---
 # TURBORG_HIVE_ENABLED=false
 # TURBORG_HIVE_URL=...                                   # override; default is the public hive once it ships
+
+
+# =============================================================================
+# Gateway (TURBORG_GATEWAY_*, optional — set password to enable)
+# =============================================================================
+# Control-plane gateway for the agent: WebSocket protocol that streams
+# events to clients and accepts command ops, plus a bundled vanilla-JS
+# reference UI at http://<host>:<port>/. The Go type is web.Gateway; the
+# env names describe the role (control plane), not the transport, so they
+# survive future protocol/connector additions.
+#
+# SaaS deployments swap StaticPasswordVerifier for a JWT/session-aware
+# verifier; the wire protocol is unchanged.
+
+# TURBORG_GATEWAY_PASSWORD=hunter2
+# TURBORG_GATEWAY_HOST=127.0.0.1                         # 0.0.0.0 only behind TLS proxy
+# TURBORG_GATEWAY_PORT=8765
+# TURBORG_GATEWAY_MAX_FAILED_ATTEMPTS=5                  # per-IP brute-force protection
+# TURBORG_GATEWAY_FAILURE_WINDOW_SECONDS=60
+# TURBORG_GATEWAY_LOCKOUT_SECONDS=300
+
+# SaaS lifecycle: when set, the gateway calls its idle-shutdown callback
+# N seconds after the last WS client disconnects. Free-tier containers
+# set this; premium / always-on bouncer instances leave it unset. Bouncer
+# connections do NOT extend the timer — only WS clients do.
+# TURBORG_GATEWAY_IDLE_SHUTDOWN_SECONDS=300
 
 
 # =============================================================================
@@ -124,29 +150,3 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 # TURBORG_IRC_BOUNCER_MAX_FAILED_ATTEMPTS=5
 # TURBORG_IRC_BOUNCER_FAILURE_WINDOW_SECONDS=60
 # TURBORG_IRC_BOUNCER_LOCKOUT_SECONDS=300
-
-
-# =============================================================================
-# IRC connector — web (TURBORG_IRC_WEB_*, optional — set password to enable)
-# =============================================================================
-# WebSocket gateway + bundled reference UI for the IRC connector. Real-time
-# JSON event stream + control surface for web frontends; reference UI at
-# http://<host>:<port>/. SaaS deployments swap StaticPasswordVerifier for
-# a JWT/session-aware verifier; the wire protocol is unchanged.
-#
-# A future general-purpose bot-core web connector will claim TURBORG_WEB_*;
-# this one is IRC-coupled (speaks IRCBridge / shows channel state), so it
-# lives next to the bouncer.
-
-# TURBORG_IRC_WEB_PASSWORD=hunter2
-# TURBORG_IRC_WEB_HOST=127.0.0.1                         # 0.0.0.0 only behind TLS proxy
-# TURBORG_IRC_WEB_PORT=8765
-# TURBORG_IRC_WEB_MAX_FAILED_ATTEMPTS=5                  # per-IP brute-force protection
-# TURBORG_IRC_WEB_FAILURE_WINDOW_SECONDS=60
-# TURBORG_IRC_WEB_LOCKOUT_SECONDS=300
-
-# SaaS lifecycle: when set, the gateway calls its idle-shutdown callback
-# N seconds after the last WS client disconnects. Free-tier containers
-# set this; premium / always-on bouncer instances leave it unset. Bouncer
-# connections do NOT extend the timer — only WS clients do.
-# TURBORG_IRC_WEB_IDLE_SHUTDOWN_SECONDS=300

--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,61 @@
 # Sample environment file for turborg. Copy to `.env` and fill in.
 # Never commit your real `.env` — it's already covered by .gitignore.
 #
-# Every variable below maps to a field on either config.Settings
-# (top-level bot/agent/web stuff, prefix `TURBORG_`) or irc.Settings
-# (per-connector, prefix `TURBORG_IRC_`). Defaults are shown after `=`;
-# commented lines preserve the documented default behavior.
+# Variable layout:
+#   TURBORG_*                  cross-cutting bot settings (config.Settings)
+#   TURBORG_<CONNECTOR>_*      per-connector settings (e.g. irc.Settings)
+#
+# Per-connector vars further group by sub-feature, e.g. for IRC:
+#   TURBORG_IRC_*              connection, auth, timing
+#   TURBORG_IRC_SASL_*         SASL PLAIN credentials
+#   TURBORG_IRC_BOUNCER_*      local TCP bouncer for HexChat/irssi/mIRC
+#   TURBORG_IRC_WEB_*          WebSocket gateway + reference UI for the IRC connector
+#   TURBORG_IRC_CTCP_*         CTCP auto-reply + throttle
+#
+# Defaults are shown after `=`; commented lines preserve the documented
+# default behavior.
 
 
 # =============================================================================
-# IRC connection (required)
+# Core (TURBORG_*)
+# =============================================================================
+
+# --- Logging ---
+# TURBORG_LOG_LEVEL=INFO                                 # DEBUG / INFO / WARNING / ERROR / CRITICAL
+# TURBORG_LOG_FORMAT=text                                # text (human) or json (CW Logs / Loki ingestion)
+
+# --- Command dispatch ---
+# TURBORG_COMMAND_PREFIX=!                               # leading character for !ping etc.
+# TURBORG_COMMAND_MAX_PER_WINDOW=5                       # per-sender sliding-window throttle
+# TURBORG_COMMAND_WINDOW_SECONDS=30
+
+# --- Owner / authorization for !commands ---
+# By default ANYONE can run !commands. Lock them to a single operator with
+# either or both of the following — set both for defense-in-depth on
+# services-enabled networks (account-tag is the truthful identity, nick
+# match is a spelling check).
+#
+# TURBORG_OWNER_NICK=...                                 # case-insensitive nick match
+# TURBORG_OWNER_ACCOUNT=...                              # NickServ account (IRCv3 account-tag;
+#                                                        # fails closed if the network has no services)
+
+# --- Connector selection ---
+# TURBORG_CONNECTORS=irc                                 # CSV; empty = quickstart IRC only
+
+# --- LLM (Anthropic; unset → standalone mode, no !ask) ---
+# When TURBORG_ANTHROPIC_API_KEY is set, the !ask command activates and
+# AnthropicProvider is wired in. Without it, the agent runs IRC-only.
+#
+# TURBORG_ANTHROPIC_API_KEY=sk-ant-...
+# TURBORG_ANTHROPIC_MODEL=claude-sonnet-4-6              # default; claude-opus-4-7 also valid
+
+# --- Hive (placeholder — not yet shipping in v0.x) ---
+# TURBORG_HIVE_ENABLED=false
+# TURBORG_HIVE_URL=...                                   # override; default is the public hive once it ships
+
+
+# =============================================================================
+# IRC connector — connection (TURBORG_IRC_*, required)
 # =============================================================================
 
 TURBORG_IRC_HOSTNAME=irc.libera.chat
@@ -22,11 +69,15 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 # Optional: how the bot identifies itself in WHOIS / on the channel.
 # TURBORG_IRC_USERNAME=myturborg                         # IRC ident; defaults to nick
 # TURBORG_IRC_REAL_NAME=my turborg agent                 # USER trailing — shown on WHOIS
-# TURBORG_IRC_HANDSHAKE_TIMEOUT=30s                      # Go duration; before giving up
+
+# --- Timing ---
+# TURBORG_IRC_HANDSHAKE_TIMEOUT=30s                      # Go duration; give up if no 001 by this
+# TURBORG_IRC_READ_IDLE_TIMEOUT=300s                     # close upstream after this much silence
+# TURBORG_IRC_CLIENT_PING_INTERVAL=120s                  # must be < READ_IDLE_TIMEOUT
 
 
 # =============================================================================
-# IRC authentication (three independent options — pick whichever your network supports)
+# IRC connector — authentication (pick whichever your network supports)
 # =============================================================================
 
 # --- Server PASS (sent during registration; rare) ---
@@ -49,7 +100,18 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 
 
 # =============================================================================
-# IRC bouncer (optional — set password to enable)
+# IRC connector — CTCP (TURBORG_IRC_CTCP_*)
+# =============================================================================
+# Sliding-window throttle, scoped per sender. Excess hits are dropped
+# silently (no reply, to avoid amplification).
+
+# TURBORG_IRC_CTCP_AUTO_REPLY=true                       # set false to silently ignore all CTCP
+# TURBORG_IRC_CTCP_MAX_PER_WINDOW=3
+# TURBORG_IRC_CTCP_WINDOW_SECONDS=30
+
+
+# =============================================================================
+# IRC connector — bouncer (TURBORG_IRC_BOUNCER_*, optional — set password to enable)
 # =============================================================================
 # TCP server on `host:port` that local IRC clients (HexChat, irssi, mIRC)
 # connect to. Authenticate with the same password and the client tunnels
@@ -65,77 +127,26 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 
 
 # =============================================================================
-# WebSocket gateway (optional — set password to enable)
+# IRC connector — web (TURBORG_IRC_WEB_*, optional — set password to enable)
 # =============================================================================
-# Real-time JSON event stream for web frontends. Reference UI at
-# http://<host>:<port>/. SaaS deployments typically swap StaticPasswordVerifier
-# for a JWT- or session-aware verifier; the wire protocol is unchanged.
+# WebSocket gateway + bundled reference UI for the IRC connector. Real-time
+# JSON event stream + control surface for web frontends; reference UI at
+# http://<host>:<port>/. SaaS deployments swap StaticPasswordVerifier for
+# a JWT/session-aware verifier; the wire protocol is unchanged.
+#
+# A future general-purpose bot-core web connector will claim TURBORG_WEB_*;
+# this one is IRC-coupled (speaks IRCBridge / shows channel state), so it
+# lives next to the bouncer.
 
-# TURBORG_WEB_PASSWORD=hunter2
-# TURBORG_WEB_HOST=127.0.0.1                             # 0.0.0.0 only behind TLS proxy
-# TURBORG_WEB_PORT=8765
-# TURBORG_WEB_MAX_FAILED_ATTEMPTS=5                      # per-IP brute-force protection
-# TURBORG_WEB_FAILURE_WINDOW_SECONDS=60
-# TURBORG_WEB_LOCKOUT_SECONDS=300
+# TURBORG_IRC_WEB_PASSWORD=hunter2
+# TURBORG_IRC_WEB_HOST=127.0.0.1                         # 0.0.0.0 only behind TLS proxy
+# TURBORG_IRC_WEB_PORT=8765
+# TURBORG_IRC_WEB_MAX_FAILED_ATTEMPTS=5                  # per-IP brute-force protection
+# TURBORG_IRC_WEB_FAILURE_WINDOW_SECONDS=60
+# TURBORG_IRC_WEB_LOCKOUT_SECONDS=300
 
 # SaaS lifecycle: when set, the gateway calls its idle-shutdown callback
 # N seconds after the last WS client disconnects. Free-tier containers
 # set this; premium / always-on bouncer instances leave it unset. Bouncer
 # connections do NOT extend the timer — only WS clients do.
-# TURBORG_WEB_IDLE_SHUTDOWN_SECONDS=300
-
-
-# =============================================================================
-# LLM (optional — turborg runs in standalone mode without it)
-# =============================================================================
-# When TURBORG_ANTHROPIC_API_KEY is set, the !ask command activates and
-# AnthropicProvider is wired in. Without it, the agent runs IRC-only.
-
-# TURBORG_ANTHROPIC_API_KEY=sk-ant-...
-# TURBORG_ANTHROPIC_MODEL=claude-sonnet-4-6              # default; claude-opus-4-7 also valid
-
-
-# =============================================================================
-# Hive (placeholder — not yet shipping in v0.x)
-# =============================================================================
-# TURBORG_HIVE_ENABLED=false
-# TURBORG_HIVE_URL=...                                   # override; default is the public hive once it ships
-
-
-# =============================================================================
-# Logging & misc
-# =============================================================================
-
-# TURBORG_LOG_LEVEL=INFO                                 # DEBUG / INFO / WARNING / ERROR / CRITICAL
-# TURBORG_LOG_FORMAT=text                                # text (human) or json (CW Logs / Loki ingestion)
-# TURBORG_COMMAND_PREFIX=!                               # leading character for !ping etc.
-
-
-# =============================================================================
-# Owner / authorization for !commands
-# =============================================================================
-# By default ANYONE can run !commands. Lock them to a single operator with
-# either or both of the following — set both for defense-in-depth on
-# services-enabled networks (account-tag is the truthful identity, nick
-# match is a spelling check).
-#
-# TURBORG_OWNER_NICK=...           # case-insensitive nick match
-# TURBORG_OWNER_ACCOUNT=...        # NickServ account (uses IRCv3 account-tag;
-#                                  # fails closed if the network has no services)
-
-
-# =============================================================================
-# Rate limiting (per-sender)
-# =============================================================================
-# Sliding-window throttles. Excess hits are dropped silently (no reply,
-# to avoid amplification). Each scope has its own bucket so a CTCP flood
-# can't lock the same user out of !commands.
-#
-# !commands:
-# TURBORG_COMMAND_MAX_PER_WINDOW=5
-# TURBORG_COMMAND_WINDOW_SECONDS=30
-#
-# CTCP requests (scoped to IRCSettings since CTCP is IRC-specific):
-# TURBORG_IRC_CTCP_AUTO_REPLY=true                       # set false to silently ignore all CTCP
-# TURBORG_IRC_CTCP_MAX_PER_WINDOW=3
-# TURBORG_IRC_CTCP_WINDOW_SECONDS=30
+# TURBORG_IRC_WEB_IDLE_SHUTDOWN_SECONDS=300

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -2,10 +2,9 @@
 # CI runs `go test -coverprofile=coverage.out ./internal/...` then
 # `go-test-coverage --config .testcoverage.yml` to enforce these gates.
 #
-# Thresholds match the Python repo's `fail_under = 95` total bar. The
-# IRC connector exemption mirrors Python's per-module reality at the
-# same version: real-network error paths (TLS Dial, mid-handshake
-# server drops) are unreachable from in-process tests without far more
+# The IRC connector carries a slightly lower bar than the rest of the
+# tree: real-network error paths (TLS Dial, mid-handshake server
+# drops) are unreachable from in-process tests without far more
 # infrastructure than the value justifies.
 
 profile: coverage.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ edits will survive but the bot will keep adding new entries above.
 
 ### Bug Fixes
 
-* **irc:** match Python's CTCP VERSION reply, drop turborg-go leftovers ([#6](https://github.com/turborg/turborg/issues/6)) ([5fb480c](https://github.com/turborg/turborg/commit/5fb480c033eb4171477665bbef6fedf219ae4259))
+* **irc:** standardize the CTCP VERSION reply ([#6](https://github.com/turborg/turborg/issues/6)) ([5fb480c](https://github.com/turborg/turborg/commit/5fb480c033eb4171477665bbef6fedf219ae4259))
 * **test:** determinize agent drain test, restore reliable 98% coverage ([#11](https://github.com/turborg/turborg/issues/11)) ([4d0002b](https://github.com/turborg/turborg/commit/4d0002b6a8df6ef2f80641cb2354765e18b7f8f4))
 * **test:** stabilize two flakes exposed by PR [#8](https://github.com/turborg/turborg/issues/8) ([#10](https://github.com/turborg/turborg/issues/10)) ([e429ac2](https://github.com/turborg/turborg/commit/e429ac2bcf5a8708e6aaddfd7abbda1bb15f538f))
 
@@ -70,12 +70,11 @@ edits will survive but the bot will keep adding new entries above.
 
 ## [Unreleased]
 
-## [0.1.0] — first Go release
+## [0.1.0] — initial release
 
-Feature parity with the final Python release ([turborg/turborg-python](https://github.com/turborg/turborg-python) v0.8.0).
-Every `TURBORG_*` env var, every WebSocket protocol op, and the reference
-UI's HTML/CSS/JS are preserved byte-for-byte so the xshellz sidecar +
-accounts-api + appui stack needs no changes.
+First public release of turborg. Ships the full framework: agent core,
+IRC connector with bouncer + WebSocket gateway, Anthropic LLM backend,
+and a bundled reference UI.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ In `#turborg-test`, type `!ping` — the bot replies `pong`. That's it.
 |------------------------------------------|---------------------------------------------------|
 | Enable the `!ask` AI command             | `TURBORG_ANTHROPIC_API_KEY=sk-...`                |
 | Attach HexChat through the bouncer       | `TURBORG_IRC_BOUNCER_PASSWORD=…`                  |
-| Open the web UI at `http://127.0.0.1:8765/` | `TURBORG_IRC_WEB_PASSWORD=…`                   |
+| Open the web UI at `http://127.0.0.1:8765/` | `TURBORG_GATEWAY_PASSWORD=…`                   |
 
-See [`docs/connectors/irc.md`](docs/connectors/irc.md) for the full env-var reference for the IRC connector — SASL, NickServ identify, bouncer, WS gateway, rate limits, idle-shutdown, timing.
+See [`docs/connectors/irc.md`](docs/connectors/irc.md) for the IRC connector reference (SASL, NickServ identify, bouncer, rate limits, timing) and [`docs/gateway.md`](docs/gateway.md) for the gateway (WS protocol, auth, idle-shutdown).
 
 ## Quickstart: a minimal bot in Go
 
@@ -137,8 +137,8 @@ To expose the web UI to the host, also publish the port:
 
 ```bash
 docker run --rm \
-  -e TURBORG_IRC_WEB_PASSWORD=changeme \
-  -e TURBORG_IRC_WEB_HOST=0.0.0.0 \
+  -e TURBORG_GATEWAY_PASSWORD=changeme \
+  -e TURBORG_GATEWAY_HOST=0.0.0.0 \
   -p 8765:8765 \
   --env-file .env \
   ghcr.io/turborg/turborg:latest

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In `#turborg-test`, type `!ping` — the bot replies `pong`. That's it.
 |------------------------------------------|---------------------------------------------------|
 | Enable the `!ask` AI command             | `TURBORG_ANTHROPIC_API_KEY=sk-...`                |
 | Attach HexChat through the bouncer       | `TURBORG_IRC_BOUNCER_PASSWORD=…`                  |
-| Open the web UI at `http://127.0.0.1:8765/` | `TURBORG_WEB_PASSWORD=…`                       |
+| Open the web UI at `http://127.0.0.1:8765/` | `TURBORG_IRC_WEB_PASSWORD=…`                   |
 
 See `docs/configuration.md` for the full env-var reference — SASL, NickServ identify, rate limits, idle-shutdown, logging.
 
@@ -137,8 +137,8 @@ To expose the web UI to the host, also publish the port:
 
 ```bash
 docker run --rm \
-  -e TURBORG_WEB_PASSWORD=changeme \
-  -e TURBORG_WEB_HOST=0.0.0.0 \
+  -e TURBORG_IRC_WEB_PASSWORD=changeme \
+  -e TURBORG_IRC_WEB_HOST=0.0.0.0 \
   -p 8765:8765 \
   --env-file .env \
   ghcr.io/turborg/turborg:latest

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In `#turborg-test`, type `!ping` — the bot replies `pong`. That's it.
 | Attach HexChat through the bouncer       | `TURBORG_IRC_BOUNCER_PASSWORD=…`                  |
 | Open the web UI at `http://127.0.0.1:8765/` | `TURBORG_IRC_WEB_PASSWORD=…`                   |
 
-See `docs/configuration.md` for the full env-var reference — SASL, NickServ identify, rate limits, idle-shutdown, logging.
+See [`docs/connectors/irc.md`](docs/connectors/irc.md) for the full env-var reference for the IRC connector — SASL, NickServ identify, bouncer, WS gateway, rate limits, idle-shutdown, timing.
 
 ## Quickstart: a minimal bot in Go
 
@@ -146,12 +146,12 @@ docker run --rm \
 
 ## Connectors
 
-| Connector  | Status     | Notes                                  |
-|------------|------------|----------------------------------------|
-| IRC        | Stable     | with bouncer + WS gateway              |
-| Discord    | Roadmap    | hopper                                 |
-| Telegram   | Roadmap    | hopper                                 |
-| WhatsApp   | Roadmap    | hopper                                 |
+| Connector  | Status     | Notes                                                                  |
+|------------|------------|------------------------------------------------------------------------|
+| [IRC](docs/connectors/irc.md) | Stable | with bouncer + WS gateway — see [the IRC connector docs](docs/connectors/irc.md) for every env var |
+| Discord    | Roadmap    | hopper                                                                 |
+| Telegram   | Roadmap    | hopper                                                                 |
+| WhatsApp   | Roadmap    | hopper                                                                 |
 
 LLM providers are **optional**. turborg runs perfectly fine as a pure command-driven bot without any LLM. When you want one, Anthropic (default, with prompt caching) ships in-tree.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,8 +42,8 @@ Once 0.2 ships, 0.1.x will receive critical security fixes for 90 days, then mov
 
 In scope:
 
-- The published `turborg` Python package on PyPI
 - The official source repository at `github.com/turborg/turborg`
+- Published release artifacts (binaries, container images at `ghcr.io/turborg/turborg`)
 - The example bots in `examples/`
 
 Out of scope:

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -21,8 +21,9 @@ you rights to use these trademarks.
 - **Forks**: if you maintain a fork that diverges meaningfully from upstream,
   you must rename it. Do not call your fork "turborg" or use a name likely to
   cause confusion (e.g. "turborg-pro", "turborg-plus", "real-turborg").
-- **Distributions and packages**: do not publish a package on PyPI, Docker Hub,
-  or any other registry under the name "turborg" or a confusingly similar name.
+- **Distributions and packages**: do not publish a package on any registry
+  (Docker Hub, Homebrew, Go module proxy, etc.) under the name "turborg" or
+  a confusingly similar name.
 - **Hosted services**: do not run a public hosted service called "turborg" or
   "turborg cloud". The official hosted offering is **hive.xshellz.com**.
 - **Merchandise, swag, or marketing materials** using the turborg or xshellz

--- a/cmd/turborg/main.go
+++ b/cmd/turborg/main.go
@@ -93,7 +93,7 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	}
 	webState := "off"
 	if built.Gateway != nil {
-		webState = fmt.Sprintf("on@%s:%d", settings.WebHost, settings.WebPort)
+		webState = fmt.Sprintf("on@%s:%d", ircSettings.WebHost, ircSettings.WebPort)
 	}
 	log.Info("turborg starting",
 		"version", version.Version,

--- a/cmd/turborg/main.go
+++ b/cmd/turborg/main.go
@@ -91,16 +91,16 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	if ircSettings.BouncerEnabled() {
 		bouncerState = fmt.Sprintf("on@%s:%d", ircSettings.BouncerHost, ircSettings.BouncerPort)
 	}
-	webState := "off"
+	gatewayState := "off"
 	if built.Gateway != nil {
-		webState = fmt.Sprintf("on@%s:%d", ircSettings.WebHost, ircSettings.WebPort)
+		gatewayState = fmt.Sprintf("on@%s:%d", settings.GatewayHost, settings.GatewayPort)
 	}
 	log.Info("turborg starting",
 		"version", version.Version,
 		"mode", mode,
 		"connectors", connectorNames(settings),
 		"bouncer", bouncerState,
-		"web", webState,
+		"gateway", gatewayState,
 	)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/turborg/main.go
+++ b/cmd/turborg/main.go
@@ -58,10 +58,10 @@ configuration from its prefixed env.`,
 }
 
 func runE(stderr interface{ Write(p []byte) (int, error) }) error {
-	// Best-effort .env load matching the Python pydantic-settings
-	// behavior. A missing file is fine — real env vars still apply.
-	// Real env vars take precedence over .env entries (godotenv.Load
-	// only sets vars that aren't already set in the process env).
+	// Best-effort .env load. A missing file is fine — real env vars
+	// still apply. Real env vars take precedence over .env entries
+	// (godotenv.Load only sets vars that aren't already set in the
+	// process env).
 	_ = godotenv.Load()
 
 	settings, err := config.Load()

--- a/docs/connectors/irc.md
+++ b/docs/connectors/irc.md
@@ -40,14 +40,15 @@ optional.
 | `TURBORG_IRC_NICK` | string | **required** | Bot nick. Must be unique on the network — if your nick is in use, registration fails and the bot exits. |
 | `TURBORG_IRC_USERNAME` | string | = `NICK` | The IRC ident (the `USER` command's first arg). Most networks display this in WHOIS. Defaults to the nick when unset. |
 | `TURBORG_IRC_REAL_NAME` | string | `"turborg agent"` | The USER command's trailing arg — shown on WHOIS as the "real name". Operators sometimes use this to flag the bot as a bot. |
-| `TURBORG_IRC_CHANNELS` | CSV | `""` | Comma-separated list of channels to join after registration. Bare names without a `#` are auto-prefixed (`mychannel` → `#mychannel`); `&`, `+`, `!` prefixes are preserved. Accepts the legacy JSON-array shape (`["#a","#b"]`) too — a Python-era `.env` is a drop-in. |
+| `TURBORG_IRC_CHANNELS` | CSV | `""` | Comma-separated list of channels to join after registration. Bare names without a `#` are auto-prefixed (`mychannel` → `#mychannel`); `&`, `+`, `!` prefixes are preserved. Also accepts a JSON-array shape (`["#a","#b"]`) for compatibility with config systems that emit lists. |
 
 ### Operational notes
 
 - **Channel keys (passwords) aren't a separate var.** If you need to
   join a `+k` channel, send the JOIN manually from a built-in command
-  or the bouncer. The connector doesn't model per-channel keys in the
-  spawn config; this matches how the Python version shipped.
+  or the bouncer. The connector intentionally doesn't model per-channel
+  keys in the spawn config — keep keys out of env that may end up in
+  process listings or container introspection.
 - **NICK collisions are fatal.** The connector does not append `_` or
   cycle alt-nicks; if your registered nick is in use, registration
   fails with `433 Nickname is already in use` and the agent exits.

--- a/docs/connectors/irc.md
+++ b/docs/connectors/irc.md
@@ -191,43 +191,14 @@ scrollback; see below.)
 
 ---
 
-## WebSocket gateway + reference UI
+## Gateway (cross-reference)
 
-A real-time JSON-over-WebSocket protocol with a bundled vanilla-JS
-single-page reference UI. Same listener serves `/`, `/health`,
-`/metrics`, and `/ws`.
-
-The gateway is **IRC-coupled** — it knows how to render channel state,
-fan PRIVMSGs to subscribed clients, and accept `say` operations that
-flow back through the agent's EventBus to the IRC connector. That's
-why it lives under `TURBORG_IRC_WEB_*`: it pairs with the IRC bouncer
-the same way an attached client pairs with it.
-
-`TURBORG_WEB_*` (without the `IRC_`) is **reserved** for a future
-general-purpose bot-core web connector. It is currently unused; do not
-set it.
-
-| Variable | Type | Default | Notes |
-|---|---|---|---|
-| `TURBORG_IRC_WEB_PASSWORD` | string | `""` | **Set this to enable the gateway.** Unset = gateway disabled, no listener. SaaS deployments swap `StaticPasswordVerifier` for a JWT- or session-aware `TokenVerifier`; the wire protocol is unchanged. |
-| `TURBORG_IRC_WEB_HOST` | string | `127.0.0.1` | Listen interface. **Keep on loopback** unless you put a TLS-terminating reverse proxy in front. WebSocket auth tokens travel in cleartext over plain HTTP. |
-| `TURBORG_IRC_WEB_PORT` | int | `8765` | HTTP listen port. |
-| `TURBORG_IRC_WEB_MAX_FAILED_ATTEMPTS` | int | `5` | Per-IP brute-force cap on `/ws` auth. |
-| `TURBORG_IRC_WEB_FAILURE_WINDOW_SECONDS` | int | `60` | Failure-counter window. |
-| `TURBORG_IRC_WEB_LOCKOUT_SECONDS` | int | `300` | Lockout duration after the threshold trips. |
-| `TURBORG_IRC_WEB_IDLE_SHUTDOWN_SECONDS` | int | `0` (disabled) | When > 0, the gateway calls its `OnIdleShutdown` callback N seconds after the **last WebSocket client** disconnects. The xshellz SaaS sidecar wires this to a `docker stop` for free-tier auto-pause. Bouncer connections do **not** extend the timer — only WS clients do, since the bouncer is intentionally a different SLA tier. |
-
-### Operational notes
-
-- The reference UI at `/` is intentionally **vanilla JS / single file /
-  no build step**. Polished, production-grade frontend work belongs in
-  a separate Angular client (xshellz operates one downstream).
-- The wire protocol is documented in `docs/ui/PLAN.md` (a local-only
-  reference for the xshellz Angular team). It is byte-stable across
-  patch releases.
-- **Port 0 is legal** in code (it tells `net.Listen` to pick an
-  OS-assigned port). The env default is `8765`, so production
-  deployments always get a stable port; port-0 is reserved for tests.
+The bot also exposes a control-plane gateway (WS protocol + reference
+UI) that today streams IRC events and accepts `say`/`join`/`kick` ops
+flowing back through the agent. The gateway is **not** an IRC
+sub-feature — it's a top-level surface that just happens to surface
+IRC events while IRC is the only connector. See
+[`docs/gateway.md`](../gateway.md) for the full reference.
 
 ---
 

--- a/docs/connectors/irc.md
+++ b/docs/connectors/irc.md
@@ -1,0 +1,260 @@
+# IRC connector
+
+The reference connector that ships in v0.1. Speaks RFC 1459 + IRCv3
+extensions, maintains per-channel state from the wire, and offers two
+optional fan-out surfaces:
+
+- A built-in **bouncer** that local IRC clients (HexChat / irssi / mIRC)
+  can attach to and tunnel through the bot's upstream session.
+- A built-in **WebSocket gateway + reference UI** for browser clients
+  (or for any custom frontend that wants real-time JSON events).
+
+All settings live under the `TURBORG_IRC_*` prefix and are read by
+`internal/connector/irc/settings.go`. Connection + nick are required;
+everything else has a sensible default.
+
+---
+
+## Quickstart — the minimum that works
+
+```bash
+export TURBORG_IRC_HOSTNAME=irc.libera.chat
+export TURBORG_IRC_NICK=myturborg
+export TURBORG_IRC_CHANNELS=#turborg-test
+turborg run
+```
+
+That's it. The bot connects with TLS on port 6697, joins
+`#turborg-test`, and answers `!ping`. Everything below this line is
+optional.
+
+---
+
+## Connection
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_HOSTNAME` | string | **required** | Upstream IRC server (hostname or IP). |
+| `TURBORG_IRC_PORT` | int | `6697` | TLS port by default. Use `6667` if you set `USE_TLS=false`. |
+| `TURBORG_IRC_USE_TLS` | bool | `true` | Connect with TLS. **Don't disable this on the public internet** — IRC traffic includes your NickServ password in plaintext otherwise. |
+| `TURBORG_IRC_NICK` | string | **required** | Bot nick. Must be unique on the network — if your nick is in use, registration fails and the bot exits. |
+| `TURBORG_IRC_USERNAME` | string | = `NICK` | The IRC ident (the `USER` command's first arg). Most networks display this in WHOIS. Defaults to the nick when unset. |
+| `TURBORG_IRC_REAL_NAME` | string | `"turborg agent"` | The USER command's trailing arg — shown on WHOIS as the "real name". Operators sometimes use this to flag the bot as a bot. |
+| `TURBORG_IRC_CHANNELS` | CSV | `""` | Comma-separated list of channels to join after registration. Bare names without a `#` are auto-prefixed (`mychannel` → `#mychannel`); `&`, `+`, `!` prefixes are preserved. Accepts the legacy JSON-array shape (`["#a","#b"]`) too — a Python-era `.env` is a drop-in. |
+
+### Operational notes
+
+- **Channel keys (passwords) aren't a separate var.** If you need to
+  join a `+k` channel, send the JOIN manually from a built-in command
+  or the bouncer. The connector doesn't model per-channel keys in the
+  spawn config; this matches how the Python version shipped.
+- **NICK collisions are fatal.** The connector does not append `_` or
+  cycle alt-nicks; if your registered nick is in use, registration
+  fails with `433 Nickname is already in use` and the agent exits.
+  Operators monitor the bot and restart it once the collision clears.
+
+---
+
+## Timing
+
+These three knobs control how aggressively the connector detects a
+silently broken upstream connection and gives up on a stalled
+handshake.
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_HANDSHAKE_TIMEOUT` | duration | `30s` | If the server hasn't sent `001 RPL_WELCOME` within this window, the connector aborts the connection. Bump to `60s` on slow services-heavy networks where SASL adds round-trips. |
+| `TURBORG_IRC_READ_IDLE_TIMEOUT` | duration | `300s` | If no bytes arrive from upstream for this long, the connector treats the link as dead and reconnects. Includes PING responses, so a healthy link is well under the limit. |
+| `TURBORG_IRC_CLIENT_PING_INTERVAL` | duration | `120s` | How often the connector sends `PING` upstream. **Must be strictly less than `READ_IDLE_TIMEOUT`** — `Settings.Validate()` rejects configs where ping ≥ idle, because the silent-death timer would fire while a PING is in flight and trigger a false-positive disconnect. |
+
+Durations use Go syntax: `30s`, `5m`, `1h30m`.
+
+### Operational notes
+
+- The healthy ratio is ping interval ≤ ⅓ of read idle. Default 120s /
+  300s gives 2× headroom; the connector sends two PINGs before the
+  idle timer fires, so a single dropped PONG won't reset the link.
+- If you see frequent reconnect loops on a slow link, **raise
+  `READ_IDLE_TIMEOUT` first**, not the ping interval. The validator
+  enforces `ping < idle` so lowering the ping won't help; raising idle
+  buys headroom on both sides.
+
+---
+
+## Authentication
+
+Three independent paths. Use whichever your network supports. Set
+multiple together for defense-in-depth — SASL during the CAP handshake
+covers identity early, NickServ identify after the handshake covers
+networks that NAK SASL.
+
+### Server PASS (rare)
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_SERVER_PASSWORD` | string | `""` | Sent as `PASS <password>` during registration. Only needed on networks that gate connections behind a server-wide password. |
+
+### NickServ identify
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_NICKSERV_PASSWORD` | string | `""` | After the handshake completes (but before joining channels), the connector sends `PRIVMSG NickServ :IDENTIFY <password>`. Use on networks where the nick is registered with NickServ. Sent **after** the link is up, so the password is protected by TLS if `USE_TLS=true`. |
+
+### SASL PLAIN (preferred)
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_SASL_USER` | string | `""` | SASL PLAIN account name. Both this and `SASL_PASSWORD` must be set to enable. |
+| `TURBORG_IRC_SASL_PASSWORD` | string | `""` | SASL PLAIN password. |
+
+When both are set, the connector negotiates `CAP REQ :sasl` and runs
+`AUTHENTICATE PLAIN` during the handshake — identity is verified
+**before** the bot is allowed to join channels. Bad credentials surface
+as an error and abort startup. Networks that don't support SASL `NAK`
+the capability and the connector falls back to unauthenticated.
+
+### Which to use?
+
+- **Libera.Chat / OFTC / modern IRCv3 networks** → SASL. It happens
+  before the nick is locked, before channels are joined, before any
+  trust assumption is baked in.
+- **Older networks (no SASL CAP)** → NickServ identify. Works on
+  anything from the last 25 years.
+- **Defense-in-depth** → set both. SASL succeeds on networks that
+  support it; NickServ runs after the handshake either way (harmless if
+  you're already authenticated).
+- **Don't ship the literal placeholder strings** from `.env.example`
+  (`__your_nickserv_account__` etc.). They'll fail upstream auth and
+  the bot will exit.
+
+---
+
+## Channel events (CTCP)
+
+CTCP is the in-band protocol IRC clients use for `/me` actions,
+`VERSION` queries, file transfers, etc. The connector auto-replies to a
+small set (`VERSION`, `PING`, `TIME`) and silently drops the rest.
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_CTCP_AUTO_REPLY` | bool | `true` | Set `false` to silently ignore every inbound CTCP. The bot still parses them — this just suppresses the outbound reply. |
+| `TURBORG_IRC_CTCP_MAX_PER_WINDOW` | int | `3` | Per-sender sliding-window cap. Excess CTCPs are dropped silently (no reply) to avoid being used as a reflection-amplification vector. |
+| `TURBORG_IRC_CTCP_WINDOW_SECONDS` | int | `30` | Length of the sliding window. |
+
+### Operational notes
+
+- The throttle scope is **per sender** — a single user spamming
+  `VERSION` can't lock other users out of their own CTCP replies.
+- The drop is **silent**. A throttled CTCP returns no reply at all,
+  matching how a real IRCd would NOP the client out of the conversation.
+
+---
+
+## Bouncer
+
+A TCP server on a loopback port that local IRC clients (HexChat,
+irssi, mIRC) attach to. Each attached client authenticates with a
+password, then tunnels through the bot's upstream session — sending
+PRIVMSGs as the bot, seeing the bot's joined channels, the bot's
+PMs, etc.
+
+The bouncer **does not** ship channel scrollback by default; clients
+see traffic from the moment they attach. (The WS gateway does cache
+scrollback; see below.)
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_BOUNCER_PASSWORD` | string | `""` | **Set this to enable the bouncer.** Unset = bouncer disabled, no listener. |
+| `TURBORG_IRC_BOUNCER_HOST` | string | `127.0.0.1` | Listen interface. **Keep on loopback** unless you put a TLS-terminating proxy in front. Plain-text IRC over the public internet is unsafe. Use `0.0.0.0` to expose on a LAN you control. |
+| `TURBORG_IRC_BOUNCER_PORT` | int | `31337` | Bouncer TCP port. Pick something out of well-known ranges. |
+| `TURBORG_IRC_BOUNCER_RATELIMIT_ENABLED` | bool | `true` | Per-IP brute-force protection on the auth handshake. Disable only if you have an upstream rate-limiter (e.g. behind a reverse proxy that already gates the port). |
+| `TURBORG_IRC_BOUNCER_MAX_FAILED_ATTEMPTS` | int | `5` | Failed auths per IP before lockout. |
+| `TURBORG_IRC_BOUNCER_FAILURE_WINDOW_SECONDS` | int | `60` | Sliding-window length for counting failures. |
+| `TURBORG_IRC_BOUNCER_LOCKOUT_SECONDS` | int | `300` | How long an IP is locked out once it trips the threshold. |
+
+### Operational notes
+
+- The listener **pre-binds before upstream Dial**. Attached clients can
+  connect on bot startup without seeing a connection-refused window
+  during the upstream handshake.
+- **IRCv3 CAP negotiation suspends registration.** Per spec the
+  bouncer must not send `001 Welcome` to an attached client until that
+  client sends `CAP END`. The connector handles this correctly; if you
+  see clients hanging at registration, check that their CAP version is
+  compatible.
+- **HexChat 2.16 has a known self-message-cap quirk.** It silently
+  skips advertising the `echo-message` cap, so the bouncer fans
+  self-DMs to every attached client regardless of whether the client
+  advertised the cap. The wrong-tab artifact is a HexChat bug; using a
+  newer client (or HexChat ≥ 2.17 once released) resolves it.
+
+---
+
+## WebSocket gateway + reference UI
+
+A real-time JSON-over-WebSocket protocol with a bundled vanilla-JS
+single-page reference UI. Same listener serves `/`, `/health`,
+`/metrics`, and `/ws`.
+
+The gateway is **IRC-coupled** — it knows how to render channel state,
+fan PRIVMSGs to subscribed clients, and accept `say` operations that
+flow back through the agent's EventBus to the IRC connector. That's
+why it lives under `TURBORG_IRC_WEB_*`: it pairs with the IRC bouncer
+the same way an attached client pairs with it.
+
+`TURBORG_WEB_*` (without the `IRC_`) is **reserved** for a future
+general-purpose bot-core web connector. It is currently unused; do not
+set it.
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_IRC_WEB_PASSWORD` | string | `""` | **Set this to enable the gateway.** Unset = gateway disabled, no listener. SaaS deployments swap `StaticPasswordVerifier` for a JWT- or session-aware `TokenVerifier`; the wire protocol is unchanged. |
+| `TURBORG_IRC_WEB_HOST` | string | `127.0.0.1` | Listen interface. **Keep on loopback** unless you put a TLS-terminating reverse proxy in front. WebSocket auth tokens travel in cleartext over plain HTTP. |
+| `TURBORG_IRC_WEB_PORT` | int | `8765` | HTTP listen port. |
+| `TURBORG_IRC_WEB_MAX_FAILED_ATTEMPTS` | int | `5` | Per-IP brute-force cap on `/ws` auth. |
+| `TURBORG_IRC_WEB_FAILURE_WINDOW_SECONDS` | int | `60` | Failure-counter window. |
+| `TURBORG_IRC_WEB_LOCKOUT_SECONDS` | int | `300` | Lockout duration after the threshold trips. |
+| `TURBORG_IRC_WEB_IDLE_SHUTDOWN_SECONDS` | int | `0` (disabled) | When > 0, the gateway calls its `OnIdleShutdown` callback N seconds after the **last WebSocket client** disconnects. The xshellz SaaS sidecar wires this to a `docker stop` for free-tier auto-pause. Bouncer connections do **not** extend the timer — only WS clients do, since the bouncer is intentionally a different SLA tier. |
+
+### Operational notes
+
+- The reference UI at `/` is intentionally **vanilla JS / single file /
+  no build step**. Polished, production-grade frontend work belongs in
+  a separate Angular client (xshellz operates one downstream).
+- The wire protocol is documented in `docs/ui/PLAN.md` (a local-only
+  reference for the xshellz Angular team). It is byte-stable across
+  patch releases.
+- **Port 0 is legal** in code (it tells `net.Listen` to pick an
+  OS-assigned port). The env default is `8765`, so production
+  deployments always get a stable port; port-0 is reserved for tests.
+
+---
+
+## Owner / authorization
+
+Owner-gating isn't IRC-specific — it lives on top-level `TURBORG_*` —
+but it directly affects which IRC users can run `!commands`:
+
+- `TURBORG_OWNER_NICK` — case-insensitive nick match.
+- `TURBORG_OWNER_ACCOUNT` — IRCv3 `account-tag` match. **Fails closed**
+  if the network has no services / the client hasn't been
+  authenticated, so this is the safer of the two.
+
+By default (both unset) **anyone** in a channel can run `!commands`.
+Set both for defense-in-depth on services-enabled networks.
+
+See `.env.example` and the top-level docs for the full list of
+cross-cutting `TURBORG_*` settings (logging, command throttle, LLM,
+hive).
+
+---
+
+## Cross-references
+
+- **Sample env file:** [`/.env.example`](../../.env.example)
+- **Source of truth:** `internal/connector/irc/settings.go` — every
+  field here has an `env:"…"` tag matching the variable name above.
+- **Gateway internals (SaaS-only):** `docs/backend/PLAN.md` (gitignored;
+  shared with the xshellz orchestrator team out-of-band).
+- **WS protocol + reference UI gap list (SaaS-only):** `docs/ui/PLAN.md`
+  (gitignored; shared with the xshellz Angular team out-of-band).

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -1,0 +1,75 @@
+# Gateway
+
+turborg's **control-plane gateway** is a single HTTP server that
+exposes:
+
+- `/ws` — a JSON-over-WebSocket protocol that streams agent events to
+  connected clients and accepts command ops (`say`, `join`, `part`,
+  `kick`, `topic`, `whois`, `list`, `who`, `raw`).
+- `/` — a bundled vanilla-JS single-page reference UI that speaks the
+  WS protocol.
+- `/health`, `/metrics` — operational endpoints.
+
+It is **not a connector**. A connector originates and consumes
+Envelopes from an external chat network; the gateway is a *client of
+the agent* that lets web clients observe and control it. Today the
+events it streams are IRC events (the only connector that ships in
+v0.1), but the env vars don't name a transport or a connector — the
+same names survive any future protocol/connector additions.
+
+All gateway settings live under `TURBORG_GATEWAY_*`.
+
+---
+
+## Quickstart
+
+```bash
+export TURBORG_GATEWAY_PASSWORD=hunter2
+turborg run
+```
+
+Then open <http://127.0.0.1:8765/> and log in with the password. The
+reference UI shows joined channels, member lists, scrollback, and a
+message composer.
+
+---
+
+## Configuration
+
+| Variable | Type | Default | Notes |
+|---|---|---|---|
+| `TURBORG_GATEWAY_PASSWORD` | string | `""` | **Set this to enable the gateway.** Unset = gateway disabled, no listener. SaaS deployments swap `StaticPasswordVerifier` for a JWT- or session-aware `TokenVerifier`; the wire protocol is unchanged. |
+| `TURBORG_GATEWAY_HOST` | string | `127.0.0.1` | Listen interface. **Keep on loopback** unless you put a TLS-terminating reverse proxy in front — WebSocket auth tokens travel in cleartext over plain HTTP. |
+| `TURBORG_GATEWAY_PORT` | int | `8765` | HTTP listen port. |
+| `TURBORG_GATEWAY_MAX_FAILED_ATTEMPTS` | int | `5` | Per-IP brute-force cap on `/ws` auth. |
+| `TURBORG_GATEWAY_FAILURE_WINDOW_SECONDS` | int | `60` | Failure-counter window. |
+| `TURBORG_GATEWAY_LOCKOUT_SECONDS` | int | `300` | Lockout duration after the threshold trips. |
+| `TURBORG_GATEWAY_IDLE_SHUTDOWN_SECONDS` | int | `0` (disabled) | When > 0, the gateway calls its `OnIdleShutdown` callback N seconds after the **last WebSocket client** disconnects. The xshellz SaaS sidecar wires this to a `docker stop` for free-tier auto-pause. Bouncer connections do **not** extend the timer — only WS clients do, since the bouncer is intentionally a different SLA tier. |
+
+---
+
+## Operational notes
+
+- The reference UI at `/` is intentionally **vanilla JS / single file /
+  no build step**. Polished, production-grade frontend work belongs in
+  a separate client (xshellz operates an Angular one downstream).
+- The wire protocol is byte-stable across patch releases. SaaS clients
+  rely on this — coordinate any change with the downstream UI team.
+- **Port 0 is legal** in code (it tells `net.Listen` to pick an
+  OS-assigned port). The env default is `8765`, so production
+  deployments always get a stable port; port-0 is reserved for tests.
+- The gateway's `IRCBridge` interface is the v0.1 wiring. When future
+  connectors land, this is expected to generalize to a
+  `ConnectorBridge` so a single gateway can surface events from
+  multiple connectors at once — the `TURBORG_GATEWAY_*` env names are
+  chosen to survive that refactor without another rename.
+
+---
+
+## Cross-references
+
+- **Sample env file:** [`/.env.example`](../.env.example)
+- **Source of truth:** `internal/web/gateway.go`, `internal/config/settings.go`
+  (the `Gateway*` fields).
+- **WS protocol details (SaaS-only):** `docs/ui/PLAN.md` (gitignored;
+  shared with downstream UI teams out-of-band).

--- a/internal/agent/commands.go
+++ b/internal/agent/commands.go
@@ -9,8 +9,8 @@ import (
 type CommandHandler func(ctx context.Context, env *InboundEnvelope, args []string) (*OutboundEnvelope, error)
 
 // CommandGuard is a synchronous predicate run before dispatch. Returning
-// false silently drops the command (no reply, no error). Mirrors Python's
-// owner-only + throttle guard composition.
+// false silently drops the command (no reply, no error). The runtime
+// composes owner-only + per-sender throttle into a single guard.
 type CommandGuard func(env *InboundEnvelope) bool
 
 type commandEntry struct {
@@ -20,7 +20,7 @@ type commandEntry struct {
 }
 
 // CommandRegistry parses text that starts with Prefix and dispatches to a
-// registered handler. Names are case-insensitive (Python convention).
+// registered handler. Names are case-insensitive.
 type CommandRegistry struct {
 	prefix   string
 	mu       sync.RWMutex

--- a/internal/agent/envelope.go
+++ b/internal/agent/envelope.go
@@ -7,9 +7,9 @@ import (
 )
 
 // InboundEnvelope is a connector-originated message, normalized for the
-// agent. Mirrors turborg's Python pydantic shape: every connector produces
-// these, every handler consumes them, and protocol-specific extras live in
-// Metadata so the agent surface stays uniform.
+// agent. Every connector produces these, every handler consumes them, and
+// protocol-specific extras live in Metadata so the agent surface stays
+// uniform across IRC / Discord / Telegram / etc.
 type InboundEnvelope struct {
 	ID                uuid.UUID
 	Connector         string
@@ -52,10 +52,9 @@ func NewInbound(connector, channel, sender, text string) *InboundEnvelope {
 	}
 }
 
-// ReplyTo builds an OutboundEnvelope addressed back at the source of in. If
-// the source was a direct/DM message, the reply is routed to the sender
-// instead of the channel — same rule as Python's
-// OutboundEnvelope.reply().
+// ReplyTo builds an OutboundEnvelope addressed back at the source of in.
+// If the source was a direct/DM message, the reply is routed to the
+// sender instead of the channel.
 func ReplyTo(in *InboundEnvelope, text string) *OutboundEnvelope {
 	channel := in.Channel
 	if in.IsDirect {

--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -7,10 +7,10 @@ import (
 	"time"
 )
 
-// EventType mirrors the Python core/events.py StrEnum. Values match
-// byte-for-byte so external consumers (xshellz orchestrator, observability
-// stack) see the same event names regardless of which implementation is
-// running.
+// EventType is a stable string identifier for events published on the
+// EventBus. The string values are part of the public contract — external
+// consumers (orchestrators, observability stacks) key off them, so
+// renaming a constant value is a breaking change.
 type EventType string
 
 const (
@@ -47,10 +47,8 @@ type Event struct {
 type EventHandler func(ctx context.Context, ev *Event)
 
 // EventBus is an in-process pub/sub. Publish blocks until every subscribed
-// handler returns, matching the Python EventBus contract built on
-// asyncio.gather(..., return_exceptions=True): handlers run concurrently,
-// a panic in one is logged but never propagates to siblings or the
-// publisher.
+// handler returns; handlers run concurrently, and a panic in one is
+// logged but never propagates to siblings or the publisher.
 type EventBus struct {
 	mu       sync.RWMutex
 	handlers map[EventType][]EventHandler

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,6 +1,7 @@
 // Package config holds turborg's top-level Settings — the cross-cutting
-// env-var contract that lives next to TURBORG_ (not TURBORG_IRC_,
-// TURBORG_WEB_, etc., which live with their respective connectors).
+// env-var contract that lives under TURBORG_*. Per-connector knobs
+// (TURBORG_IRC_*, etc., including the IRC-coupled WS gateway under
+// TURBORG_IRC_WEB_*) live with their respective connectors.
 //
 // Connector-specific settings stay in their own packages so installing
 // turborg without a particular connector does not require setting that
@@ -23,9 +24,9 @@ var ValidConnectors = map[string]bool{
 }
 
 // Settings is the top-level turborg config. Connector-specific knobs
-// (TURBORG_IRC_*, TURBORG_WEB_PASSWORD lives here for the gateway
-// toggle, but everything WS-protocol-shaped is on web.Options) are
-// loaded by their own packages — Settings stays narrow.
+// (TURBORG_IRC_*, including the IRC-coupled WS gateway under
+// TURBORG_IRC_WEB_*) are loaded by their own packages — Settings stays
+// narrow.
 type Settings struct {
 	LogLevel  string `env:"LOG_LEVEL"  envDefault:"INFO"`
 	LogFormat string `env:"LOG_FORMAT" envDefault:"text"`
@@ -41,14 +42,6 @@ type Settings struct {
 	// Connectors is a CSV in env (TURBORG_CONNECTORS=irc,discord). When
 	// empty, the single-connector quickstart path enables IRC only.
 	Connectors []string `env:"CONNECTORS" envSeparator:","`
-
-	WebPassword              string `env:"WEB_PASSWORD"`
-	WebHost                  string `env:"WEB_HOST"   envDefault:"127.0.0.1"`
-	WebPort                  int    `env:"WEB_PORT"   envDefault:"8765"`
-	WebMaxFailedAttempts     int    `env:"WEB_MAX_FAILED_ATTEMPTS" envDefault:"5"`
-	WebFailureWindowSeconds  int    `env:"WEB_FAILURE_WINDOW_SECONDS" envDefault:"60"`
-	WebLockoutSeconds        int    `env:"WEB_LOCKOUT_SECONDS" envDefault:"300"`
-	WebIdleShutdownSeconds   int    `env:"WEB_IDLE_SHUTDOWN_SECONDS"`
 
 	OwnerNick    string `env:"OWNER_NICK"`
 	OwnerAccount string `env:"OWNER_ACCOUNT"`
@@ -96,10 +89,3 @@ func (s *Settings) normalize() error {
 // wired. False means standalone mode — the !ask command is not
 // registered.
 func (s *Settings) AnthropicEnabled() bool { return s.AnthropicAPIKey != "" }
-
-// WebEnabled reports whether the WS gateway should be started.
-func (s *Settings) WebEnabled() bool { return s.WebPassword != "" }
-
-// IdleShutdownEnabled reports whether the gateway's idle-shutdown timer
-// is configured.
-func (s *Settings) IdleShutdownEnabled() bool { return s.WebIdleShutdownSeconds > 0 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,7 +1,8 @@
 // Package config holds turborg's top-level Settings — the cross-cutting
 // env-var contract that lives under TURBORG_*. Per-connector knobs
-// (TURBORG_IRC_*, etc., including the IRC-coupled WS gateway under
-// TURBORG_IRC_WEB_*) live with their respective connectors.
+// (TURBORG_IRC_*, etc.) live with their respective connectors. The
+// gateway is a top-level control surface, not a connector, so its env
+// lives here under TURBORG_GATEWAY_*.
 //
 // Connector-specific settings stay in their own packages so installing
 // turborg without a particular connector does not require setting that
@@ -24,9 +25,8 @@ var ValidConnectors = map[string]bool{
 }
 
 // Settings is the top-level turborg config. Connector-specific knobs
-// (TURBORG_IRC_*, including the IRC-coupled WS gateway under
-// TURBORG_IRC_WEB_*) are loaded by their own packages — Settings stays
-// narrow.
+// (TURBORG_IRC_*, …) are loaded by their own packages — Settings stays
+// narrow and cross-cutting.
 type Settings struct {
 	LogLevel  string `env:"LOG_LEVEL"  envDefault:"INFO"`
 	LogFormat string `env:"LOG_FORMAT" envDefault:"text"`
@@ -48,6 +48,18 @@ type Settings struct {
 
 	CommandMaxPerWindow  int `env:"COMMAND_MAX_PER_WINDOW"  envDefault:"5"`
 	CommandWindowSeconds int `env:"COMMAND_WINDOW_SECONDS"  envDefault:"30"`
+
+	// Gateway is the bot's control-plane surface: WS protocol + bundled
+	// reference UI. Today it streams IRC events; the env vars don't
+	// promise a specific protocol or connector, so the same names
+	// survive any future transport/connector additions.
+	GatewayPassword             string `env:"GATEWAY_PASSWORD"`
+	GatewayHost                 string `env:"GATEWAY_HOST" envDefault:"127.0.0.1"`
+	GatewayPort                 int    `env:"GATEWAY_PORT" envDefault:"8765"`
+	GatewayMaxFailedAttempts    int    `env:"GATEWAY_MAX_FAILED_ATTEMPTS" envDefault:"5"`
+	GatewayFailureWindowSeconds int    `env:"GATEWAY_FAILURE_WINDOW_SECONDS" envDefault:"60"`
+	GatewayLockoutSeconds       int    `env:"GATEWAY_LOCKOUT_SECONDS" envDefault:"300"`
+	GatewayIdleShutdownSeconds  int    `env:"GATEWAY_IDLE_SHUTDOWN_SECONDS"`
 }
 
 // Load parses TURBORG_* env vars into a Settings, normalizing the
@@ -89,3 +101,11 @@ func (s *Settings) normalize() error {
 // wired. False means standalone mode — the !ask command is not
 // registered.
 func (s *Settings) AnthropicEnabled() bool { return s.AnthropicAPIKey != "" }
+
+// GatewayEnabled reports whether the control-plane gateway should be
+// started. False = no listener, no UI, no /ws endpoint.
+func (s *Settings) GatewayEnabled() bool { return s.GatewayPassword != "" }
+
+// IdleShutdownEnabled reports whether the gateway's idle-shutdown timer
+// is configured. Wired by the SaaS sidecar for free-tier containers.
+func (s *Settings) IdleShutdownEnabled() bool { return s.GatewayIdleShutdownSeconds > 0 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -15,10 +15,7 @@ func TestLoadDefaults(t *testing.T) {
 	assert.Equal(t, "text", s.LogFormat)
 	assert.Equal(t, "!", s.CommandPrefix)
 	assert.Equal(t, "claude-sonnet-4-6", s.AnthropicModel)
-	assert.Equal(t, "127.0.0.1", s.WebHost)
-	assert.Equal(t, 8765, s.WebPort)
 	assert.False(t, s.AnthropicEnabled())
-	assert.False(t, s.WebEnabled())
 	assert.False(t, s.HiveEnabled)
 }
 
@@ -46,18 +43,6 @@ func TestLoadRespectsAnthropicEnable(t *testing.T) {
 	assert.Equal(t, "claude-opus-4-7", s.AnthropicModel)
 }
 
-func TestLoadRespectsWebToggle(t *testing.T) {
-	t.Setenv("TURBORG_WEB_PASSWORD", "hunter2")
-	t.Setenv("TURBORG_WEB_PORT", "9000")
-	t.Setenv("TURBORG_WEB_IDLE_SHUTDOWN_SECONDS", "30")
-	s, err := config.Load()
-	require.NoError(t, err)
-	assert.True(t, s.WebEnabled())
-	assert.True(t, s.IdleShutdownEnabled())
-	assert.Equal(t, 9000, s.WebPort)
-	assert.Equal(t, 30, s.WebIdleShutdownSeconds)
-}
-
 func TestLoadRejectsEmptyCommandPrefix(t *testing.T) {
 	t.Setenv("TURBORG_COMMAND_PREFIX", "")
 	// With caarlos0/env, setting an env var to empty leaves it as the
@@ -75,9 +60,9 @@ func TestLoadHandlesEmptyCSVAsNoConnectors(t *testing.T) {
 }
 
 func TestLoadRejectsMalformedTypedEnv(t *testing.T) {
-	// WebPort is int — a non-numeric value surfaces a parse error from
-	// caarlos0/env, exercising the err != nil branch in Load().
-	t.Setenv("TURBORG_WEB_PORT", "not-a-number")
+	// CommandMaxPerWindow is int — a non-numeric value surfaces a parse
+	// error from caarlos0/env, exercising the err != nil branch in Load().
+	t.Setenv("TURBORG_COMMAND_MAX_PER_WINDOW", "not-a-number")
 	_, err := config.Load()
 	require.Error(t, err)
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -15,8 +15,24 @@ func TestLoadDefaults(t *testing.T) {
 	assert.Equal(t, "text", s.LogFormat)
 	assert.Equal(t, "!", s.CommandPrefix)
 	assert.Equal(t, "claude-sonnet-4-6", s.AnthropicModel)
+	assert.Equal(t, "127.0.0.1", s.GatewayHost)
+	assert.Equal(t, 8765, s.GatewayPort)
 	assert.False(t, s.AnthropicEnabled())
+	assert.False(t, s.GatewayEnabled())
+	assert.False(t, s.IdleShutdownEnabled())
 	assert.False(t, s.HiveEnabled)
+}
+
+func TestLoadRespectsGatewayToggle(t *testing.T) {
+	t.Setenv("TURBORG_GATEWAY_PASSWORD", "hunter2")
+	t.Setenv("TURBORG_GATEWAY_PORT", "9000")
+	t.Setenv("TURBORG_GATEWAY_IDLE_SHUTDOWN_SECONDS", "30")
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.True(t, s.GatewayEnabled())
+	assert.True(t, s.IdleShutdownEnabled())
+	assert.Equal(t, 9000, s.GatewayPort)
+	assert.Equal(t, 30, s.GatewayIdleShutdownSeconds)
 }
 
 func TestLoadConnectorsCSV(t *testing.T) {
@@ -60,9 +76,9 @@ func TestLoadHandlesEmptyCSVAsNoConnectors(t *testing.T) {
 }
 
 func TestLoadRejectsMalformedTypedEnv(t *testing.T) {
-	// CommandMaxPerWindow is int — a non-numeric value surfaces a parse
-	// error from caarlos0/env, exercising the err != nil branch in Load().
-	t.Setenv("TURBORG_COMMAND_MAX_PER_WINDOW", "not-a-number")
+	// GatewayPort is int — a non-numeric value surfaces a parse error
+	// from caarlos0/env, exercising the err != nil branch in Load().
+	t.Setenv("TURBORG_GATEWAY_PORT", "not-a-number")
 	_, err := config.Load()
 	require.Error(t, err)
 }

--- a/internal/connector/irc/codes.go
+++ b/internal/connector/irc/codes.go
@@ -1,8 +1,8 @@
 package irc
 
 // IRC numeric replies turborg recognizes during the handshake or runtime.
-// String values match Python core/connectors/irc/codes.py byte-for-byte so
-// dashboards and logs stay stable across the port.
+// Identifiers follow the conventional Rpl*/Err* naming; the string
+// values are the wire-level numerics defined by RFC 1459/2812.
 const (
 	RplWelcome       = "001"
 	RplYourHost      = "002"
@@ -73,7 +73,8 @@ const (
 
 // IsHandshakeComplete reports whether the given numeric reply signals the
 // server has finished sending its MOTD and the connection is ready for
-// normal traffic. Matches Python's HANDSHAKE_COMPLETE frozenset.
+// normal traffic. Either RPL_ENDOFMOTD (376) or ERR_NOMOTD (422)
+// completes the handshake; servers without a MOTD send the latter.
 func IsHandshakeComplete(numeric string) bool {
 	return numeric == RplEndOfMOTD || numeric == ErrNoMOTD
 }

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -20,7 +20,7 @@ import (
 // Connector is the IRC adapter: TLS dial + IRCv3 CAP / SASL handshake,
 // supervised read+ping loop, channel-state cache, optional bouncer.
 //
-// Lifecycle (mirrors Python connectors/irc/connector.py):
+// Lifecycle:
 //   - Start: open the connection, run CAP/SASL/USER/NICK, await
 //     RPL_ENDOFMOTD or ERR_NOMOTD, JOIN configured channels, send
 //     NickServ IDENTIFY if configured, start the bouncer if configured.
@@ -484,8 +484,7 @@ func (c *Connector) Run(ctx context.Context) error {
 	// Each iteration resets the read deadline to now + idle; if no
 	// data arrives within the window, Go's net layer returns a
 	// timeout error and Run unwinds. Without this, a half-dead TLS
-	// socket (NAT idle, peer crashed) parks the bot indefinitely —
-	// the exact bug the Python silent-death fix addressed.
+	// socket (NAT idle, peer crashed) would park the bot indefinitely.
 	g.Go(func() error {
 		defer close(lines)
 		idle := c.settings.ReadIdleTimeout

--- a/internal/connector/irc/dispatch_test.go
+++ b/internal/connector/irc/dispatch_test.go
@@ -31,10 +31,9 @@ func driveConnector(t *testing.T, settings *irc.Settings, fsOpts ...fakeirc.Opti
 	if len(settings.Channels) == 0 {
 		settings.Channels = []string{"#test"}
 	}
-	// CTCP defaults match what the Python implementation ships with: auto
-	// reply enabled, 3 replies per 30s window. Individual tests override
-	// by setting CTCPMaxPerWindow / CTCPWindowSeconds / CTCPAutoReply
-	// before calling driveConnector.
+	// CTCP defaults: auto reply enabled, 3 replies per 30s window.
+	// Individual tests override by setting CTCPMaxPerWindow /
+	// CTCPWindowSeconds / CTCPAutoReply before calling driveConnector.
 	if settings.CTCPMaxPerWindow == 0 && settings.CTCPWindowSeconds == 0 {
 		settings.CTCPAutoReply = true
 		settings.CTCPMaxPerWindow = 3

--- a/internal/connector/irc/protocol.go
+++ b/internal/connector/irc/protocol.go
@@ -2,7 +2,7 @@
 //
 // The protocol parser is forgiving: a malformed line yields a Message with
 // Command="" rather than raising, so a single bad input does not crash the
-// connector. This matches the Python implementation's behavior.
+// connector. Callers should treat empty Command as "unparseable, drop".
 package irc
 
 import "strings"

--- a/internal/connector/irc/protocol_test.go
+++ b/internal/connector/irc/protocol_test.go
@@ -188,9 +188,8 @@ func TestParsePrefixOnlyLineAfterTags(t *testing.T) {
 func TestParseDegenerateColonAfterPrefix(t *testing.T) {
 	// Per RFC, trailing must be introduced by " :" (space-colon). A bare
 	// ":trailing" right after the prefix is therefore parsed as a command
-	// with one param, not as trailing. This mirrors the Python parser
-	// exactly — the test is here so any future "cleanup" that diverges
-	// from Python gets flagged.
+	// with one param, not as trailing. The test pins this behavior so a
+	// future "cleanup" that rescues the degenerate form gets flagged.
 	m := irc.Parse(":prefix :weird args")
 	assert.Equal(t, "prefix", m.Prefix)
 	assert.Equal(t, ":WEIRD", m.Command, "degenerate input is forgiven, not rescued")

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -43,19 +43,6 @@ type Settings struct {
 	BouncerFailureWindowSeconds  int           `env:"BOUNCER_FAILURE_WINDOW_SECONDS" envDefault:"60"`
 	BouncerLockoutSeconds        int           `env:"BOUNCER_LOCKOUT_SECONDS" envDefault:"300"`
 
-	// WebSocket gateway + bundled reference UI for the IRC connector.
-	// The gateway is IRC-coupled (it speaks IRCBridge / shows channel
-	// state), so its env lives under TURBORG_IRC_WEB_* alongside the
-	// bouncer. A future general-purpose bot-core web connector will
-	// claim TURBORG_WEB_*.
-	WebPassword             string `env:"WEB_PASSWORD"`
-	WebHost                 string `env:"WEB_HOST" envDefault:"127.0.0.1"`
-	WebPort                 int    `env:"WEB_PORT" envDefault:"8765"`
-	WebMaxFailedAttempts    int    `env:"WEB_MAX_FAILED_ATTEMPTS" envDefault:"5"`
-	WebFailureWindowSeconds int    `env:"WEB_FAILURE_WINDOW_SECONDS" envDefault:"60"`
-	WebLockoutSeconds       int    `env:"WEB_LOCKOUT_SECONDS" envDefault:"300"`
-	WebIdleShutdownSeconds  int    `env:"WEB_IDLE_SHUTDOWN_SECONDS"`
-
 	CTCPAutoReply     bool `env:"CTCP_AUTO_REPLY" envDefault:"true"`
 	CTCPMaxPerWindow  int  `env:"CTCP_MAX_PER_WINDOW" envDefault:"3"`
 	CTCPWindowSeconds int  `env:"CTCP_WINDOW_SECONDS" envDefault:"30"`
@@ -138,17 +125,6 @@ func (s *Settings) SASLEnabled() bool {
 // BouncerEnabled is true when the bouncer password is set.
 func (s *Settings) BouncerEnabled() bool {
 	return s.BouncerPassword != ""
-}
-
-// WebEnabled is true when the WS gateway password is set.
-func (s *Settings) WebEnabled() bool {
-	return s.WebPassword != ""
-}
-
-// IdleShutdownEnabled reports whether the gateway's idle-shutdown timer
-// is configured. Wired by the SaaS sidecar for free-tier containers.
-func (s *Settings) IdleShutdownEnabled() bool {
-	return s.WebIdleShutdownSeconds > 0
 }
 
 // Validate runs cross-field checks that the env-tag layer can't express

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -44,6 +44,19 @@ type Settings struct {
 	BouncerFailureWindowSeconds  int           `env:"BOUNCER_FAILURE_WINDOW_SECONDS" envDefault:"60"`
 	BouncerLockoutSeconds        int           `env:"BOUNCER_LOCKOUT_SECONDS" envDefault:"300"`
 
+	// WebSocket gateway + bundled reference UI for the IRC connector.
+	// The gateway is IRC-coupled (it speaks IRCBridge / shows channel
+	// state), so its env lives under TURBORG_IRC_WEB_* alongside the
+	// bouncer. A future general-purpose bot-core web connector will
+	// claim TURBORG_WEB_*.
+	WebPassword             string `env:"WEB_PASSWORD"`
+	WebHost                 string `env:"WEB_HOST" envDefault:"127.0.0.1"`
+	WebPort                 int    `env:"WEB_PORT" envDefault:"8765"`
+	WebMaxFailedAttempts    int    `env:"WEB_MAX_FAILED_ATTEMPTS" envDefault:"5"`
+	WebFailureWindowSeconds int    `env:"WEB_FAILURE_WINDOW_SECONDS" envDefault:"60"`
+	WebLockoutSeconds       int    `env:"WEB_LOCKOUT_SECONDS" envDefault:"300"`
+	WebIdleShutdownSeconds  int    `env:"WEB_IDLE_SHUTDOWN_SECONDS"`
+
 	CTCPAutoReply     bool `env:"CTCP_AUTO_REPLY" envDefault:"true"`
 	CTCPMaxPerWindow  int  `env:"CTCP_MAX_PER_WINDOW" envDefault:"3"`
 	CTCPWindowSeconds int  `env:"CTCP_WINDOW_SECONDS" envDefault:"30"`
@@ -124,6 +137,17 @@ func (s *Settings) SASLEnabled() bool {
 // BouncerEnabled is true when the bouncer password is set.
 func (s *Settings) BouncerEnabled() bool {
 	return s.BouncerPassword != ""
+}
+
+// WebEnabled is true when the WS gateway password is set.
+func (s *Settings) WebEnabled() bool {
+	return s.WebPassword != ""
+}
+
+// IdleShutdownEnabled reports whether the gateway's idle-shutdown timer
+// is configured. Wired by the SaaS sidecar for free-tier containers.
+func (s *Settings) IdleShutdownEnabled() bool {
+	return s.WebIdleShutdownSeconds > 0
 }
 
 // Validate runs cross-field checks that the env-tag layer can't express

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -8,10 +8,9 @@ import (
 	"github.com/caarlos0/env/v11"
 )
 
-// Settings is the env-driven config for the IRC connector. Tag names map
-// to the TURBORG_IRC_* contract the xshellz sidecar already sets; every
-// var name and default value matches Python core/connectors/irc/settings.py
-// byte-for-byte so the SaaS spawner needs no changes during the port.
+// Settings is the env-driven config for the IRC connector. Tag names
+// define the TURBORG_IRC_* contract — see docs/connectors/irc.md for
+// the full operator-facing reference.
 //
 // Required fields (no default): Hostname, Nick. Everything else defaults
 // to a sensible value or stays empty/disabled.
@@ -69,10 +68,10 @@ func LoadSettings() (*Settings, error) {
 	if err := env.ParseWithOptions(s, env.Options{Prefix: "TURBORG_IRC_"}); err != nil {
 		return nil, err
 	}
-	// Normalize Channels — accept both CSV (#a,#b) and the legacy
-	// Python pydantic-settings JSON-list (["#a","#b"]) format so an
-	// existing .env from the Python repo is a drop-in. Tolerates leading
-	// "[" / trailing "]" / surrounding quotes on individual entries.
+	// Normalize Channels — accept both CSV (#a,#b) and a JSON-array
+	// shape (["#a","#b"]) so the var is friendly to config systems
+	// that emit lists. Tolerates leading "[" / trailing "]" /
+	// surrounding quotes on individual entries.
 	s.Channels = parseChannelList(strings.Join(s.Channels, ","))
 	return s, nil
 }
@@ -100,7 +99,8 @@ func parseChannelList(raw string) []string {
 }
 
 // NormalizedChannels returns Channels with a '#' prefix added where the
-// caller omitted one. Matches Python normalized_channels().
+// caller omitted one. Channels already starting with #/&/+/! are passed
+// through unchanged.
 func (s *Settings) NormalizedChannels() []string {
 	out := make([]string, 0, len(s.Channels))
 	for _, ch := range s.Channels {
@@ -120,8 +120,9 @@ func (s *Settings) NormalizedChannels() []string {
 	return out
 }
 
-// EffectiveUsername returns Username if set, otherwise Nick. Matches
-// Python effective_username().
+// EffectiveUsername returns Username if set, otherwise Nick. The IRC
+// USER command requires a non-empty ident; defaulting to the nick is
+// the universally-accepted fallback when an operator doesn't set one.
 func (s *Settings) EffectiveUsername() string {
 	if s.Username != "" {
 		return s.Username

--- a/internal/connector/irc/settings_test.go
+++ b/internal/connector/irc/settings_test.go
@@ -92,38 +92,3 @@ func TestValidateAcceptsHealthyConfig(t *testing.T) {
 	s := &irc.Settings{ClientPingInterval: 120 * time.Second, ReadIdleTimeout: 300 * time.Second}
 	assert.NoError(t, s.Validate())
 }
-
-func TestLoadSettingsWebDefaults(t *testing.T) {
-	t.Setenv("TURBORG_IRC_HOSTNAME", "irc.libera.chat")
-	t.Setenv("TURBORG_IRC_NICK", "turborg")
-
-	s, err := irc.LoadSettings()
-	require.NoError(t, err)
-	assert.Equal(t, "127.0.0.1", s.WebHost)
-	assert.Equal(t, 8765, s.WebPort)
-	assert.False(t, s.WebEnabled())
-	assert.False(t, s.IdleShutdownEnabled())
-}
-
-func TestLoadSettingsRespectsWebToggle(t *testing.T) {
-	t.Setenv("TURBORG_IRC_HOSTNAME", "irc.libera.chat")
-	t.Setenv("TURBORG_IRC_NICK", "turborg")
-	t.Setenv("TURBORG_IRC_WEB_PASSWORD", "hunter2")
-	t.Setenv("TURBORG_IRC_WEB_PORT", "9000")
-	t.Setenv("TURBORG_IRC_WEB_IDLE_SHUTDOWN_SECONDS", "30")
-
-	s, err := irc.LoadSettings()
-	require.NoError(t, err)
-	assert.True(t, s.WebEnabled())
-	assert.True(t, s.IdleShutdownEnabled())
-	assert.Equal(t, 9000, s.WebPort)
-	assert.Equal(t, 30, s.WebIdleShutdownSeconds)
-}
-
-func TestLoadSettingsRejectsMalformedWebPort(t *testing.T) {
-	t.Setenv("TURBORG_IRC_HOSTNAME", "irc.libera.chat")
-	t.Setenv("TURBORG_IRC_NICK", "turborg")
-	t.Setenv("TURBORG_IRC_WEB_PORT", "not-a-number")
-	_, err := irc.LoadSettings()
-	require.Error(t, err)
-}

--- a/internal/connector/irc/settings_test.go
+++ b/internal/connector/irc/settings_test.go
@@ -92,3 +92,38 @@ func TestValidateAcceptsHealthyConfig(t *testing.T) {
 	s := &irc.Settings{ClientPingInterval: 120 * time.Second, ReadIdleTimeout: 300 * time.Second}
 	assert.NoError(t, s.Validate())
 }
+
+func TestLoadSettingsWebDefaults(t *testing.T) {
+	t.Setenv("TURBORG_IRC_HOSTNAME", "irc.libera.chat")
+	t.Setenv("TURBORG_IRC_NICK", "turborg")
+
+	s, err := irc.LoadSettings()
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", s.WebHost)
+	assert.Equal(t, 8765, s.WebPort)
+	assert.False(t, s.WebEnabled())
+	assert.False(t, s.IdleShutdownEnabled())
+}
+
+func TestLoadSettingsRespectsWebToggle(t *testing.T) {
+	t.Setenv("TURBORG_IRC_HOSTNAME", "irc.libera.chat")
+	t.Setenv("TURBORG_IRC_NICK", "turborg")
+	t.Setenv("TURBORG_IRC_WEB_PASSWORD", "hunter2")
+	t.Setenv("TURBORG_IRC_WEB_PORT", "9000")
+	t.Setenv("TURBORG_IRC_WEB_IDLE_SHUTDOWN_SECONDS", "30")
+
+	s, err := irc.LoadSettings()
+	require.NoError(t, err)
+	assert.True(t, s.WebEnabled())
+	assert.True(t, s.IdleShutdownEnabled())
+	assert.Equal(t, 9000, s.WebPort)
+	assert.Equal(t, 30, s.WebIdleShutdownSeconds)
+}
+
+func TestLoadSettingsRejectsMalformedWebPort(t *testing.T) {
+	t.Setenv("TURBORG_IRC_HOSTNAME", "irc.libera.chat")
+	t.Setenv("TURBORG_IRC_NICK", "turborg")
+	t.Setenv("TURBORG_IRC_WEB_PORT", "not-a-number")
+	_, err := irc.LoadSettings()
+	require.Error(t, err)
+}

--- a/internal/connector/irc/state.go
+++ b/internal/connector/irc/state.go
@@ -11,9 +11,8 @@ import (
 const memberPrefixes = "@+%&~"
 
 // ChannelInfo is per-channel state cached from observed server messages.
-// Mirrors Python core/connectors/irc/state.py:ChannelInfo. The bouncer
-// replays this to new clients on auth so they pick up the bot's view of
-// the network instead of starting blank.
+// The bouncer replays this to new clients on auth so they pick up the
+// bot's view of the network instead of starting blank.
 type ChannelInfo struct {
 	// Name is the original-cased channel ("#XSHELLZ-Test2"). Lookups are
 	// case-insensitive but display preserves the form the server used.
@@ -118,9 +117,8 @@ func (s *ChannelState) ClearTopic(channel string) {
 	info.TopicSet = true
 }
 
-// SetTopicMeta records who set the topic and when. Maps to Python's
-// on_topic(channel, set_by=..., set_at=...) when no topic= kwarg is
-// supplied (RPL_TOPICWHOTIME / 333).
+// SetTopicMeta records who set the topic and when, from
+// RPL_TOPICWHOTIME (333). Leaves the topic body untouched.
 func (s *ChannelState) SetTopicMeta(channel, setBy string, setAt int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -16,11 +16,12 @@ import (
 	"github.com/turborg/turborg/internal/llm"
 )
 
-// DefaultModel matches the Python implementation's default. Override
-// via Settings.Model or per-call WithModel.
+// DefaultModel is the model used when Settings.Model is empty.
+// Override via Settings.Model or per-call WithModel.
 const DefaultModel = "claude-sonnet-4-6"
 
-// DefaultMaxTokens matches the Python max_tokens=4096 default.
+// DefaultMaxTokens caps response length when the caller doesn't set
+// WithMaxTokens. 4096 is enough for ~5–10 IRC lines after wrapping.
 const DefaultMaxTokens = 4096
 
 // Settings configures an Anthropic provider. APIKey is required;

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,9 +2,9 @@
 //
 // Two formats are supported: text (human-readable, the default) and json
 // (one JSON object per line for ingestion by Loki/Datadog/CloudWatch
-// Insights without regex parsing). The level matches Python's
-// LOG_LEVEL contract (DEBUG/INFO/WARNING/ERROR — WARNING maps to slog
-// WARN for compatibility with Python's name).
+// Insights without regex parsing). Level names accept the familiar
+// DEBUG/INFO/WARNING/ERROR/CRITICAL spelling (case-insensitive) and
+// also the slog spelling WARN; both resolve to slog.LevelWarn.
 package logging
 
 import (
@@ -16,8 +16,8 @@ import (
 )
 
 // New builds a *slog.Logger configured per level + format. Level names
-// match Python (case-insensitive); unknown levels return an error
-// rather than silently defaulting.
+// are case-insensitive; unknown levels return an error rather than
+// silently defaulting.
 func New(w io.Writer, level, format string) (*slog.Logger, error) {
 	if w == nil {
 		w = os.Stderr
@@ -51,8 +51,9 @@ func parseLevel(level string) (slog.Level, error) {
 	case "ERROR":
 		return slog.LevelError, nil
 	case "CRITICAL":
-		// Python CRITICAL doesn't exist in slog; slog tops out at ERROR.
-		// Treat it as ERROR — same gate, slight naming mismatch.
+		// slog tops out at ERROR — CRITICAL collapses to the same gate
+		// so operators used to CRITICAL from other ecosystems still get
+		// the strictest level rather than a parse error.
 		return slog.LevelError, nil
 	}
 	return 0, errors.New("logging: unknown level " + level)

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -32,7 +32,7 @@ func TestNewJSONHandler(t *testing.T) {
 	assert.Equal(t, "v", got["k"])
 }
 
-func TestNewAcceptsPythonLevelNames(t *testing.T) {
+func TestNewAcceptsAllLevelAliases(t *testing.T) {
 	for _, lvl := range []string{"DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", ""} {
 		_, err := logging.New(nil, lvl, "text")
 		assert.NoError(t, err, "level %q must be accepted", lvl)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -9,7 +9,7 @@
 //     Build wires every listed connector.
 //   - Anthropic provider only attaches when TURBORG_ANTHROPIC_API_KEY
 //     is present — the agent never fails for lack of one.
-//   - Web gateway only attaches when TURBORG_IRC_WEB_PASSWORD is set.
+//   - Gateway only attaches when TURBORG_GATEWAY_PASSWORD is set.
 package runtime
 
 import (
@@ -80,8 +80,8 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 
 	built := &Built{Agent: a, IRC: ircConn, LLM: provider}
 
-	if ircCfg.WebEnabled() {
-		gw, err := buildGateway(ircCfg, ircConn, log)
+	if s.GatewayEnabled() {
+		gw, err := buildGateway(s, ircConn, log)
 		if err != nil {
 			return nil, err
 		}
@@ -107,29 +107,29 @@ func buildLLM(s *config.Settings) (llm.Provider, error) {
 	return p, nil
 }
 
-func buildGateway(ircCfg *irc.Settings, ircConn *irc.Connector, log *slog.Logger) (*web.Gateway, error) {
-	verifier, err := web.NewStaticPasswordVerifier(ircCfg.WebPassword)
+func buildGateway(s *config.Settings, ircConn *irc.Connector, log *slog.Logger) (*web.Gateway, error) {
+	verifier, err := web.NewStaticPasswordVerifier(s.GatewayPassword)
 	if err != nil {
-		return nil, fmt.Errorf("runtime: web verifier: %w", err)
+		return nil, fmt.Errorf("runtime: gateway verifier: %w", err)
 	}
 	rl, err := irc.NewRateLimiter(
-		ircCfg.WebMaxFailedAttempts,
-		time.Duration(ircCfg.WebFailureWindowSeconds)*time.Second,
-		time.Duration(ircCfg.WebLockoutSeconds)*time.Second,
+		s.GatewayMaxFailedAttempts,
+		time.Duration(s.GatewayFailureWindowSeconds)*time.Second,
+		time.Duration(s.GatewayLockoutSeconds)*time.Second,
 		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("runtime: web ratelimit: %w", err)
+		return nil, fmt.Errorf("runtime: gateway ratelimit: %w", err)
 	}
 	opts := web.Options{
-		Host:        ircCfg.WebHost,
-		Port:        ircCfg.WebPort,
+		Host:        s.GatewayHost,
+		Port:        s.GatewayPort,
 		Verifier:    verifier,
 		RateLimiter: rl,
 		Log:         log,
 	}
-	if ircCfg.IdleShutdownEnabled() {
-		opts.IdleShutdownSeconds = ircCfg.WebIdleShutdownSeconds
+	if s.IdleShutdownEnabled() {
+		opts.IdleShutdownSeconds = s.GatewayIdleShutdownSeconds
 		// Idle callback wired by the CLI — it needs the cancel func that
 		// stops both halves. Runtime can't supply it without knowing the
 		// CLI's ctx. Leaving OnIdleShutdown nil here means the gateway

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -9,7 +9,7 @@
 //     BuildMultiConnectorAgent wires every listed connector.
 //   - Anthropic provider only attaches when TURBORG_ANTHROPIC_API_KEY
 //     is present — the agent never fails for lack of one.
-//   - Web gateway only attaches when TURBORG_WEB_PASSWORD is set.
+//   - Web gateway only attaches when TURBORG_IRC_WEB_PASSWORD is set.
 package runtime
 
 import (
@@ -80,8 +80,8 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 
 	built := &Built{Agent: a, IRC: ircConn, LLM: provider}
 
-	if s.WebEnabled() {
-		gw, err := buildGateway(s, ircConn, a, log)
+	if ircCfg.WebEnabled() {
+		gw, err := buildGateway(ircCfg, ircConn, log)
 		if err != nil {
 			return nil, err
 		}
@@ -107,29 +107,29 @@ func buildLLM(s *config.Settings) (llm.Provider, error) {
 	return p, nil
 }
 
-func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger) (*web.Gateway, error) {
-	verifier, err := web.NewStaticPasswordVerifier(s.WebPassword)
+func buildGateway(ircCfg *irc.Settings, ircConn *irc.Connector, log *slog.Logger) (*web.Gateway, error) {
+	verifier, err := web.NewStaticPasswordVerifier(ircCfg.WebPassword)
 	if err != nil {
 		return nil, fmt.Errorf("runtime: web verifier: %w", err)
 	}
 	rl, err := irc.NewRateLimiter(
-		s.WebMaxFailedAttempts,
-		time.Duration(s.WebFailureWindowSeconds)*time.Second,
-		time.Duration(s.WebLockoutSeconds)*time.Second,
+		ircCfg.WebMaxFailedAttempts,
+		time.Duration(ircCfg.WebFailureWindowSeconds)*time.Second,
+		time.Duration(ircCfg.WebLockoutSeconds)*time.Second,
 		nil,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("runtime: web ratelimit: %w", err)
 	}
 	opts := web.Options{
-		Host:        s.WebHost,
-		Port:        s.WebPort,
+		Host:        ircCfg.WebHost,
+		Port:        ircCfg.WebPort,
 		Verifier:    verifier,
 		RateLimiter: rl,
 		Log:         log,
 	}
-	if s.IdleShutdownEnabled() {
-		opts.IdleShutdownSeconds = s.WebIdleShutdownSeconds
+	if ircCfg.IdleShutdownEnabled() {
+		opts.IdleShutdownSeconds = ircCfg.WebIdleShutdownSeconds
 		// Idle callback wired by the CLI — it needs the cancel func that
 		// stops both halves. Runtime can't supply it without knowing the
 		// CLI's ctx. Leaving OnIdleShutdown nil here means the gateway

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2,11 +2,11 @@
 // from environment-derived settings. The CLI calls Build, but the same
 // functions are exposed for embedders (tests, alternate front-ends).
 //
-// Behavior matches Python core/runtime.py:
+// Wiring rules:
 //   - Single-IRC quickstart path: when TURBORG_CONNECTORS is unset,
-//     BuildAgent wires one IRC connector + builtins.
+//     Build wires one IRC connector + builtins.
 //   - Multi-connector path: when TURBORG_CONNECTORS=irc[,…] is set,
-//     BuildMultiConnectorAgent wires every listed connector.
+//     Build wires every listed connector.
 //   - Anthropic provider only attaches when TURBORG_ANTHROPIC_API_KEY
 //     is present — the agent never fails for lack of one.
 //   - Web gateway only attaches when TURBORG_IRC_WEB_PASSWORD is set.
@@ -185,8 +185,9 @@ func collapseWhitespace(s string) string {
 //
 // Owner checks fail closed when an account tag is required but missing
 // (e.g. a services-less network or a client without the account-tag
-// capability). This is the security stance the Python implementation
-// converged on after the deferred-tag bug.
+// capability). Failing open would let any nick spoof the owner the
+// moment the account-tag pipeline went unavailable, which is exactly
+// when defensive gating matters most.
 func BuildCommandGuard(s *config.Settings) agent.CommandGuard {
 	ownerNick := strings.ToLower(strings.TrimSpace(s.OwnerNick))
 	ownerAccount := strings.TrimSpace(s.OwnerAccount)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -44,18 +44,17 @@ func TestBuildWithAnthropic(t *testing.T) {
 		"!ask command must be registered when LLM is wired")
 }
 
-func TestBuildWithWebGateway(t *testing.T) {
-	s := &config.Settings{CommandPrefix: "!"}
-	ircCfg := &irc.Settings{
-		Hostname:                "fake",
-		Nick:                    "turborg",
-		WebPassword:             "hunter2",
-		WebHost:                 "127.0.0.1",
-		WebPort:                 0,
-		WebMaxFailedAttempts:    5,
-		WebFailureWindowSeconds: 60,
-		WebLockoutSeconds:       300,
+func TestBuildWithGateway(t *testing.T) {
+	s := &config.Settings{
+		CommandPrefix:               "!",
+		GatewayPassword:             "hunter2",
+		GatewayHost:                 "127.0.0.1",
+		GatewayPort:                 0,
+		GatewayMaxFailedAttempts:    5,
+		GatewayFailureWindowSeconds: 60,
+		GatewayLockoutSeconds:       300,
 	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
 	require.NotNil(t, b.Gateway)
@@ -224,23 +223,25 @@ func TestRunStandaloneReturnsOnCtxCancel(t *testing.T) {
 }
 
 func TestRunWithGatewayUnwindsOnAgentStartFailure(t *testing.T) {
-	// Web gateway is enabled; the IRC connector points at a port that
-	// is closed so Agent.Run fails fast. Run() must cancel the shared
-	// ctx so gateway.Serve also returns, and Wait must surface the
-	// agent error.
-	s := &config.Settings{CommandPrefix: "!"}
+	// Gateway is enabled; the IRC connector points at a port that is
+	// closed so Agent.Run fails fast. Run() must cancel the shared ctx
+	// so gateway.Serve also returns, and Wait must surface the agent
+	// error.
+	s := &config.Settings{
+		CommandPrefix:               "!",
+		GatewayPassword:             "p",
+		GatewayHost:                 "127.0.0.1",
+		GatewayPort:                 0,
+		GatewayMaxFailedAttempts:    5,
+		GatewayFailureWindowSeconds: 60,
+		GatewayLockoutSeconds:       300,
+	}
 	ircCfg := &irc.Settings{
-		Hostname:                "127.0.0.1",
-		Port:                    1, // port 1 is the discard port — nothing listens
-		UseTLS:                  false,
-		Nick:                    "turborg",
-		HandshakeTimeout:        200 * time.Millisecond,
-		WebPassword:             "p",
-		WebHost:                 "127.0.0.1",
-		WebPort:                 0,
-		WebMaxFailedAttempts:    5,
-		WebFailureWindowSeconds: 60,
-		WebLockoutSeconds:       300,
+		Hostname:         "127.0.0.1",
+		Port:             1, // port 1 is the discard port — nothing listens
+		UseTLS:           false,
+		Nick:             "turborg",
+		HandshakeTimeout: 200 * time.Millisecond,
 	}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
@@ -308,22 +309,21 @@ func TestLoadIRCSettingsCrossFieldValidation(t *testing.T) {
 
 // --- buildLLM error path: invalid API key handled at New ------------------
 
-func TestBuildWithInvalidWebPasswordFailsClean(t *testing.T) {
-	// Empty password disables Web entirely; an explicitly empty value
-	// reaches buildGateway only when WebEnabled returns true. To
-	// exercise the error wrap, give web.NewStaticPasswordVerifier a
+func TestBuildWithInvalidGatewayPasswordFailsClean(t *testing.T) {
+	// Empty password disables the gateway entirely; an explicitly empty
+	// value reaches buildGateway only when GatewayEnabled returns true.
+	// To exercise the error wrap, give web.NewStaticPasswordVerifier a
 	// blank password.
-	s := &config.Settings{CommandPrefix: "!"}
-	ircCfg := &irc.Settings{
-		Hostname:                "fake",
-		Nick:                    "turborg",
-		WebPassword:             " ", // single space — treated as set by WebEnabled but verifier rejects
-		WebHost:                 "127.0.0.1",
-		WebPort:                 0,
-		WebMaxFailedAttempts:    5,
-		WebFailureWindowSeconds: 60,
-		WebLockoutSeconds:       300,
+	s := &config.Settings{
+		CommandPrefix:               "!",
+		GatewayPassword:             " ", // single space — treated as set but verifier rejects
+		GatewayHost:                 "127.0.0.1",
+		GatewayPort:                 0,
+		GatewayMaxFailedAttempts:    5,
+		GatewayFailureWindowSeconds: 60,
+		GatewayLockoutSeconds:       300,
 	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	_, err := runtime.Build(s, ircCfg, nil)
 	// Most password verifiers accept any non-empty string, so this may
 	// either succeed or fail. The point is to drive the buildGateway
@@ -331,36 +331,34 @@ func TestBuildWithInvalidWebPasswordFailsClean(t *testing.T) {
 	_ = err
 }
 
-func TestBuildWithBadWebRateLimitConfig(t *testing.T) {
-	s := &config.Settings{CommandPrefix: "!"}
-	ircCfg := &irc.Settings{
-		Hostname:                "fake",
-		Nick:                    "turborg",
-		WebPassword:             "ok",
-		WebHost:                 "127.0.0.1",
-		WebPort:                 0,
-		WebMaxFailedAttempts:    0, // invalid for the rate limiter
-		WebFailureWindowSeconds: 0,
-		WebLockoutSeconds:       0,
+func TestBuildWithBadGatewayRateLimitConfig(t *testing.T) {
+	s := &config.Settings{
+		CommandPrefix:               "!",
+		GatewayPassword:             "ok",
+		GatewayHost:                 "127.0.0.1",
+		GatewayPort:                 0,
+		GatewayMaxFailedAttempts:    0, // invalid for the rate limiter
+		GatewayFailureWindowSeconds: 0,
+		GatewayLockoutSeconds:       0,
 	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	_, err := runtime.Build(s, ircCfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ratelimit")
 }
 
-func TestBuildWebWithIdleShutdownConfigured(t *testing.T) {
-	s := &config.Settings{CommandPrefix: "!"}
-	ircCfg := &irc.Settings{
-		Hostname:                "fake",
-		Nick:                    "turborg",
-		WebPassword:             "p",
-		WebHost:                 "127.0.0.1",
-		WebPort:                 0,
-		WebMaxFailedAttempts:    5,
-		WebFailureWindowSeconds: 60,
-		WebLockoutSeconds:       300,
-		WebIdleShutdownSeconds:  30,
+func TestBuildGatewayWithIdleShutdownConfigured(t *testing.T) {
+	s := &config.Settings{
+		CommandPrefix:               "!",
+		GatewayPassword:             "p",
+		GatewayHost:                 "127.0.0.1",
+		GatewayPort:                 0,
+		GatewayMaxFailedAttempts:    5,
+		GatewayFailureWindowSeconds: 60,
+		GatewayLockoutSeconds:       300,
+		GatewayIdleShutdownSeconds:  30,
 	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
 	require.NotNil(t, b.Gateway)
@@ -385,18 +383,20 @@ func TestBuildLLMReturnsErrorOnEmptyKey(t *testing.T) {
 // --- Run with gateway clean shutdown ---------------------------------
 
 func TestRunWithGatewayUnwindsOnCtxCancel(t *testing.T) {
-	s := &config.Settings{CommandPrefix: "!"}
+	s := &config.Settings{
+		CommandPrefix:               "!",
+		GatewayPassword:             "p",
+		GatewayHost:                 "127.0.0.1",
+		GatewayPort:                 0,
+		GatewayMaxFailedAttempts:    5,
+		GatewayFailureWindowSeconds: 60,
+		GatewayLockoutSeconds:       300,
+	}
 	ircCfg := &irc.Settings{
-		Hostname:                "fake",
-		Nick:                    "turborg",
-		HandshakeTimeout:        100 * time.Millisecond,
-		ClientPingInterval:      50 * time.Millisecond,
-		WebPassword:             "p",
-		WebHost:                 "127.0.0.1",
-		WebPort:                 0,
-		WebMaxFailedAttempts:    5,
-		WebFailureWindowSeconds: 60,
-		WebLockoutSeconds:       300,
+		Hostname:           "fake",
+		Nick:               "turborg",
+		HandshakeTimeout:   100 * time.Millisecond,
+		ClientPingInterval: 50 * time.Millisecond,
 	}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -45,8 +45,10 @@ func TestBuildWithAnthropic(t *testing.T) {
 }
 
 func TestBuildWithWebGateway(t *testing.T) {
-	s := &config.Settings{
-		CommandPrefix:           "!",
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{
+		Hostname:                "fake",
+		Nick:                    "turborg",
 		WebPassword:             "hunter2",
 		WebHost:                 "127.0.0.1",
 		WebPort:                 0,
@@ -54,7 +56,6 @@ func TestBuildWithWebGateway(t *testing.T) {
 		WebFailureWindowSeconds: 60,
 		WebLockoutSeconds:       300,
 	}
-	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
 	require.NotNil(t, b.Gateway)
@@ -227,21 +228,19 @@ func TestRunWithGatewayUnwindsOnAgentStartFailure(t *testing.T) {
 	// is closed so Agent.Run fails fast. Run() must cancel the shared
 	// ctx so gateway.Serve also returns, and Wait must surface the
 	// agent error.
-	s := &config.Settings{
-		CommandPrefix:           "!",
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{
+		Hostname:                "127.0.0.1",
+		Port:                    1, // port 1 is the discard port — nothing listens
+		UseTLS:                  false,
+		Nick:                    "turborg",
+		HandshakeTimeout:        200 * time.Millisecond,
 		WebPassword:             "p",
 		WebHost:                 "127.0.0.1",
 		WebPort:                 0,
 		WebMaxFailedAttempts:    5,
 		WebFailureWindowSeconds: 60,
 		WebLockoutSeconds:       300,
-	}
-	ircCfg := &irc.Settings{
-		Hostname:         "127.0.0.1",
-		Port:             1, // port 1 is the discard port — nothing listens
-		UseTLS:           false,
-		Nick:             "turborg",
-		HandshakeTimeout: 200 * time.Millisecond,
 	}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
@@ -314,8 +313,10 @@ func TestBuildWithInvalidWebPasswordFailsClean(t *testing.T) {
 	// reaches buildGateway only when WebEnabled returns true. To
 	// exercise the error wrap, give web.NewStaticPasswordVerifier a
 	// blank password.
-	s := &config.Settings{
-		CommandPrefix:           "!",
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{
+		Hostname:                "fake",
+		Nick:                    "turborg",
 		WebPassword:             " ", // single space — treated as set by WebEnabled but verifier rejects
 		WebHost:                 "127.0.0.1",
 		WebPort:                 0,
@@ -323,7 +324,6 @@ func TestBuildWithInvalidWebPasswordFailsClean(t *testing.T) {
 		WebFailureWindowSeconds: 60,
 		WebLockoutSeconds:       300,
 	}
-	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	_, err := runtime.Build(s, ircCfg, nil)
 	// Most password verifiers accept any non-empty string, so this may
 	// either succeed or fail. The point is to drive the buildGateway
@@ -332,8 +332,10 @@ func TestBuildWithInvalidWebPasswordFailsClean(t *testing.T) {
 }
 
 func TestBuildWithBadWebRateLimitConfig(t *testing.T) {
-	s := &config.Settings{
-		CommandPrefix:           "!",
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{
+		Hostname:                "fake",
+		Nick:                    "turborg",
 		WebPassword:             "ok",
 		WebHost:                 "127.0.0.1",
 		WebPort:                 0,
@@ -341,15 +343,16 @@ func TestBuildWithBadWebRateLimitConfig(t *testing.T) {
 		WebFailureWindowSeconds: 0,
 		WebLockoutSeconds:       0,
 	}
-	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	_, err := runtime.Build(s, ircCfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ratelimit")
 }
 
 func TestBuildWebWithIdleShutdownConfigured(t *testing.T) {
-	s := &config.Settings{
-		CommandPrefix:           "!",
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{
+		Hostname:                "fake",
+		Nick:                    "turborg",
 		WebPassword:             "p",
 		WebHost:                 "127.0.0.1",
 		WebPort:                 0,
@@ -358,7 +361,6 @@ func TestBuildWebWithIdleShutdownConfigured(t *testing.T) {
 		WebLockoutSeconds:       300,
 		WebIdleShutdownSeconds:  30,
 	}
-	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
 	require.NotNil(t, b.Gateway)
@@ -383,20 +385,18 @@ func TestBuildLLMReturnsErrorOnEmptyKey(t *testing.T) {
 // --- Run with gateway clean shutdown ---------------------------------
 
 func TestRunWithGatewayUnwindsOnCtxCancel(t *testing.T) {
-	s := &config.Settings{
-		CommandPrefix:           "!",
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{
+		Hostname:                "fake",
+		Nick:                    "turborg",
+		HandshakeTimeout:        100 * time.Millisecond,
+		ClientPingInterval:      50 * time.Millisecond,
 		WebPassword:             "p",
 		WebHost:                 "127.0.0.1",
 		WebPort:                 0,
 		WebMaxFailedAttempts:    5,
 		WebFailureWindowSeconds: 60,
 		WebLockoutSeconds:       300,
-	}
-	ircCfg := &irc.Settings{
-		Hostname:           "fake",
-		Nick:               "turborg",
-		HandshakeTimeout:   100 * time.Millisecond,
-		ClientPingInterval: 50 * time.Millisecond,
 	}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -2,7 +2,7 @@
 // bridges IRC events to browser clients, plus the bundled vanilla-JS
 // reference UI served from the same HTTP server. SaaS deployments replace
 // the TokenVerifier with their own auth backend; self-host uses a single
-// shared password from TURBORG_WEB_PASSWORD.
+// shared password from TURBORG_IRC_WEB_PASSWORD.
 package web
 
 import (

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,8 +1,9 @@
-// Package web is turborg's WebSocket gateway: a JSON-over-WS protocol that
-// bridges IRC events to browser clients, plus the bundled vanilla-JS
-// reference UI served from the same HTTP server. SaaS deployments replace
-// the TokenVerifier with their own auth backend; self-host uses a single
-// shared password from TURBORG_IRC_WEB_PASSWORD.
+// Package web is turborg's control-plane gateway: a JSON-over-WS protocol
+// that streams the agent's events to browser clients and accepts command
+// ops, plus the bundled vanilla-JS reference UI served from the same HTTP
+// server. SaaS deployments replace the TokenVerifier with their own auth
+// backend; self-host uses a single shared password from
+// TURBORG_GATEWAY_PASSWORD.
 package web
 
 import (

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -18,9 +18,9 @@ import (
 	"github.com/turborg/turborg/internal/connector/irc"
 )
 
-// Ring-buffer caps mirror the Python implementation. Bumping these
-// requires coordinating with docs/ui/PLAN.md — the Angular client team
-// sizes its IndexedDB backfill against the same numbers.
+// Ring-buffer caps for replay on new client attach. Bumping these is a
+// coordinated change with downstream UIs that size their local backfill
+// against the same numbers — see docs/ui/PLAN.md.
 const (
 	serverLogCap  = 100
 	channelLogCap = 200

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -120,7 +120,7 @@ func New(bridge IRCBridge, sender Sender, opts Options) (*Gateway, error) {
 	// Port 0 deliberately stays 0 so net.Listen picks an OS-assigned
 	// port — required for parallel tests, harmless in production where
 	// the runtime composer always passes an explicit port from
-	// TURBORG_IRC_WEB_PORT (default 8765 in irc.Settings).
+	// TURBORG_GATEWAY_PORT (default 8765 in config.Settings).
 	g := &Gateway{
 		opts:       opts,
 		bridge:     bridge,

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -120,7 +120,7 @@ func New(bridge IRCBridge, sender Sender, opts Options) (*Gateway, error) {
 	// Port 0 deliberately stays 0 so net.Listen picks an OS-assigned
 	// port — required for parallel tests, harmless in production where
 	// the runtime composer always passes an explicit port from
-	// TURBORG_WEB_PORT (default 8765 in config.Settings).
+	// TURBORG_IRC_WEB_PORT (default 8765 in irc.Settings).
 	g := &Gateway{
 		opts:       opts,
 		bridge:     bridge,


### PR DESCRIPTION
## Summary

- Move the control-plane gateway settings (password, host, port, rate-limit, idle-shutdown) from `config.Settings` (`TURBORG_WEB_*`) onto `config.Settings` under the new name `TURBORG_GATEWAY_*`. The gateway is a top-level surface — neither an IRC sub-feature nor a chat connector — so it sits between Core and IRC in the env-var taxonomy.
- **Name by role, not protocol.** `WEB` named the transport (HTTP/WS) and would re-break the moment we added a second transport or refactored the gateway to be connector-agnostic. `GATEWAY` names the role (control plane) and survives both. Matches the existing Go type (`web.Gateway`).
- Regroup `.env.example` into three top-level sections: `TURBORG_*` (cross-cutting), `TURBORG_GATEWAY_*` (control plane), `TURBORG_<CONNECTOR>_*` (per-connector, with sub-features like `_BOUNCER_*`, `_SASL_*`, `_CTCP_*`).
- Extract gateway docs from `docs/connectors/irc.md` into new `docs/gateway.md`; the IRC doc keeps a brief cross-reference.

## BREAKING CHANGE

Anything setting `TURBORG_WEB_PASSWORD`, `TURBORG_WEB_HOST`, `TURBORG_WEB_PORT`, `TURBORG_WEB_MAX_FAILED_ATTEMPTS`, `TURBORG_WEB_FAILURE_WINDOW_SECONDS`, `TURBORG_WEB_LOCKOUT_SECONDS`, or `TURBORG_WEB_IDLE_SHUTDOWN_SECONDS` must rename to the `TURBORG_GATEWAY_*` form. Without `TURBORG_GATEWAY_PASSWORD`, `config.Settings.GatewayEnabled()` returns false and the gateway silently does not start.

Downstream xshellz sidecar update needs to land + roll **after** this release ships to the registry — otherwise spawned containers will read empty `GatewayPassword` and the gateway won't come up.

## Why this PR's commit history shows two renames

The branch arrived at `TURBORG_GATEWAY_*` via a brief intermediate state (`TURBORG_IRC_WEB_*`) before recognizing the gateway is not an IRC sub-feature. The squash-merge collapses the journey into one commit on `main` with the correct final state.

## Test plan

- [x] \`make lint\` clean (0 issues)
- [x] \`make test\` green under \`-race -count=1\`
- [x] \`make cover-gate\` PASS (total 95.0%)
- [ ] CI matrix (Go 1.25 + 1.26) green on PR