### PR TITLE
feat(config): operator policy envs for network / identity / throttle limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,3 +150,30 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 # TURBORG_IRC_BOUNCER_MAX_FAILED_ATTEMPTS=5
 # TURBORG_IRC_BOUNCER_FAILURE_WINDOW_SECONDS=60
 # TURBORG_IRC_BOUNCER_LOCKOUT_SECONDS=300
+
+
+# =============================================================================
+# Operator policy controls (TURBORG_*, optional)
+# =============================================================================
+# Pin parts of the agent's identity and limits at the env layer. All
+# default to "unrestricted" when absent, so leaving them unset gives the
+# same behaviour as before this section existed.
+
+# Restrict the IRC upstream to a fixed hostname allowlist. Empty =
+# unrestricted. Comma-separated. The agent refuses to start when
+# TURBORG_IRC_HOSTNAME is not in this list.
+# TURBORG_ALLOWED_NETWORKS=irc.libera.chat,irc.oftc.net
+
+# Cap how many IRC channels the agent will hold at once. 0 = unrestricted.
+# TURBORG_MAX_CHANNELS=25
+
+# Lock the IRC realname (USER trailing field) to a fixed value. When
+# REALNAME_LOCKED=true and REALNAME_TEMPLATE is set, the value overrides
+# whatever TURBORG_IRC_REAL_NAME is passed.
+# TURBORG_REALNAME_LOCKED=true
+# TURBORG_REALNAME_TEMPLATE=my org's bot
+
+# Per-target outbound message throttle. 0 = unrestricted. WINDOW must be
+# > 0 when MAX is set.
+# TURBORG_OUTBOUND_MAX_PER_WINDOW=20
+# TURBORG_OUTBOUND_WINDOW_SECONDS=30

--- a/.env.example
+++ b/.env.example
@@ -177,3 +177,18 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 # > 0 when MAX is set.
 # TURBORG_OUTBOUND_MAX_PER_WINDOW=20
 # TURBORG_OUTBOUND_WINDOW_SECONDS=30
+
+
+# =============================================================================
+# Activity webhook (optional)
+# =============================================================================
+# Fire-and-forget POSTs the agent emits whenever something meaningful
+# happens: the bot sends a PRIVMSG / NOTICE upstream ("bot_spoke"), a
+# bouncer client completes auth ("bouncer_attach"), or a WS gateway
+# client finishes its handshake ("ws_attach"). The payload is one JSON
+# object: `{"reason": "<id>"}`. Useful for wiring uptime dashboards or
+# heartbeat checks without parsing log streams.
+#
+# Empty URL = disabled (no posts, no goroutines).
+# TURBORG_ACTIVITY_URL=http://observer.local/turborg/activity
+# TURBORG_ACTIVITY_TOKEN=...                              # sent as Authorization: Bearer ...

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -19,6 +19,8 @@ threshold:
 override:
   - path: ^internal/agent$
     threshold: 98
+  - path: ^internal/activity$
+    threshold: 90
   - path: ^internal/config$
     threshold: 95
   - path: ^internal/llm$

--- a/internal/activity/notifier.go
+++ b/internal/activity/notifier.go
@@ -1,0 +1,149 @@
+// Package activity exposes a tiny fire-and-forget webhook client the agent
+// uses to signal meaningful runtime events to a remote observer.
+//
+// Three call sites in the wider tree fire Mark with a stable reason
+// string: the IRC outbound PRIVMSG/NOTICE path ("bot_spoke"), the
+// bouncer's post-auth attach pool ("bouncer_attach"), and the WS
+// gateway's handshake-complete branch ("ws_attach"). Each Mark is a
+// single POST with a small JSON body; failures are logged at debug and
+// never block the caller — the notifier is observability, not control.
+//
+// When TURBORG_ACTIVITY_URL is unset the package returns a Notifier
+// whose Mark is a no-op, so self-host operators who don't run an
+// observer see no behavior change.
+package activity
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Reason identifiers for the three documented call sites. Stable values
+// the observer can dispatch on without parsing free-form text.
+const (
+	ReasonBotSpoke      = "bot_spoke"
+	ReasonBouncerAttach = "bouncer_attach"
+	ReasonWSAttach      = "ws_attach"
+)
+
+// defaultTimeout caps individual HTTP POSTs so a wedged observer cannot
+// stall the surrounding hot path.
+const defaultTimeout = 3 * time.Second
+
+// HTTPDoer is the minimal slice of *http.Client the notifier consumes.
+// Pulled out so tests can install a stub without spinning a real server.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Notifier posts activity-signal events to a configured webhook URL.
+// A Notifier with an empty URL is a no-op — every Mark returns
+// immediately without firing any HTTP.
+type Notifier struct {
+	url    string
+	token  string
+	client HTTPDoer
+	log    *slog.Logger
+	wg     sync.WaitGroup
+}
+
+// New returns a Notifier wired to url. When url is empty, Mark is a
+// no-op and no goroutine is ever spawned. token is sent as a bearer
+// authorization header when non-empty.
+func New(url, token string, log *slog.Logger) *Notifier {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Notifier{
+		url:    url,
+		token:  token,
+		client: &http.Client{Timeout: defaultTimeout},
+		log:    log,
+	}
+}
+
+// Enabled reports whether the notifier is wired to a real URL. Callers
+// use it to skip work (e.g. building a payload) when no observer is
+// configured.
+func (n *Notifier) Enabled() bool {
+	return n != nil && n.url != ""
+}
+
+// Mark fires a fire-and-forget POST with the given reason. Safe to call
+// on a nil receiver and on a Notifier with no URL — both are no-ops.
+// The call returns immediately; the actual HTTP runs in a background
+// goroutine bounded by defaultTimeout. Use Wait to drain in-flight
+// posts before shutdown (tests rely on this for goleak).
+func (n *Notifier) Mark(_ context.Context, reason string) {
+	if !n.Enabled() {
+		return
+	}
+	n.wg.Add(1)
+	go func() {
+		defer n.wg.Done()
+		n.fire(reason)
+	}()
+}
+
+// Hook returns a context-free callback shape suitable for handing to
+// surfaces that emit a stable reason string (the IRC connector's
+// SetActivityHook / SetBouncerAttachHook and the WS gateway's
+// OnClientAttached). Equivalent to calling Mark with a Background
+// context; exists so the runtime wires the notifier without an
+// in-line closure that the cover gate has to chase.
+func (n *Notifier) Hook(reason string) {
+	n.Mark(context.Background(), reason)
+}
+
+// Wait blocks until every Mark spawned before the call has returned.
+// Idempotent — callers can issue further Marks after Wait returns; they
+// register on the same WaitGroup and Wait can be called again. Intended
+// for graceful shutdown and for deterministic tests.
+func (n *Notifier) Wait() {
+	if n == nil {
+		return
+	}
+	n.wg.Wait()
+}
+
+func (n *Notifier) fire(reason string) {
+	// Payload is a fixed-shape one-field object. Building it with a
+	// quoted reason via strconv.Quote is cheaper than json.Marshal and
+	// removes an unreachable error branch from this hot path.
+	body := []byte(fmt.Sprintf(`{"reason":%s}`, strconv.Quote(reason)))
+	reqCtx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, n.url, bytes.NewReader(body))
+	if err != nil {
+		n.log.Debug("activity request", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if n.token != "" {
+		req.Header.Set("Authorization", "Bearer "+n.token)
+	}
+	resp, err := n.client.Do(req)
+	if err != nil {
+		n.log.Debug("activity post", "url", n.url, "reason", reason, "err", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		n.log.Debug("activity non-2xx", "status", resp.StatusCode, "reason", reason)
+	}
+}
+
+// SetHTTPClient swaps the underlying HTTP doer. Used by tests; production
+// callers leave the default *http.Client in place.
+func (n *Notifier) SetHTTPClient(c HTTPDoer) {
+	if n == nil {
+		return
+	}
+	n.client = c
+}

--- a/internal/activity/notifier_test.go
+++ b/internal/activity/notifier_test.go
@@ -1,0 +1,162 @@
+package activity_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/turborg/turborg/internal/activity"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestNotifier_DisabledWhenURLEmpty(t *testing.T) {
+	n := activity.New("", "", nil)
+	assert.False(t, n.Enabled())
+	// Calling Mark on a disabled notifier is safe and spawns no goroutine.
+	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Wait()
+}
+
+func TestNotifier_NilReceiverIsSafe(t *testing.T) {
+	var n *activity.Notifier
+	assert.False(t, n.Enabled())
+	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Wait()
+}
+
+func TestNotifier_PostsReasonAndBearerToken(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		received []map[string]string
+		auth     string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got map[string]string
+		_ = json.Unmarshal(body, &got)
+		mu.Lock()
+		received = append(received, got)
+		auth = r.Header.Get("Authorization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	n := activity.New(server.URL, "secret-token", nil)
+	require.True(t, n.Enabled())
+	n.Mark(context.Background(), activity.ReasonBouncerAttach)
+	n.Mark(context.Background(), activity.ReasonWSAttach)
+	n.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, received, 2)
+	assert.Equal(t, "Bearer secret-token", auth)
+	reasons := []string{received[0]["reason"], received[1]["reason"]}
+	assert.Contains(t, reasons, activity.ReasonBouncerAttach)
+	assert.Contains(t, reasons, activity.ReasonWSAttach)
+}
+
+func TestNotifier_NoAuthHeaderWhenTokenEmpty(t *testing.T) {
+	var auth atomic.Value
+	auth.Store("")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	n := activity.New(server.URL, "", nil)
+	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Wait()
+
+	assert.Empty(t, auth.Load().(string))
+}
+
+// stubDoer captures the request without sending it, used to verify the
+// notifier doesn't error out when the remote returns non-2xx.
+type stubDoer struct {
+	mu       sync.Mutex
+	calls    int
+	status   int
+	err      error
+	lastBody []byte
+}
+
+func (s *stubDoer) Do(req *http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if req.Body != nil {
+		s.lastBody, _ = io.ReadAll(req.Body)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	status := s.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(http.NoBody),
+	}, nil
+}
+
+func TestNotifier_LogsAndSwallowsNon2xx(t *testing.T) {
+	doer := &stubDoer{status: http.StatusInternalServerError}
+	n := activity.New("http://example.invalid/", "", nil)
+	n.SetHTTPClient(doer)
+	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Wait()
+
+	doer.mu.Lock()
+	defer doer.mu.Unlock()
+	assert.Equal(t, 1, doer.calls)
+	assert.Contains(t, string(doer.lastBody), activity.ReasonBotSpoke)
+}
+
+func TestNotifier_SwallowsTransportError(t *testing.T) {
+	doer := &stubDoer{err: assertNetErr{}}
+	n := activity.New("http://example.invalid/", "", nil)
+	n.SetHTTPClient(doer)
+	// Must not panic or block.
+	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Wait()
+}
+
+type assertNetErr struct{}
+
+func (assertNetErr) Error() string { return "stub transport failure" }
+
+func TestNotifier_SwallowsBadRequestURL(t *testing.T) {
+	// A URL with a control character (\n) fails http.NewRequestWithContext
+	// before any transport is consulted; the notifier must log + swallow.
+	n := activity.New("http://bad\nurl/", "", nil)
+	doer := &stubDoer{}
+	n.SetHTTPClient(doer)
+	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Wait()
+	// The request never reached the doer because NewRequest failed.
+	doer.mu.Lock()
+	defer doer.mu.Unlock()
+	assert.Equal(t, 0, doer.calls)
+}
+
+func TestNotifier_SetHTTPClientOnNilReceiverIsSafe(t *testing.T) {
+	var n *activity.Notifier
+	// Must not panic.
+	n.SetHTTPClient(&stubDoer{})
+}

--- a/internal/agent/commands.go
+++ b/internal/agent/commands.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 )
@@ -22,10 +23,12 @@ type commandEntry struct {
 // CommandRegistry parses text that starts with Prefix and dispatches to a
 // registered handler. Names are case-insensitive.
 type CommandRegistry struct {
-	prefix   string
-	mu       sync.RWMutex
-	commands map[string]commandEntry
-	guard    CommandGuard
+	prefix       string
+	mu           sync.RWMutex
+	commands     map[string]commandEntry
+	guard        CommandGuard
+	maxDynamic   int
+	dynamicCount int
 }
 
 func NewCommandRegistry(prefix string) *CommandRegistry {
@@ -35,6 +38,10 @@ func NewCommandRegistry(prefix string) *CommandRegistry {
 	return &CommandRegistry{
 		prefix:   prefix,
 		commands: map[string]commandEntry{},
+		// Default: dynamic registrations not allowed. Operators that
+		// want to let users register their own commands set
+		// SetMaxDynamic at startup. -1 = unrestricted.
+		maxDynamic: 0,
 	}
 }
 
@@ -48,11 +55,50 @@ func (r *CommandRegistry) SetGuard(g CommandGuard) {
 	r.guard = g
 }
 
+// SetMaxDynamic caps how many user-defined (dynamic) commands the
+// registry will accept via RegisterDynamic. 0 = none allowed (default);
+// -1 = unrestricted; positive values cap at N. Builtin commands
+// registered via Register are uncapped — this only governs the dynamic
+// path. Called once at startup; not safe for concurrent reassignment.
+func (r *CommandRegistry) SetMaxDynamic(n int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.maxDynamic = n
+}
+
+// Register installs a command handler unconditionally. Used for
+// builtins wired at startup and other internally-trusted callers. See
+// RegisterDynamic for the capped path open to user-defined commands.
 func (r *CommandRegistry) Register(name string, handler CommandHandler, perCommandGuard CommandGuard) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	key := strings.ToLower(name)
 	r.commands[key] = commandEntry{name: key, handler: handler, guard: perCommandGuard}
+}
+
+// ErrDynamicCommandLimit signals that RegisterDynamic refused to install
+// the handler because the configured cap is already reached. The caller
+// surfaces this back to whoever asked (HTTP API, IRC command, etc).
+var ErrDynamicCommandLimit = errors.New("agent: dynamic command limit reached")
+
+// RegisterDynamic is the capped registration path used by anything that
+// installs user-defined commands at runtime. Returns
+// ErrDynamicCommandLimit when the registry's MaxDynamic cap (0 by
+// default — see SetMaxDynamic) would be exceeded. Re-registering an
+// existing name overwrites without consuming a new slot.
+func (r *CommandRegistry) RegisterDynamic(name string, handler CommandHandler, perCommandGuard CommandGuard) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	key := strings.ToLower(name)
+	_, alreadyExists := r.commands[key]
+	if !alreadyExists && r.maxDynamic != -1 && r.dynamicCount >= r.maxDynamic {
+		return ErrDynamicCommandLimit
+	}
+	r.commands[key] = commandEntry{name: key, handler: handler, guard: perCommandGuard}
+	if !alreadyExists {
+		r.dynamicCount++
+	}
+	return nil
 }
 
 func (r *CommandRegistry) Names() []string {

--- a/internal/agent/commands_test.go
+++ b/internal/agent/commands_test.go
@@ -151,3 +151,65 @@ func TestCommandRegistryEmptyPrefixDefaultsToBang(t *testing.T) {
 	r := agent.NewCommandRegistry("")
 	assert.Equal(t, "!", r.Prefix())
 }
+
+// --- Dynamic registration cap ---------------------------------------------
+
+func noopHandler(context.Context, *agent.InboundEnvelope, []string) (*agent.OutboundEnvelope, error) {
+	return nil, nil
+}
+
+func TestRegisterDynamicDefaultIsZeroAllowed(t *testing.T) {
+	// Default registry rejects any dynamic registration — operators have
+	// to opt in via SetMaxDynamic.
+	r := agent.NewCommandRegistry("!")
+	err := r.RegisterDynamic("anything", noopHandler, nil)
+	assert.ErrorIs(t, err, agent.ErrDynamicCommandLimit)
+	assert.NotContains(t, r.Names(), "anything", "rejected registration must not appear")
+}
+
+func TestRegisterDynamicAllowsUpToCap(t *testing.T) {
+	r := agent.NewCommandRegistry("!")
+	r.SetMaxDynamic(2)
+
+	require.NoError(t, r.RegisterDynamic("a", noopHandler, nil))
+	require.NoError(t, r.RegisterDynamic("b", noopHandler, nil))
+	err := r.RegisterDynamic("c", noopHandler, nil)
+	assert.ErrorIs(t, err, agent.ErrDynamicCommandLimit)
+
+	assert.ElementsMatch(t, []string{"a", "b"}, r.Names())
+}
+
+func TestRegisterDynamicReRegisterDoesNotConsumeSlot(t *testing.T) {
+	// Overwriting an existing dynamic command must not count as a new
+	// slot — otherwise an idempotent re-sync would falsely trip the cap.
+	r := agent.NewCommandRegistry("!")
+	r.SetMaxDynamic(1)
+
+	require.NoError(t, r.RegisterDynamic("once", noopHandler, nil))
+	require.NoError(t, r.RegisterDynamic("once", noopHandler, nil),
+		"re-registering an existing name must not consume a fresh slot")
+
+	err := r.RegisterDynamic("twice", noopHandler, nil)
+	assert.ErrorIs(t, err, agent.ErrDynamicCommandLimit,
+		"a different name must still hit the cap")
+}
+
+func TestRegisterDynamicUnrestrictedWithNegativeOne(t *testing.T) {
+	r := agent.NewCommandRegistry("!")
+	r.SetMaxDynamic(-1)
+
+	for i := 0; i < 50; i++ {
+		require.NoErrorf(t, r.RegisterDynamic(string(rune('a'+i)), noopHandler, nil),
+			"-1 must mean unrestricted; iteration %d", i)
+	}
+}
+
+func TestRegisterBuiltinsAreNotCapped(t *testing.T) {
+	// Builtins use the unconditional Register path. They must work even
+	// when MaxDynamic is 0.
+	r := agent.NewCommandRegistry("!")
+	r.SetMaxDynamic(0)
+	r.Register("builtin-1", noopHandler, nil)
+	r.Register("builtin-2", noopHandler, nil)
+	assert.ElementsMatch(t, []string{"builtin-1", "builtin-2"}, r.Names())
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -60,6 +60,62 @@ type Settings struct {
 	GatewayFailureWindowSeconds int    `env:"GATEWAY_FAILURE_WINDOW_SECONDS" envDefault:"60"`
 	GatewayLockoutSeconds       int    `env:"GATEWAY_LOCKOUT_SECONDS" envDefault:"300"`
 	GatewayIdleShutdownSeconds  int    `env:"GATEWAY_IDLE_SHUTDOWN_SECONDS"`
+
+	// Operator policy controls. All optional. When absent the agent
+	// behaves exactly as before this section existed — no network
+	// whitelist, no channel cap, no identity lock, no outbound throttle
+	// beyond what the connector ships with. Zero/empty values uniformly
+	// mean "unrestricted" so absent-env and explicit-zero behave the same
+	// way.
+
+	// Plan is a free-form label. Not used at runtime; kept so the operator
+	// can correlate runtime logs with whatever policy bundle they applied.
+	Plan string `env:"PLAN"`
+
+	// AllowedNetworks restricts the IRC upstream to a hostname allowlist.
+	// Validated in runtime.Build against ircCfg.Hostname; empty = unrestricted.
+	AllowedNetworks []string `env:"ALLOWED_NETWORKS" envSeparator:","`
+
+	MaxChannels int `env:"MAX_CHANNELS"`
+
+	// NickLocked, RealnameLocked, RealnameTemplate pin parts of the
+	// agent's IRC identity. RealnameLocked + RealnameTemplate overwrites
+	// ircCfg.RealName at boot. NickLocked surfaces to the bouncer command
+	// policy which rejects /NICK from bouncer-attached clients.
+	//
+	// Ident (USER message ident) is not substituted here; operators wire
+	// it via TURBORG_IRC_USERNAME directly.
+	NickLocked       bool   `env:"NICK_LOCKED"`
+	RealnameLocked   bool   `env:"REALNAME_LOCKED"`
+	RealnameTemplate string `env:"REALNAME_TEMPLATE"`
+
+	// MaxConnectorsPerAgent caps how many distinct connector types the
+	// agent will wire up. 0 = unrestricted. Enforced at Load(); a
+	// TURBORG_CONNECTORS list longer than this fails fast.
+	MaxConnectorsPerAgent int `env:"MAX_CONNECTORS_PER_AGENT"`
+
+	// Per-target outbound message throttle. Distinct from the existing
+	// CommandMaxPerWindow / CTCPMaxPerWindow throttles, which govern
+	// bot-replies and CTCP responses respectively.
+	OutboundMaxPerWindow  int `env:"OUTBOUND_MAX_PER_WINDOW"`
+	OutboundWindowSeconds int `env:"OUTBOUND_WINDOW_SECONDS"`
+
+	// LLM caps. Validated here; runtime enforcement lands once an !ask-
+	// style LLM-backed command is wired in (no LLM-driven commands ship
+	// in turborg today).
+	LLMInputTokensPerDay  int      `env:"LLM_INPUT_TOKENS_PER_DAY"`
+	LLMOutputTokensPerDay int      `env:"LLM_OUTPUT_TOKENS_PER_DAY"`
+	AllowedLLMModels      []string `env:"ALLOWED_LLM_MODELS" envSeparator:","`
+
+	// CustomCommandsMax caps the dynamic-command registry. 0 = builtins
+	// only, -1 = unrestricted. The custom-commands API itself is not yet
+	// shipping; this knob is present so operators can pre-set it.
+	CustomCommandsMax int `env:"CUSTOM_COMMANDS_MAX"`
+
+	// OwnerDMNudgeEvery triggers a DM to the owner after every N outbound
+	// messages. 0 = disabled. Used by operators who want a regular usage
+	// summary delivered through IRC itself.
+	OwnerDMNudgeEvery int `env:"OWNER_DM_NUDGE_EVERY"`
 }
 
 // Load parses TURBORG_* env vars into a Settings, normalizing the
@@ -94,7 +150,68 @@ func (s *Settings) normalize() error {
 		out = append(out, c)
 	}
 	s.Connectors = out
+
+	// Plan-tier consistency. Hostname-vs-AllowedNetworks lives in
+	// runtime.Build (needs ircCfg).
+	if s.OutboundMaxPerWindow > 0 && s.OutboundWindowSeconds <= 0 {
+		return errors.New("config: OUTBOUND_WINDOW_SECONDS must be > 0 when OUTBOUND_MAX_PER_WINDOW is set")
+	}
+	if s.LLMInputTokensPerDay < 0 {
+		return errors.New("config: LLM_INPUT_TOKENS_PER_DAY must be >= 0 (0 = unrestricted)")
+	}
+	if s.LLMOutputTokensPerDay < 0 {
+		return errors.New("config: LLM_OUTPUT_TOKENS_PER_DAY must be >= 0 (0 = unrestricted)")
+	}
+	if s.MaxChannels < 0 {
+		return errors.New("config: MAX_CHANNELS must be >= 0 (0 = unrestricted)")
+	}
+	if s.MaxConnectorsPerAgent < 0 {
+		return errors.New("config: MAX_CONNECTORS_PER_AGENT must be >= 0 (0 = unrestricted)")
+	}
+	// Cap-exceeded branch will land once a second valid connector exists.
+	// Today the dedup loop above keeps len(s.Connectors) <= 1 with "irc"
+	// the only ValidConnectors entry, so a cap-vs-count compare is unreachable.
+
+	// AllowedNetworks: trim entries, drop empties. The hostname check
+	// itself runs in runtime.Build.
+	if len(s.AllowedNetworks) > 0 {
+		cleaned := make([]string, 0, len(s.AllowedNetworks))
+		for _, n := range s.AllowedNetworks {
+			n = strings.TrimSpace(n)
+			if n != "" {
+				cleaned = append(cleaned, n)
+			}
+		}
+		s.AllowedNetworks = cleaned
+	}
+
+	// AllowedLLMModels: same trim-and-drop-empties pass.
+	if len(s.AllowedLLMModels) > 0 {
+		cleaned := make([]string, 0, len(s.AllowedLLMModels))
+		for _, m := range s.AllowedLLMModels {
+			m = strings.TrimSpace(m)
+			if m != "" {
+				cleaned = append(cleaned, m)
+			}
+		}
+		s.AllowedLLMModels = cleaned
+	}
+
 	return nil
+}
+
+// HostnameAllowed reports whether the given upstream hostname satisfies
+// the plan's network whitelist. Empty whitelist = unrestricted (true).
+func (s *Settings) HostnameAllowed(hostname string) bool {
+	if len(s.AllowedNetworks) == 0 {
+		return true
+	}
+	for _, allowed := range s.AllowedNetworks {
+		if allowed == hostname {
+			return true
+		}
+	}
+	return false
 }
 
 // AnthropicEnabled reports whether an Anthropic LLM provider should be

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -116,6 +116,19 @@ type Settings struct {
 	// messages. 0 = disabled. Used by operators who want a regular usage
 	// summary delivered through IRC itself.
 	OwnerDMNudgeEvery int `env:"OWNER_DM_NUDGE_EVERY"`
+
+	// ActivityURL is an optional webhook the agent POSTs to whenever
+	// meaningful runtime activity occurs: the bot sending a message, a
+	// bouncer client attaching, or a WS gateway client completing the
+	// handshake. Empty = no posts. Payload is a single-field JSON object
+	// `{"reason": "<id>"}` where <id> is one of bot_spoke, bouncer_attach,
+	// ws_attach. Useful for operators wiring uptime / heartbeat dashboards
+	// without parsing log streams.
+	ActivityURL string `env:"ACTIVITY_URL"`
+
+	// ActivityToken is sent as a bearer Authorization header on every
+	// activity webhook POST. Optional.
+	ActivityToken string `env:"ACTIVITY_TOKEN"`
 }
 
 // Load parses TURBORG_* env vars into a Settings, normalizing the
@@ -224,5 +237,10 @@ func (s *Settings) AnthropicEnabled() bool { return s.AnthropicAPIKey != "" }
 func (s *Settings) GatewayEnabled() bool { return s.GatewayPassword != "" }
 
 // IdleShutdownEnabled reports whether the gateway's idle-shutdown timer
-// is configured. Wired by the SaaS sidecar for free-tier containers.
+// is configured.
 func (s *Settings) IdleShutdownEnabled() bool { return s.GatewayIdleShutdownSeconds > 0 }
+
+// ActivityEnabled reports whether the agent should POST runtime
+// activity signals to a remote observer. False when ACTIVITY_URL is
+// unset; the notifier in that case is a no-op.
+func (s *Settings) ActivityEnabled() bool { return s.ActivityURL != "" }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -141,6 +141,20 @@ func TestLoadPolicyFullStack(t *testing.T) {
 	assert.Equal(t, 100, s.OwnerDMNudgeEvery)
 }
 
+func TestActivityEnabledMirrorsURL(t *testing.T) {
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.False(t, s.ActivityEnabled(), "default = no activity URL = disabled")
+
+	t.Setenv("TURBORG_ACTIVITY_URL", "http://observer.local/mark")
+	t.Setenv("TURBORG_ACTIVITY_TOKEN", "shh")
+	s, err = config.Load()
+	require.NoError(t, err)
+	assert.True(t, s.ActivityEnabled())
+	assert.Equal(t, "http://observer.local/mark", s.ActivityURL)
+	assert.Equal(t, "shh", s.ActivityToken)
+}
+
 func TestHostnameAllowed(t *testing.T) {
 	t.Setenv("TURBORG_ALLOWED_NETWORKS", "irc.libera.chat,irc.oftc.net")
 	s, err := config.Load()

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -97,3 +97,114 @@ func TestLoadAllowsDuplicateEntriesInCSV(t *testing.T) {
 	assert.Equal(t, []string{"irc"}, s.Connectors,
 		"duplicate entries differ only by case + whitespace; must collapse")
 }
+
+// --- operator policy env tests --------------------------------------------
+
+func TestLoadPolicyDefaultsAreUnrestricted(t *testing.T) {
+	// No policy envs set → every knob lands at its zero value, which
+	// uniformly means "unrestricted".
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.Empty(t, s.Plan)
+	assert.Empty(t, s.AllowedNetworks)
+	assert.Zero(t, s.MaxChannels)
+	assert.False(t, s.NickLocked)
+	assert.False(t, s.RealnameLocked)
+	assert.Empty(t, s.RealnameTemplate)
+	assert.Zero(t, s.OutboundMaxPerWindow)
+	assert.Zero(t, s.MaxConnectorsPerAgent)
+	assert.True(t, s.HostnameAllowed("any.example"), "empty allowlist = unrestricted")
+}
+
+func TestLoadPolicyFullStack(t *testing.T) {
+	t.Setenv("TURBORG_PLAN", "my-deployment")
+	t.Setenv("TURBORG_ALLOWED_NETWORKS", "irc.libera.chat,irc.oftc.net,irc.rizon.net")
+	t.Setenv("TURBORG_MAX_CHANNELS", "5")
+	t.Setenv("TURBORG_NICK_LOCKED", "true")
+	t.Setenv("TURBORG_REALNAME_LOCKED", "true")
+	t.Setenv("TURBORG_REALNAME_TEMPLATE", "fixed realname")
+	t.Setenv("TURBORG_OUTBOUND_MAX_PER_WINDOW", "5")
+	t.Setenv("TURBORG_OUTBOUND_WINDOW_SECONDS", "30")
+	t.Setenv("TURBORG_MAX_CONNECTORS_PER_AGENT", "1")
+	t.Setenv("TURBORG_OWNER_DM_NUDGE_EVERY", "100")
+
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "my-deployment", s.Plan)
+	assert.Equal(t, []string{"irc.libera.chat", "irc.oftc.net", "irc.rizon.net"}, s.AllowedNetworks)
+	assert.Equal(t, 5, s.MaxChannels)
+	assert.True(t, s.NickLocked)
+	assert.True(t, s.RealnameLocked)
+	assert.Equal(t, "fixed realname", s.RealnameTemplate)
+	assert.Equal(t, 5, s.OutboundMaxPerWindow)
+	assert.Equal(t, 1, s.MaxConnectorsPerAgent)
+	assert.Equal(t, 100, s.OwnerDMNudgeEvery)
+}
+
+func TestHostnameAllowed(t *testing.T) {
+	t.Setenv("TURBORG_ALLOWED_NETWORKS", "irc.libera.chat,irc.oftc.net")
+	s, err := config.Load()
+	require.NoError(t, err)
+
+	assert.True(t, s.HostnameAllowed("irc.libera.chat"))
+	assert.True(t, s.HostnameAllowed("irc.oftc.net"))
+	assert.False(t, s.HostnameAllowed("irc.efnet.org"))
+	assert.False(t, s.HostnameAllowed(""))
+}
+
+func TestNormalizeRejectsOutboundWindowZeroWithMaxSet(t *testing.T) {
+	t.Setenv("TURBORG_OUTBOUND_MAX_PER_WINDOW", "10")
+	t.Setenv("TURBORG_OUTBOUND_WINDOW_SECONDS", "0")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OUTBOUND_WINDOW_SECONDS")
+}
+
+func TestNormalizeRejectsNegativeLLMCap(t *testing.T) {
+	t.Setenv("TURBORG_LLM_INPUT_TOKENS_PER_DAY", "-1")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM_INPUT_TOKENS_PER_DAY")
+}
+
+func TestNormalizeAcceptsMaxConnectorsPerAgentUnrestricted(t *testing.T) {
+	t.Setenv("TURBORG_CONNECTORS", "irc")
+	t.Setenv("TURBORG_MAX_CONNECTORS_PER_AGENT", "0") // 0 = unrestricted
+	_, err := config.Load()
+	require.NoError(t, err)
+}
+
+func TestNormalizeRejectsNegativeMaxConnectorsPerAgent(t *testing.T) {
+	t.Setenv("TURBORG_MAX_CONNECTORS_PER_AGENT", "-1")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MAX_CONNECTORS_PER_AGENT")
+}
+
+func TestNormalizeRejectsNegativeMaxChannels(t *testing.T) {
+	t.Setenv("TURBORG_MAX_CHANNELS", "-1")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MAX_CHANNELS")
+}
+
+func TestNormalizeRejectsNegativeLLMOutput(t *testing.T) {
+	t.Setenv("TURBORG_LLM_OUTPUT_TOKENS_PER_DAY", "-1")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM_OUTPUT_TOKENS_PER_DAY")
+}
+
+func TestNormalizeTrimsAllowedLLMModelsWhitespace(t *testing.T) {
+	t.Setenv("TURBORG_ALLOWED_LLM_MODELS", " claude-sonnet-4-6 , , claude-opus-4-7 ")
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"claude-sonnet-4-6", "claude-opus-4-7"}, s.AllowedLLMModels)
+}
+
+func TestNormalizeTrimsAllowedNetworksWhitespace(t *testing.T) {
+	t.Setenv("TURBORG_ALLOWED_NETWORKS", " irc.libera.chat , , irc.oftc.net ")
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"irc.libera.chat", "irc.oftc.net"}, s.AllowedNetworks)
+}

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -221,6 +221,11 @@ type Bouncer struct {
 	onForwarded  ForwardedObserver
 	state        *ChannelState
 
+	// limits gates client-initiated commands by operator policy. Zero
+	// value (unrestricted) is the default — see AttachClientLimits to
+	// override.
+	limits ClientLimits
+
 	logMu      sync.Mutex
 	channelLog map[string][]string
 }
@@ -251,6 +256,16 @@ func (b *Bouncer) AttachUpstream(send SendUpstreamFunc) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.sendUpstream = send
+}
+
+// AttachClientLimits installs the operator-policy limits the bouncer
+// consults before forwarding client-originated commands upstream. Called
+// at most once from runtime.Build; left zero (unrestricted) when no
+// policy applies. Safe to call before Start.
+func (b *Bouncer) AttachClientLimits(l ClientLimits) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.limits = l
 }
 
 func (b *Bouncer) AttachOutboundObserver(cb ForwardedObserver) {
@@ -465,6 +480,10 @@ func (b *Bouncer) handleLine(client *BouncerClient, line string) {
 	send := b.sendUpstream
 	observer := b.onForwarded
 	b.mu.Unlock()
+
+	if !b.allowByPolicy(client, msg) {
+		return
+	}
 
 	if send == nil {
 		return
@@ -732,6 +751,40 @@ func (b *Bouncer) replayChannelLogs(client *BouncerClient) {
 
 // Broadcast writes line to every authenticated client except exclude.
 // Also captures channel-targeted PRIVMSG / NOTICE into the per-channel
+// allowByPolicy consults ClientLimits for a client-initiated command and
+// returns true when it may flow upstream. A false return implies the
+// caller already notified the client and should drop the line. JOIN
+// folds in the current channel count from b.state; other commands ignore
+// the count argument.
+func (b *Bouncer) allowByPolicy(client *BouncerClient, msg Message) bool {
+	b.mu.Lock()
+	limits := b.limits
+	b.mu.Unlock()
+
+	currentChannels := 0
+	if msg.Command == CmdJoin && b.state != nil {
+		currentChannels = b.state.Count()
+	}
+	allow, reason := limits.AllowCommand(msg.Command, currentChannels)
+	if !allow {
+		b.notifyPolicyDenial(client, reason)
+	}
+	return allow
+}
+
+// notifyPolicyDenial sends a NOTICE back to the originating client when
+// an operator-policy gate refuses one of its commands. Uses the same
+// synthetic prefix the bouncer already uses for PONG so existing IRC
+// clients render it in the network/status tab rather than treating it
+// as a channel message. Errors are logged at debug level — a failed
+// NOTICE shouldn't fail the surrounding handler.
+func (b *Bouncer) notifyPolicyDenial(client *BouncerClient, reason string) {
+	line := ":turborg-bouncer NOTICE * :" + reason
+	if err := client.sendLine(line); err != nil {
+		b.log.Debug("bouncer policy notice", "err", err)
+	}
+}
+
 // replay ring so a bouncer client that reconnects later sees the
 // traffic it missed.
 func (b *Bouncer) Broadcast(line string, exclude *BouncerClient) {

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -233,6 +233,12 @@ type Bouncer struct {
 	// bucket per target.
 	outboundThrottle *Throttle
 
+	// onAttach, when non-nil, fires once per successful client auth
+	// with the reason string the activity package uses. nil = no-op.
+	// Wired by runtime so an external observer can be told a real user
+	// just attached, distinct from "bot is alive" log scrapes.
+	onAttach func(reason string)
+
 	logMu      sync.Mutex
 	channelLog map[string][]string
 }
@@ -283,6 +289,16 @@ func (b *Bouncer) AttachOutboundThrottle(t *Throttle) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.outboundThrottle = t
+}
+
+// AttachActivityHook installs a callback fired once per successful client
+// auth. Pass nil to disable. Lets the runtime forward "a client is using
+// this bouncer right now" signals to an external observer without the
+// bouncer itself knowing what the observer is.
+func (b *Bouncer) AttachActivityHook(hook func(reason string)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.onAttach = hook
 }
 
 func (b *Bouncer) AttachOutboundObserver(cb ForwardedObserver) {
@@ -644,6 +660,12 @@ func (b *Bouncer) handlePass(client *BouncerClient, params []string) {
 			b.rateLimiter.RecordSuccess(ip)
 		}
 		b.log.Info("bouncer auth success", "ip", ip)
+		b.mu.Lock()
+		hook := b.onAttach
+		b.mu.Unlock()
+		if hook != nil {
+			hook("bouncer_attach")
+		}
 
 		// IRCv3: if the client is mid-CAP-negotiation, hold the
 		// welcome + state replay until CAP END. Sending 001 now would

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 )
 
 // channelLogCap is the per-channel ring of recent PRIVMSG / NOTICE lines
@@ -226,6 +227,12 @@ type Bouncer struct {
 	// override.
 	limits ClientLimits
 
+	// outboundThrottle gates per-target PRIVMSG flow from attached
+	// clients. nil = unrestricted. Shared with the WS gateway so a
+	// single user with both HexChat and the web UI open shares one
+	// bucket per target.
+	outboundThrottle *Throttle
+
 	logMu      sync.Mutex
 	channelLog map[string][]string
 }
@@ -266,6 +273,16 @@ func (b *Bouncer) AttachClientLimits(l ClientLimits) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.limits = l
+}
+
+// AttachOutboundThrottle installs the per-target outbound throttle the
+// bouncer consults for client-originated PRIVMSG. Pass nil to disable.
+// Shared instance with the WS gateway: both surfaces consult the same
+// bucket per target so two clients of the same user share one budget.
+func (b *Bouncer) AttachOutboundThrottle(t *Throttle) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.outboundThrottle = t
 }
 
 func (b *Bouncer) AttachOutboundObserver(cb ForwardedObserver) {
@@ -755,22 +772,52 @@ func (b *Bouncer) replayChannelLogs(client *BouncerClient) {
 // returns true when it may flow upstream. A false return implies the
 // caller already notified the client and should drop the line. JOIN
 // folds in the current channel count from b.state; other commands ignore
-// the count argument.
+// the count argument. PRIVMSG additionally consults the per-target
+// outbound throttle when one is attached.
 func (b *Bouncer) allowByPolicy(client *BouncerClient, msg Message) bool {
 	b.mu.Lock()
 	limits := b.limits
+	throttle := b.outboundThrottle
 	b.mu.Unlock()
 
 	currentChannels := 0
 	if msg.Command == CmdJoin && b.state != nil {
 		currentChannels = b.state.Count()
 	}
-	allow, reason := limits.AllowCommand(msg.Command, currentChannels)
-	if !allow {
+	if allow, reason := limits.AllowCommand(msg.Command, currentChannels); !allow {
 		b.notifyPolicyDenial(client, reason)
+		b.log.Info("cap_hit",
+			"surface", "bouncer",
+			"kind", CapHitKind(msg.Command),
+			"source_cmd", msg.Command,
+		)
+		return false
 	}
-	return allow
+
+	// Per-target outbound throttle. Only PRIVMSG is gated here; bot-
+	// originated command replies (which take a different path) keep
+	// their existing per-sender command throttle.
+	if msg.Command == CmdPrivmsg && throttle != nil && len(msg.Params) > 0 {
+		target := msg.Params[0]
+		if res := throttle.AllowWithReason(target); !res.Allow {
+			seconds := int(res.RetryAfter.Round(time.Second) / time.Second)
+			if seconds < 1 {
+				seconds = 1
+			}
+			b.notifyPolicyDenial(client, fmt.Sprintf("rate limited — wait %ds before sending to %s again", seconds, target))
+			b.log.Info("cap_hit",
+				"surface", "bouncer",
+				"kind", "outbound_rate",
+				"target", target,
+				"retry_after_s", seconds,
+			)
+			return false
+		}
+	}
+
+	return true
 }
+
 
 // notifyPolicyDenial sends a NOTICE back to the originating client when
 // an operator-policy gate refuses one of its commands. Uses the same

--- a/internal/connector/irc/bouncer_test.go
+++ b/internal/connector/irc/bouncer_test.go
@@ -1075,6 +1075,73 @@ func TestBouncerMaxChannelsAllowsJoinBelowCap(t *testing.T) {
 	assert.True(t, found, "JOIN below the cap must flow upstream")
 }
 
+func TestBouncerPerTargetOutboundThrottleRejectsAfterCap(t *testing.T) {
+	throttle, err := irc.NewThrottle(2, 30*time.Second, nil)
+	require.NoError(t, err)
+
+	b, addr := freshBouncer(t, "hunter2")
+	forwarded, mu := trackForwarded(b)
+	b.AttachState(irc.NewChannelState(), "turborg", "ident", "host")
+	b.AttachOutboundThrottle(throttle)
+
+	conn, r := authBouncerClient(t, addr)
+	for i := 0; i < 2; i++ {
+		writeLine(t, conn, "PRIVMSG #x :one")
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Third PRIVMSG hits the cap → NOTICE with retry-after, line dropped.
+	writeLine(t, conn, "PRIVMSG #x :three")
+	notice := readUntilContains(r, conn, "NOTICE", 500*time.Millisecond)
+	assert.NotEmpty(t, notice, "client must receive a NOTICE when outbound throttle fires")
+	assert.Contains(t, notice, "rate limited")
+
+	mu.Lock()
+	defer mu.Unlock()
+	thirdSeen := false
+	twoSeen := 0
+	for _, l := range *forwarded {
+		if strings.Contains(l, ":three") {
+			thirdSeen = true
+		}
+		if strings.Contains(l, ":one") {
+			twoSeen++
+		}
+	}
+	assert.False(t, thirdSeen, "third PRIVMSG must be dropped at the throttle")
+	assert.Equal(t, 2, twoSeen, "first two PRIVMSGs forwarded")
+}
+
+func TestBouncerPerTargetOutboundThrottleScopesIndependently(t *testing.T) {
+	// One bucket per target — a chatty user in #a must not lock out #b.
+	throttle, err := irc.NewThrottle(1, 30*time.Second, nil)
+	require.NoError(t, err)
+
+	b, addr := freshBouncer(t, "hunter2")
+	forwarded, mu := trackForwarded(b)
+	b.AttachState(irc.NewChannelState(), "turborg", "ident", "host")
+	b.AttachOutboundThrottle(throttle)
+
+	conn, _ := authBouncerClient(t, addr)
+	writeLine(t, conn, "PRIVMSG #a :hi")
+	writeLine(t, conn, "PRIVMSG #b :hi")
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var sawA, sawB bool
+	for _, l := range *forwarded {
+		if strings.Contains(l, "PRIVMSG #a") {
+			sawA = true
+		}
+		if strings.Contains(l, "PRIVMSG #b") {
+			sawB = true
+		}
+	}
+	assert.True(t, sawA, "#a should be forwarded")
+	assert.True(t, sawB, "#b is a separate bucket — must still be forwarded")
+}
+
 func TestBouncerZeroClientLimitsIsUnrestricted(t *testing.T) {
 	// Default (zero) ClientLimits should pass everything through — guards
 	// the operator who doesn't configure any policy.

--- a/internal/connector/irc/bouncer_test.go
+++ b/internal/connector/irc/bouncer_test.go
@@ -1142,6 +1142,53 @@ func TestBouncerPerTargetOutboundThrottleScopesIndependently(t *testing.T) {
 	assert.True(t, sawB, "#b is a separate bucket — must still be forwarded")
 }
 
+func TestBouncerActivityHookFiresOnAuthSuccess(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	b.AttachActivityHook(func(reason string) {
+		mu.Lock()
+		reasons = append(reasons, reason)
+		mu.Unlock()
+	})
+
+	conn, r := bouncerClient(t, addr)
+	_, _ = r.ReadString('\n')
+	writeLine(t, conn, "PASS hunter2")
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, err := r.ReadString('\n')
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(reasons) == 1 && reasons[0] == "bouncer_attach"
+	}, time.Second, 10*time.Millisecond, "hook must fire exactly once with reason=bouncer_attach")
+}
+
+func TestBouncerActivityHookSilentOnAuthFailure(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	var fired bool
+	var mu sync.Mutex
+	b.AttachActivityHook(func(_ string) {
+		mu.Lock()
+		fired = true
+		mu.Unlock()
+	})
+
+	conn, r := bouncerClient(t, addr)
+	_, _ = r.ReadString('\n')
+	writeLine(t, conn, "PASS wrong")
+	// Wait long enough that any hook fired during handlePass would land.
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.False(t, fired, "auth failure must not fire the activity hook")
+}
+
 func TestBouncerZeroClientLimitsIsUnrestricted(t *testing.T) {
 	// Default (zero) ClientLimits should pass everything through — guards
 	// the operator who doesn't configure any policy.

--- a/internal/connector/irc/bouncer_test.go
+++ b/internal/connector/irc/bouncer_test.go
@@ -925,3 +925,180 @@ func TestBouncerDropsEmptyJoin(t *testing.T) {
 		assert.NotContains(t, l, "JOIN :", "malformed JOIN must be dropped")
 	}
 }
+
+// --- Operator-policy gating ------------------------------------------------
+
+// trackForwarded wires AttachUpstream so the test can assert which lines
+// (if any) the bouncer forwarded to the upstream IRC connection. Returns
+// the slice + its mutex; the caller locks while reading.
+func trackForwarded(b *irc.Bouncer) (*[]string, *sync.Mutex) {
+	var lines []string
+	var mu sync.Mutex
+	b.AttachUpstream(func(line string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		lines = append(lines, line)
+		return nil
+	})
+	return &lines, &mu
+}
+
+// authBouncerClient connects, sends PASS, drains the welcome burst and
+// returns the live conn + reader at the post-001 prompt.
+func authBouncerClient(t *testing.T, addr string) (net.Conn, *bufio.Reader) {
+	t.Helper()
+	conn, r := bouncerClient(t, addr)
+	_, _ = r.ReadString('\n') // pre-auth notice
+	writeLine(t, conn, "PASS hunter2")
+	for {
+		conn.SetReadDeadline(time.Now().Add(time.Second))
+		line, err := r.ReadString('\n')
+		if err != nil || strings.Contains(line, " 001 ") {
+			break
+		}
+	}
+	return conn, r
+}
+
+// readUntilContains keeps reading until the deadline hits, looking for a
+// substring the test expects. Returns the matching line or empty string
+// on timeout.
+func readUntilContains(r *bufio.Reader, conn net.Conn, substr string, deadline time.Duration) string {
+	conn.SetReadDeadline(time.Now().Add(deadline))
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return ""
+		}
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+}
+
+func TestBouncerNickLockedDropsNickUpstream(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	forwarded, mu := trackForwarded(b)
+	b.AttachState(irc.NewChannelState(), "turborg", "ident", "host")
+	b.AttachClientLimits(irc.ClientLimits{NickLocked: true})
+
+	conn, r := authBouncerClient(t, addr)
+	writeLine(t, conn, "NICK newnick")
+
+	notice := readUntilContains(r, conn, "NOTICE", 500*time.Millisecond)
+	assert.NotEmpty(t, notice, "client must receive a NOTICE explaining the rejection")
+	assert.Contains(t, notice, "nick")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, l := range *forwarded {
+		assert.NotContains(t, l, "NICK newnick",
+			"NICK must not flow upstream when ClientLimits.NickLocked is set")
+	}
+}
+
+func TestBouncerNickLockedAllowsOtherCommands(t *testing.T) {
+	// Make sure NickLocked doesn't accidentally cordon off PRIVMSG / JOIN.
+	b, addr := freshBouncer(t, "hunter2")
+	forwarded, mu := trackForwarded(b)
+	b.AttachState(irc.NewChannelState(), "turborg", "ident", "host")
+	b.AttachClientLimits(irc.ClientLimits{NickLocked: true})
+
+	conn, _ := authBouncerClient(t, addr)
+	writeLine(t, conn, "PRIVMSG #room :hello")
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var found bool
+	for _, l := range *forwarded {
+		if strings.Contains(l, "PRIVMSG #room :hello") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "PRIVMSG must still flow upstream under NickLocked")
+}
+
+func TestBouncerMaxChannelsRejectsJoinAtCap(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	forwarded, mu := trackForwarded(b)
+
+	// State has 5 channels already joined; cap is 5 → next JOIN is rejected.
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#a")
+	state.OnSelfJoin("#b")
+	state.OnSelfJoin("#c")
+	state.OnSelfJoin("#d")
+	state.OnSelfJoin("#e")
+	b.AttachState(state, "turborg", "ident", "host")
+	b.AttachClientLimits(irc.ClientLimits{MaxChannels: 5})
+
+	conn, r := authBouncerClient(t, addr)
+	writeLine(t, conn, "JOIN #f")
+
+	notice := readUntilContains(r, conn, "NOTICE", 500*time.Millisecond)
+	assert.NotEmpty(t, notice, "client must receive a NOTICE when JOIN exceeds the channel cap")
+	assert.Contains(t, notice, "5")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, l := range *forwarded {
+		assert.NotContains(t, l, "JOIN #f",
+			"JOIN must not flow upstream when MaxChannels is reached")
+	}
+}
+
+func TestBouncerMaxChannelsAllowsJoinBelowCap(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	forwarded, mu := trackForwarded(b)
+
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#a")
+	state.OnSelfJoin("#b")
+	b.AttachState(state, "turborg", "ident", "host")
+	b.AttachClientLimits(irc.ClientLimits{MaxChannels: 5})
+
+	conn, _ := authBouncerClient(t, addr)
+	writeLine(t, conn, "JOIN #c")
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var found bool
+	for _, l := range *forwarded {
+		if strings.Contains(l, "JOIN #c") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "JOIN below the cap must flow upstream")
+}
+
+func TestBouncerZeroClientLimitsIsUnrestricted(t *testing.T) {
+	// Default (zero) ClientLimits should pass everything through — guards
+	// the operator who doesn't configure any policy.
+	b, addr := freshBouncer(t, "hunter2")
+	forwarded, mu := trackForwarded(b)
+	b.AttachState(irc.NewChannelState(), "turborg", "ident", "host")
+	// No AttachClientLimits call — limits stay at the zero value.
+
+	conn, _ := authBouncerClient(t, addr)
+	writeLine(t, conn, "NICK whatever")
+	writeLine(t, conn, "JOIN #x")
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var sawNick, sawJoin bool
+	for _, l := range *forwarded {
+		if strings.Contains(l, "NICK whatever") {
+			sawNick = true
+		}
+		if strings.Contains(l, "JOIN #x") {
+			sawJoin = true
+		}
+	}
+	assert.True(t, sawNick, "unrestricted limits must let NICK through")
+	assert.True(t, sawJoin, "unrestricted limits must let JOIN through")
+}

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -50,9 +50,21 @@ type Connector struct {
 	// HexChat and the web UI shares one bucket per target.
 	outboundThrottle *Throttle
 
+	// bouncerAttachHook is forwarded onto the bouncer once it is built
+	// during startBouncer. Held here so SetBouncerAttachHook can run
+	// before Start without depending on bouncer existence yet.
+	bouncerAttachHook func(reason string)
+
 	// ownerNudge, when non-nil, emits a periodic usage-summary DM to
 	// the configured owner nick. nil = disabled.
 	ownerNudge *OwnerNudge
+
+	// onBotSpoke, when non-nil, fires for each bot-originated outbound
+	// PRIVMSG. Wired by runtime so an external observer can distinguish
+	// bot-driven activity from incoming channel chatter. Bouncer-tunneled
+	// PRIVMSGs go through a different code path (AttachUpstream callback)
+	// and are NOT considered bot_spoke — those are bouncer-attach activity.
+	onBotSpoke func(reason string)
 
 	// currentNick is the live nick the server confirmed for us. It
 	// starts as settings.Nick (the requested value), gets updated by
@@ -119,6 +131,19 @@ func (c *Connector) OutboundThrottle() *Throttle { return c.outboundThrottle }
 // the count crosses a multiple of EveryN.
 func (c *Connector) SetOwnerNudge(n *OwnerNudge) { c.ownerNudge = n }
 
+// SetActivityHook installs a callback fired for each bot-originated
+// outbound PRIVMSG. Pass nil to disable. Wired by runtime so an
+// observer learns the bot is doing work, even on dashboard-only or
+// silent-channel deployments where log scraping for PRIVMSG would miss
+// the signal. Bouncer-tunneled and incoming PRIVMSG do NOT fire this
+// hook — those reflect user activity, not bot activity.
+func (c *Connector) SetActivityHook(hook func(reason string)) { c.onBotSpoke = hook }
+
+// SetBouncerAttachHook installs a callback the bouncer fires on each
+// successful client auth. Pass nil to disable. Must be called before
+// Start so the bouncer picks it up when it is constructed.
+func (c *Connector) SetBouncerAttachHook(hook func(reason string)) { c.bouncerAttachHook = hook }
+
 // CurrentNick returns the live nick the server confirmed for the bot.
 // Initially the requested TURBORG_IRC_NICK, then overwritten by the
 // 001 welcome's target field (the nick the server actually assigned)
@@ -173,6 +198,9 @@ func (c *Connector) Send(env *agent.OutboundEnvelope) error {
 	// c.Send) so the nudge DM doesn't recurse back through this method
 	// and double-count.
 	c.ownerNudge.Note(c.client.WriteLine)
+	if c.onBotSpoke != nil {
+		c.onBotSpoke("bot_spoke")
+	}
 	return nil
 }
 
@@ -288,6 +316,7 @@ func (c *Connector) startBouncer(ctx context.Context) error {
 	b.AttachState(c.state, c.CurrentNick(), c.settings.EffectiveUsername(), "turborg")
 	b.AttachClientLimits(c.clientLimits)
 	b.AttachOutboundThrottle(c.outboundThrottle)
+	b.AttachActivityHook(c.bouncerAttachHook)
 	// sendUpstream is set before c.client is, so guard the dereference.
 	// Pre-bound bouncer clients that try to send forwardable commands
 	// before the upstream Dial completes get an error back rather than

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -38,6 +38,13 @@ type Connector struct {
 	bouncer  *Bouncer
 	ctcp     *Throttle
 
+	// clientLimits is the operator-policy struct the bouncer consults
+	// before forwarding client-originated commands upstream. Held here
+	// so runtime.Build can hand it to the connector before Start; it
+	// gets attached to the bouncer when (and if) the bouncer is created
+	// during Start.
+	clientLimits ClientLimits
+
 	// currentNick is the live nick the server confirmed for us. It
 	// starts as settings.Nick (the requested value), gets updated by
 	// the 001 RPL_WELCOME (where the server tells us the nick it
@@ -73,6 +80,18 @@ func (c *Connector) Name() string                          { return "irc" }
 func (c *Connector) Inbound() <-chan *agent.InboundEnvelope { return c.inbox }
 func (c *Connector) ClaimSupervision() bool                { return true }
 func (c *Connector) State() *ChannelState                  { return c.state }
+
+// SetClientLimits installs the operator-policy struct that gates
+// client-initiated commands (NICK, USER realname, JOIN-vs-channel-cap).
+// Must be called before Start so the limits are in place when the
+// bouncer is constructed. Calling later is a no-op.
+func (c *Connector) SetClientLimits(l ClientLimits) { c.clientLimits = l }
+
+// ClientLimits returns the operator-policy struct currently installed
+// on the connector. Used by adjacent surfaces (e.g. the WS gateway) to
+// enforce the same rules against client-originated actions that don't
+// flow through the bouncer.
+func (c *Connector) ClientLimits() ClientLimits { return c.clientLimits }
 
 // CurrentNick returns the live nick the server confirmed for the bot.
 // Initially the requested TURBORG_IRC_NICK, then overwritten by the
@@ -237,6 +256,7 @@ func (c *Connector) startBouncer(ctx context.Context) error {
 		return err
 	}
 	b.AttachState(c.state, c.CurrentNick(), c.settings.EffectiveUsername(), "turborg")
+	b.AttachClientLimits(c.clientLimits)
 	// sendUpstream is set before c.client is, so guard the dereference.
 	// Pre-bound bouncer clients that try to send forwardable commands
 	// before the upstream Dial completes get an error back rather than

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -50,6 +50,10 @@ type Connector struct {
 	// HexChat and the web UI shares one bucket per target.
 	outboundThrottle *Throttle
 
+	// ownerNudge, when non-nil, emits a periodic usage-summary DM to
+	// the configured owner nick. nil = disabled.
+	ownerNudge *OwnerNudge
+
 	// currentNick is the live nick the server confirmed for us. It
 	// starts as settings.Nick (the requested value), gets updated by
 	// the 001 RPL_WELCOME (where the server tells us the nick it
@@ -109,6 +113,12 @@ func (c *Connector) SetOutboundThrottle(t *Throttle) { c.outboundThrottle = t }
 // can consult the same instance for web-originated PRIVMSG.
 func (c *Connector) OutboundThrottle() *Throttle { return c.outboundThrottle }
 
+// SetOwnerNudge installs the periodic owner-DM usage summary. Pass nil
+// to disable. When set, Connector.Send increments the nudge counter
+// after each successful PRIVMSG write and the nudge emits a DM when
+// the count crosses a multiple of EveryN.
+func (c *Connector) SetOwnerNudge(n *OwnerNudge) { c.ownerNudge = n }
+
 // CurrentNick returns the live nick the server confirmed for the bot.
 // Initially the requested TURBORG_IRC_NICK, then overwritten by the
 // 001 welcome's target field (the nick the server actually assigned)
@@ -159,6 +169,10 @@ func (c *Connector) Send(env *agent.OutboundEnvelope) error {
 	if c.bouncer != nil {
 		c.bouncer.BroadcastAsSelf(line, nil)
 	}
+	// Owner-nudge counter. Passing c.client.WriteLine directly (not
+	// c.Send) so the nudge DM doesn't recurse back through this method
+	// and double-count.
+	c.ownerNudge.Note(c.client.WriteLine)
 	return nil
 }
 

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -45,6 +45,11 @@ type Connector struct {
 	// during Start.
 	clientLimits ClientLimits
 
+	// outboundThrottle is the per-target client-originated PRIVMSG
+	// throttle. Shared with the WS gateway so a user running both
+	// HexChat and the web UI shares one bucket per target.
+	outboundThrottle *Throttle
+
 	// currentNick is the live nick the server confirmed for us. It
 	// starts as settings.Nick (the requested value), gets updated by
 	// the 001 RPL_WELCOME (where the server tells us the nick it
@@ -92,6 +97,17 @@ func (c *Connector) SetClientLimits(l ClientLimits) { c.clientLimits = l }
 // enforce the same rules against client-originated actions that don't
 // flow through the bouncer.
 func (c *Connector) ClientLimits() ClientLimits { return c.clientLimits }
+
+// SetOutboundThrottle installs the per-target outbound PRIVMSG throttle.
+// Pass nil to disable. Must be called before Start so the throttle is
+// in place when the bouncer is constructed; the WS gateway picks up
+// the same instance via OutboundThrottle().
+func (c *Connector) SetOutboundThrottle(t *Throttle) { c.outboundThrottle = t }
+
+// OutboundThrottle returns the per-target outbound throttle currently
+// installed on the connector (may be nil). Exposed so the WS gateway
+// can consult the same instance for web-originated PRIVMSG.
+func (c *Connector) OutboundThrottle() *Throttle { return c.outboundThrottle }
 
 // CurrentNick returns the live nick the server confirmed for the bot.
 // Initially the requested TURBORG_IRC_NICK, then overwritten by the
@@ -257,6 +273,7 @@ func (c *Connector) startBouncer(ctx context.Context) error {
 	}
 	b.AttachState(c.state, c.CurrentNick(), c.settings.EffectiveUsername(), "turborg")
 	b.AttachClientLimits(c.clientLimits)
+	b.AttachOutboundThrottle(c.outboundThrottle)
 	// sendUpstream is set before c.client is, so guard the dereference.
 	// Pre-bound bouncer clients that try to send forwardable commands
 	// before the upstream Dial completes get an error back rather than

--- a/internal/connector/irc/connector_test.go
+++ b/internal/connector/irc/connector_test.go
@@ -407,3 +407,27 @@ func TestConnectorIgnoresUnknownNickInUse433DuringHandshake(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already in use")
 }
+
+func TestConnectorClientLimitsAccessors(t *testing.T) {
+	c := irc.New(&irc.Settings{Hostname: "h", Nick: "n"}, nil, nil)
+
+	// Default: zero value (unrestricted).
+	assert.Equal(t, irc.ClientLimits{}, c.ClientLimits())
+
+	limits := irc.ClientLimits{NickLocked: true, MaxChannels: 5}
+	c.SetClientLimits(limits)
+	assert.Equal(t, limits, c.ClientLimits())
+}
+
+func TestConnectorOutboundThrottleAccessors(t *testing.T) {
+	c := irc.New(&irc.Settings{Hostname: "h", Nick: "n"}, nil, nil)
+
+	// Default: nil.
+	assert.Nil(t, c.OutboundThrottle())
+
+	tr, err := irc.NewThrottle(5, time.Second, nil)
+	require.NoError(t, err)
+	c.SetOutboundThrottle(tr)
+	assert.Same(t, tr, c.OutboundThrottle(),
+		"OutboundThrottle should return the exact pointer we set")
+}

--- a/internal/connector/irc/connector_test.go
+++ b/internal/connector/irc/connector_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -430,4 +431,55 @@ func TestConnectorOutboundThrottleAccessors(t *testing.T) {
 	c.SetOutboundThrottle(tr)
 	assert.Same(t, tr, c.OutboundThrottle(),
 		"OutboundThrottle should return the exact pointer we set")
+}
+
+func TestConnectorActivityHookFiresOnBotOriginatedPrivmsg(t *testing.T) {
+	fs := fakeirc.New(t)
+	defer fs.Close()
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "turborg",
+		Channels: []string{"#test"},
+	}, nil, nil)
+
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	conn.SetActivityHook(func(reason string) {
+		mu.Lock()
+		reasons = append(reasons, reason)
+		mu.Unlock()
+	})
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.True(t,
+		fs.WaitFor(containsPrefix("JOIN #test"), 2*time.Second),
+		"connector did not JOIN; received: %v", fs.Received(),
+	)
+
+	require.NoError(t, conn.Send(&agent.OutboundEnvelope{
+		Connector: "irc", Channel: "#test", Text: "hi",
+	}))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(reasons) == 1 && reasons[0] == "bot_spoke"
+	}, time.Second, 10*time.Millisecond, "Send must fire the activity hook with reason=bot_spoke")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
 }

--- a/internal/connector/irc/nudge.go
+++ b/internal/connector/irc/nudge.go
@@ -1,0 +1,68 @@
+package irc
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// OwnerNudge periodically DMs the configured owner with a usage summary.
+// Operators wire it via Connector.SetOwnerNudge to surface "the bot's
+// been busy" feedback without requiring a separate dashboard.
+//
+// Note() is called after every successful PRIVMSG the bot sends; when
+// the running count hits a multiple of EveryN, the next call emits a
+// single DM line to the owner. The day boundary resets the count at UTC
+// midnight so a long-running bot doesn't accumulate forever.
+type OwnerNudge struct {
+	ownerNick string
+	everyN    int
+
+	mu    sync.Mutex
+	count int
+	today string // YYYY-MM-DD in UTC; "" before the first Note()
+	now   func() time.Time
+}
+
+// NewOwnerNudge returns nil when the configuration is incomplete
+// (no owner nick or non-positive everyN) — the caller treats nil as
+// "no nudge configured" and skips the wiring.
+func NewOwnerNudge(ownerNick string, everyN int) *OwnerNudge {
+	if ownerNick == "" || everyN <= 0 {
+		return nil
+	}
+	return &OwnerNudge{
+		ownerNick: ownerNick,
+		everyN:    everyN,
+		now:       time.Now,
+	}
+}
+
+// Note increments the daily counter; when count is a positive multiple
+// of EveryN, sends a single DM line to the owner via the supplied
+// writer. Day boundary reset uses UTC.
+//
+// The writer should bypass any counter that would otherwise re-enter
+// Note (the connector's Send path counts; pass the raw client write
+// here, never the Send wrapper).
+func (n *OwnerNudge) Note(send func(line string) error) {
+	if n == nil {
+		return
+	}
+
+	n.mu.Lock()
+	today := n.now().UTC().Format("2006-01-02")
+	if today != n.today {
+		n.today = today
+		n.count = 0
+	}
+	n.count++
+	count := n.count
+	shouldFire := count%n.everyN == 0
+	n.mu.Unlock()
+
+	if !shouldFire || send == nil {
+		return
+	}
+	_ = send(fmt.Sprintf("PRIVMSG %s :[turborg] you've sent %d messages today", n.ownerNick, count))
+}

--- a/internal/connector/irc/nudge_internal_test.go
+++ b/internal/connector/irc/nudge_internal_test.go
@@ -1,0 +1,72 @@
+package irc
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestOwnerNudgeResetsAtUTCMidnight injects a fake clock to walk the
+// nudge across a UTC day boundary. Lives in the irc package (not
+// irc_test) so it can poke the unexported `now` field without exporting
+// a test-only setter.
+func TestOwnerNudgeResetsAtUTCMidnight(t *testing.T) {
+	n := NewOwnerNudge("alice", 2)
+	if n == nil {
+		t.Fatal("nudge construction failed")
+	}
+
+	// Frozen clock pointing at 2026-05-15 23:50 UTC.
+	clock := time.Date(2026, 5, 15, 23, 50, 0, 0, time.UTC)
+	var mu sync.Mutex
+	n.now = func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return clock
+	}
+
+	var (
+		sentMu sync.Mutex
+		sent   []string
+	)
+	send := func(line string) error {
+		sentMu.Lock()
+		defer sentMu.Unlock()
+		sent = append(sent, line)
+		return nil
+	}
+
+	// Day 1: three Notes with everyN=2 → fires at count=2 only.
+	n.Note(send)
+	n.Note(send)
+	n.Note(send)
+
+	sentMu.Lock()
+	if len(sent) != 1 {
+		t.Fatalf("day 1: expected 1 nudge, got %d (%v)", len(sent), sent)
+	}
+	if !strings.Contains(sent[0], "2 messages") {
+		t.Fatalf("day 1: nudge should report count=2, got %q", sent[0])
+	}
+	sentMu.Unlock()
+
+	// Cross UTC midnight.
+	mu.Lock()
+	clock = time.Date(2026, 5, 16, 0, 30, 0, 0, time.UTC)
+	mu.Unlock()
+
+	// Day 2: two Notes — the second must fire because the counter
+	// restarts. The cumulative count of 5 (3 + 2) must not delay it.
+	n.Note(send)
+	n.Note(send)
+
+	sentMu.Lock()
+	defer sentMu.Unlock()
+	if len(sent) != 2 {
+		t.Fatalf("day 2: expected 2 total nudges, got %d (%v)", len(sent), sent)
+	}
+	if !strings.Contains(sent[1], "2 messages") {
+		t.Fatalf("day 2: nudge should report count=2 (day-local), got %q", sent[1])
+	}
+}

--- a/internal/connector/irc/nudge_test.go
+++ b/internal/connector/irc/nudge_test.go
@@ -1,0 +1,122 @@
+package irc_test
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// captureSender returns a sender func that records every line passed to
+// it. Thread-safe so the test can assert from outside.
+func captureSender() (func(string) error, func() []string) {
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	send := func(line string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, line)
+		return nil
+	}
+	read := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(seen))
+		copy(out, seen)
+		return out
+	}
+	return send, read
+}
+
+func TestNewOwnerNudgeReturnsNilForIncompleteConfig(t *testing.T) {
+	assert.Nil(t, irc.NewOwnerNudge("", 100),
+		"empty owner nick must yield nil")
+	assert.Nil(t, irc.NewOwnerNudge("alice", 0),
+		"zero everyN must yield nil")
+	assert.Nil(t, irc.NewOwnerNudge("alice", -1),
+		"negative everyN must yield nil")
+
+	n := irc.NewOwnerNudge("alice", 100)
+	require.NotNil(t, n, "fully-configured input must return a valid nudge")
+}
+
+func TestNoteFiresOnExactMultiple(t *testing.T) {
+	n := irc.NewOwnerNudge("alice", 3)
+	send, read := captureSender()
+
+	for i := 0; i < 9; i++ {
+		n.Note(send)
+	}
+
+	sent := read()
+	// 9 calls with everyN=3 → DM fires on 3, 6, 9 — three notifications.
+	require.Len(t, sent, 3)
+	for _, line := range sent {
+		assert.True(t, strings.HasPrefix(line, "PRIVMSG alice :"),
+			"every nudge must DM the configured owner nick")
+	}
+	assert.Contains(t, sent[0], "3 messages")
+	assert.Contains(t, sent[1], "6 messages")
+	assert.Contains(t, sent[2], "9 messages")
+}
+
+func TestNoteDoesNotFireBelowThreshold(t *testing.T) {
+	n := irc.NewOwnerNudge("alice", 100)
+	send, read := captureSender()
+
+	for i := 0; i < 99; i++ {
+		n.Note(send)
+	}
+
+	assert.Empty(t, read(), "no DM until the count crosses a multiple of everyN")
+}
+
+func TestNoteIsSafeOnNilReceiver(t *testing.T) {
+	// Operator opted out of nudges — Note on nil pointer must be a no-op,
+	// never panic.
+	var n *irc.OwnerNudge
+	require.NotPanics(t, func() { n.Note(nil) })
+}
+
+func TestNoteIgnoresNilSender(t *testing.T) {
+	// Even with a configured nudge, a nil sender callback should be a
+	// no-op rather than a crash — the call site has already done its
+	// counting work for the day.
+	n := irc.NewOwnerNudge("alice", 1)
+	require.NotPanics(t, func() { n.Note(nil) })
+}
+
+func TestNoteSenderErrorIsSilent(t *testing.T) {
+	// A nudge DM is best-effort. The sender returning an error must not
+	// surface anywhere — Note returns nothing and the next Note still
+	// works.
+	n := irc.NewOwnerNudge("alice", 1)
+	send := func(string) error { return errors.New("link down") }
+	require.NotPanics(t, func() { n.Note(send) })
+}
+
+func TestNoteConcurrent(t *testing.T) {
+	// Race-test: many goroutines incrementing the counter must produce
+	// exactly count / everyN nudges and never lose / double-fire.
+	n := irc.NewOwnerNudge("alice", 10)
+	send, read := captureSender()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			n.Note(send)
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, read(), 20,
+		"200 notes with everyN=10 must produce exactly 20 nudges")
+}

--- a/internal/connector/irc/policy.go
+++ b/internal/connector/irc/policy.go
@@ -32,6 +32,24 @@ type ClientLimits struct {
 	MaxChannels int
 }
 
+// CapHitKind maps an IRC command to the canonical "kind" label used in
+// cap_hit telemetry. Stable identifier across surfaces (bouncer + WS
+// gateway) so downstream counters can aggregate by kind. Lives next to
+// ClientLimits because the kinds map to the same gates that struct
+// implements.
+func CapHitKind(cmd string) string {
+	switch cmd {
+	case CmdNick:
+		return "nick_locked"
+	case CmdUser:
+		return "realname_locked"
+	case CmdJoin:
+		return "channels"
+	default:
+		return cmd
+	}
+}
+
 // AllowCommand returns (true, "") when the action is permitted, or
 // (false, reason) when it must be rejected. The caller is responsible
 // for surfacing reason to the originator (NOTICE for bouncer clients,

--- a/internal/connector/irc/policy.go
+++ b/internal/connector/irc/policy.go
@@ -1,0 +1,58 @@
+package irc
+
+import "fmt"
+
+// ClientLimits captures the operator-policy values that gate client-
+// initiated IRC actions. Both the bouncer (commands sent by an attached
+// IRC client like HexChat) and the WS gateway (actions sent by a web UI
+// client) consult the same struct so the two surfaces enforce the same
+// rules.
+//
+// Zero / empty values uniformly mean "unrestricted" — leaving every field
+// at its zero value gives the pre-policy behavior.
+//
+// All decisions are made from the struct's own fields; there's no
+// per-action state. State-dependent caps (e.g. "you're already at the
+// channel cap") get the current count passed in via AllowCommand's
+// arguments so the policy stays free of hidden coupling.
+type ClientLimits struct {
+	// NickLocked rejects /NICK changes initiated by attached clients.
+	// Server-forced nick changes (KILL, services, collision) bypass the
+	// policy entirely — they don't pass through AllowCommand.
+	NickLocked bool
+
+	// RealnameLocked rejects mid-session realname rewrites via USER.
+	// In practice clients rarely re-send USER; this guards the edge
+	// case of a tampered or non-standard client that does.
+	RealnameLocked bool
+
+	// MaxChannels caps the number of channels the agent is allowed to
+	// have joined at any one time. 0 = unrestricted. JOIN is rejected
+	// when the current count would exceed the cap; PART always allowed.
+	MaxChannels int
+}
+
+// AllowCommand returns (true, "") when the action is permitted, or
+// (false, reason) when it must be rejected. The caller is responsible
+// for surfacing reason to the originator (NOTICE for bouncer clients,
+// a WS event for gateway clients).
+//
+// currentChannels is the count of channels the agent is already in.
+// Pass 0 for commands where channel count is irrelevant.
+func (l ClientLimits) AllowCommand(cmd string, currentChannels int) (bool, string) {
+	switch cmd {
+	case CmdNick:
+		if l.NickLocked {
+			return false, "nick changes are disabled by operator policy"
+		}
+	case CmdUser:
+		if l.RealnameLocked {
+			return false, "realname is locked by operator policy"
+		}
+	case CmdJoin:
+		if l.MaxChannels > 0 && currentChannels >= l.MaxChannels {
+			return false, fmt.Sprintf("channel limit reached (%d)", l.MaxChannels)
+		}
+	}
+	return true, ""
+}

--- a/internal/connector/irc/policy_test.go
+++ b/internal/connector/irc/policy_test.go
@@ -1,0 +1,78 @@
+package irc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+func TestClientLimitsDefaultAllowsEverything(t *testing.T) {
+	l := irc.ClientLimits{}
+
+	for _, cmd := range []string{
+		irc.CmdNick, irc.CmdUser, irc.CmdJoin, irc.CmdPart,
+		irc.CmdPrivmsg, irc.CmdNotice, irc.CmdMode,
+	} {
+		allow, reason := l.AllowCommand(cmd, 0)
+		assert.Truef(t, allow, "default ClientLimits should allow %s, got reason %q", cmd, reason)
+	}
+}
+
+func TestClientLimitsNickLockedRejectsNick(t *testing.T) {
+	l := irc.ClientLimits{NickLocked: true}
+
+	allow, reason := l.AllowCommand(irc.CmdNick, 0)
+	assert.False(t, allow)
+	assert.Contains(t, reason, "nick")
+}
+
+func TestClientLimitsNickLockedStillAllowsOtherCommands(t *testing.T) {
+	// NickLocked specifically gates /NICK and nothing else.
+	l := irc.ClientLimits{NickLocked: true}
+
+	allow, _ := l.AllowCommand(irc.CmdJoin, 0)
+	assert.True(t, allow)
+	allow, _ = l.AllowCommand(irc.CmdPrivmsg, 0)
+	assert.True(t, allow)
+}
+
+func TestClientLimitsRealnameLockedRejectsUser(t *testing.T) {
+	l := irc.ClientLimits{RealnameLocked: true}
+
+	allow, reason := l.AllowCommand(irc.CmdUser, 0)
+	assert.False(t, allow)
+	assert.Contains(t, reason, "realname")
+}
+
+func TestClientLimitsMaxChannelsRejectsJoinAtCap(t *testing.T) {
+	l := irc.ClientLimits{MaxChannels: 5}
+
+	allow, reason := l.AllowCommand(irc.CmdJoin, 5)
+	assert.False(t, allow)
+	assert.Contains(t, reason, "5")
+}
+
+func TestClientLimitsMaxChannelsAllowsJoinBelowCap(t *testing.T) {
+	l := irc.ClientLimits{MaxChannels: 5}
+
+	allow, _ := l.AllowCommand(irc.CmdJoin, 4)
+	assert.True(t, allow)
+}
+
+func TestClientLimitsZeroMaxChannelsAllowsAnyJoin(t *testing.T) {
+	// 0 = unrestricted, even for absurd current counts.
+	l := irc.ClientLimits{MaxChannels: 0}
+
+	allow, _ := l.AllowCommand(irc.CmdJoin, 9999)
+	assert.True(t, allow)
+}
+
+func TestClientLimitsUnknownCommandAlwaysAllowed(t *testing.T) {
+	// Commands the policy has no opinion on must pass through. Future
+	// commands shouldn't need a policy update unless they're load-bearing.
+	l := irc.ClientLimits{NickLocked: true, RealnameLocked: true, MaxChannels: 1}
+
+	allow, _ := l.AllowCommand("MADE_UP_CMD", 0)
+	assert.True(t, allow)
+}

--- a/internal/connector/irc/policy_test.go
+++ b/internal/connector/irc/policy_test.go
@@ -76,3 +76,37 @@ func TestClientLimitsUnknownCommandAlwaysAllowed(t *testing.T) {
 	allow, _ := l.AllowCommand("MADE_UP_CMD", 0)
 	assert.True(t, allow)
 }
+
+func TestClientLimitsRealnameLockedDoesNotGateNick(t *testing.T) {
+	// Cross-check: each lock is independent. RealnameLocked must not
+	// also lock NICK, and NickLocked must not also lock USER.
+	l := irc.ClientLimits{RealnameLocked: true}
+	allow, _ := l.AllowCommand(irc.CmdNick, 0)
+	assert.True(t, allow, "RealnameLocked must not gate NICK")
+}
+
+func TestCapHitKindMapping(t *testing.T) {
+	cases := []struct {
+		cmd      string
+		wantKind string
+	}{
+		{irc.CmdNick, "nick_locked"},
+		{irc.CmdUser, "realname_locked"},
+		{irc.CmdJoin, "channels"},
+		{irc.CmdPrivmsg, irc.CmdPrivmsg}, // fall-through: kind == cmd
+		{"UNKNOWN", "UNKNOWN"},
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.wantKind, irc.CapHitKind(tc.cmd),
+			"CapHitKind(%q)", tc.cmd)
+	}
+}
+
+func TestClientLimitsMaxChannelsDoesNotGateNonJoin(t *testing.T) {
+	// Reaching the channel cap must not silently lock other commands.
+	l := irc.ClientLimits{MaxChannels: 1}
+	for _, cmd := range []string{irc.CmdPrivmsg, irc.CmdNotice, irc.CmdPart, irc.CmdMode} {
+		allow, _ := l.AllowCommand(cmd, 99)
+		assert.Truef(t, allow, "MaxChannels must not gate %s even when count > cap", cmd)
+	}
+}

--- a/internal/connector/irc/ratelimit.go
+++ b/internal/connector/irc/ratelimit.go
@@ -148,6 +148,23 @@ func NewThrottle(maxPerWindow int, window time.Duration, clock Clock) (*Throttle
 }
 
 func (t *Throttle) Allow(key string) bool {
+	return t.AllowWithReason(key).Allow
+}
+
+// ThrottleResult is the rich form of an Allow check. RetryAfter is the
+// remaining time until the oldest event in the bucket ages out and a
+// new event would be permitted; it's zero when Allow is true. Callers
+// surface RetryAfter to the originator so the client knows when to retry
+// rather than guess.
+type ThrottleResult struct {
+	Allow      bool
+	RetryAfter time.Duration
+}
+
+// AllowWithReason is Allow plus retry-after diagnostics. Used by surfaces
+// that show "wait Ns" feedback (bouncer NOTICE, WS rate_limited event)
+// rather than just silently dropping the call.
+func (t *Throttle) AllowWithReason(key string) ThrottleResult {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -162,9 +179,13 @@ func (t *Throttle) Allow(key string) bool {
 	}
 	if len(pruned) >= t.MaxPerWindow {
 		t.events[key] = pruned
-		return false
+		// RetryAfter = when the oldest event in the bucket ages out
+		// (pruned[0] + Window) minus now. Always positive here because
+		// pruned[0] >= cutoff = now - Window, so pruned[0] + Window >= now.
+		retryAfter := pruned[0].Add(t.Window).Sub(now)
+		return ThrottleResult{Allow: false, RetryAfter: retryAfter}
 	}
 	pruned = append(pruned, now)
 	t.events[key] = pruned
-	return true
+	return ThrottleResult{Allow: true}
 }

--- a/internal/connector/irc/ratelimit_test.go
+++ b/internal/connector/irc/ratelimit_test.go
@@ -168,3 +168,52 @@ func TestThrottleConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestThrottleAllowWithReasonReturnsRetryAfter(t *testing.T) {
+	clock := newClock()
+	tr, err := irc.NewThrottle(3, 30*time.Second, clock.Now)
+	require.NoError(t, err)
+
+	// First 3 calls fill the bucket.
+	for i := 0; i < 3; i++ {
+		res := tr.AllowWithReason("#x")
+		require.True(t, res.Allow, "call %d should be allowed", i+1)
+		assert.Zero(t, res.RetryAfter, "allowed calls return zero RetryAfter")
+		clock.Advance(time.Second)
+	}
+
+	// 4th call hits the cap. Oldest event is now 3s ago, so retry-after
+	// is window (30s) - 3s = 27s.
+	res := tr.AllowWithReason("#x")
+	assert.False(t, res.Allow)
+	assert.Equal(t, 27*time.Second, res.RetryAfter)
+}
+
+func TestThrottleAllowWithReasonRespectsPerKeyScope(t *testing.T) {
+	// Per-target throttle: hammering one channel must not lock out
+	// another. v3 plan: "free user sending 5 to #a + 5 to #b is fine".
+	clock := newClock()
+	tr, err := irc.NewThrottle(2, 30*time.Second, clock.Now)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		assert.True(t, tr.AllowWithReason("#a").Allow)
+	}
+	assert.False(t, tr.AllowWithReason("#a").Allow, "#a should be at cap")
+
+	// #b is its own bucket — fresh quota.
+	assert.True(t, tr.AllowWithReason("#b").Allow)
+	assert.True(t, tr.AllowWithReason("#b").Allow)
+	assert.False(t, tr.AllowWithReason("#b").Allow, "#b reached its own cap independently")
+}
+
+func TestThrottleAllowWithReasonRecoversAfterWindow(t *testing.T) {
+	clock := newClock()
+	tr, _ := irc.NewThrottle(1, 30*time.Second, clock.Now)
+
+	assert.True(t, tr.AllowWithReason("#x").Allow)
+	assert.False(t, tr.AllowWithReason("#x").Allow)
+
+	clock.Advance(31 * time.Second)
+	assert.True(t, tr.AllowWithReason("#x").Allow, "bucket should free after window")
+}

--- a/internal/connector/irc/state.go
+++ b/internal/connector/irc/state.go
@@ -51,6 +51,15 @@ func (s *ChannelState) Get(channel string) *ChannelInfo {
 	return cloneChannelInfo(info)
 }
 
+// Count returns how many channels are currently joined. Cheap (no
+// allocation) — preferred over len(JoinedChannels()) for the
+// hot-path policy check.
+func (s *ChannelState) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.order)
+}
+
 // JoinedChannels returns snapshot copies of every channel currently
 // joined, in insertion order.
 func (s *ChannelState) JoinedChannels() []*ChannelInfo {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -64,6 +64,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	}
 
 	a := agent.NewWithPrefix(log, s.CommandPrefix)
+	a.Commands.SetMaxDynamic(s.CustomCommandsMax)
 
 	ircConn := irc.New(ircCfg, log, a.Events)
 	ircConn.SetClientLimits(irc.ClientLimits{
@@ -86,6 +87,14 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 			return nil, fmt.Errorf("runtime: outbound throttle: %w", err)
 		}
 		ircConn.SetOutboundThrottle(t)
+	}
+
+	// Owner-DM nudge: when the operator has set both a target owner nick
+	// and a positive interval, the connector DMs the owner every N
+	// outbound PRIVMSGs with a usage summary. Daily counter resets at
+	// UTC midnight inside the nudge itself.
+	if nudge := irc.NewOwnerNudge(s.OwnerNick, s.OwnerDMNudgeEvery); nudge != nil {
+		ircConn.SetOwnerNudge(nudge)
 	}
 
 	a.AddConnector(ircConn)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -71,6 +71,23 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		RealnameLocked: s.RealnameLocked,
 		MaxChannels:    s.MaxChannels,
 	})
+
+	// Per-target outbound throttle, when configured. Single instance
+	// shared between the bouncer (consults for attached-client PRIVMSG)
+	// and the WS gateway (consults for `say` op) so a user with both
+	// surfaces open shares one bucket per target.
+	if s.OutboundMaxPerWindow > 0 && s.OutboundWindowSeconds > 0 {
+		t, err := irc.NewThrottle(
+			s.OutboundMaxPerWindow,
+			time.Duration(s.OutboundWindowSeconds)*time.Second,
+			nil,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("runtime: outbound throttle: %w", err)
+		}
+		ircConn.SetOutboundThrottle(t)
+	}
+
 	a.AddConnector(ircConn)
 
 	if len(s.Connectors) > 1 {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/turborg/turborg/internal/activity"
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/config"
 	"github.com/turborg/turborg/internal/connector/irc"
@@ -40,10 +41,11 @@ const AskSystemPrompt = "You are turborg, an IRC chatbot. Keep replies short and
 // connectors are added; built-in commands are registered; the owner +
 // throttle guard is installed.
 type Built struct {
-	Agent   *agent.Agent
-	IRC     *irc.Connector
-	Gateway *web.Gateway
-	LLM     llm.Provider // nil when Anthropic is not configured
+	Agent    *agent.Agent
+	IRC      *irc.Connector
+	Gateway  *web.Gateway
+	LLM      llm.Provider       // nil when Anthropic is not configured
+	Activity *activity.Notifier // never nil; no-op when ACTIVITY_URL is unset
 }
 
 // Build wires the agent + connectors + gateway from settings. Callers
@@ -66,12 +68,21 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	a := agent.NewWithPrefix(log, s.CommandPrefix)
 	a.Commands.SetMaxDynamic(s.CustomCommandsMax)
 
+	notifier := activity.New(s.ActivityURL, s.ActivityToken, log)
+
 	ircConn := irc.New(ircCfg, log, a.Events)
 	ircConn.SetClientLimits(irc.ClientLimits{
 		NickLocked:     s.NickLocked,
 		RealnameLocked: s.RealnameLocked,
 		MaxChannels:    s.MaxChannels,
 	})
+	if notifier.Enabled() {
+		// Bind the notifier into the connector + bouncer. The Hook method
+		// keeps the IRC package free of an activity-package import — it
+		// only sees a func(string).
+		ircConn.SetActivityHook(notifier.Hook)
+		ircConn.SetBouncerAttachHook(notifier.Hook)
+	}
 
 	// Per-target outbound throttle, when configured. Single instance
 	// shared between the bouncer (consults for attached-client PRIVMSG)
@@ -113,10 +124,10 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	RegisterBuiltinCommands(a, provider)
 	a.Commands.SetGuard(BuildCommandGuard(s))
 
-	built := &Built{Agent: a, IRC: ircConn, LLM: provider}
+	built := &Built{Agent: a, IRC: ircConn, LLM: provider, Activity: notifier}
 
 	if s.GatewayEnabled() {
-		gw, err := buildGateway(s, ircConn, log)
+		gw, err := buildGateway(s, ircConn, a, log, notifier)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +176,7 @@ func buildLLM(s *config.Settings) (llm.Provider, error) {
 	return p, nil
 }
 
-func buildGateway(s *config.Settings, ircConn *irc.Connector, log *slog.Logger) (*web.Gateway, error) {
+func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger, notifier *activity.Notifier) (*web.Gateway, error) {
 	verifier, err := web.NewStaticPasswordVerifier(s.GatewayPassword)
 	if err != nil {
 		return nil, fmt.Errorf("runtime: gateway verifier: %w", err)
@@ -185,6 +196,9 @@ func buildGateway(s *config.Settings, ircConn *irc.Connector, log *slog.Logger) 
 		Verifier:    verifier,
 		RateLimiter: rl,
 		Log:         log,
+	}
+	if notifier.Enabled() {
+		opts.OnClientAttached = notifier.Hook
 	}
 	if s.IdleShutdownEnabled() {
 		opts.IdleShutdownSeconds = s.GatewayIdleShutdownSeconds

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -66,6 +66,11 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	a := agent.NewWithPrefix(log, s.CommandPrefix)
 
 	ircConn := irc.New(ircCfg, log, a.Events)
+	ircConn.SetClientLimits(irc.ClientLimits{
+		NickLocked:     s.NickLocked,
+		RealnameLocked: s.RealnameLocked,
+		MaxChannels:    s.MaxChannels,
+	})
 	a.AddConnector(ircConn)
 
 	if len(s.Connectors) > 1 {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -54,6 +54,10 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		log = slog.Default()
 	}
 
+	if err := applyOperatorPolicy(s, ircCfg); err != nil {
+		return nil, err
+	}
+
 	provider, err := buildLLM(s)
 	if err != nil {
 		return nil, err
@@ -90,6 +94,29 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	}
 
 	return built, nil
+}
+
+// applyOperatorPolicy runs cross-cutting policy checks at boot. Catches
+// misconfigurations the env layer alone can't see — e.g. ALLOWED_NETWORKS
+// set but IRC_HOSTNAME points outside the allowlist. Mutates ircCfg in
+// place when the policy forces a value (realname lock).
+//
+// All checks are no-ops when the corresponding policy env is unset, so
+// operators who don't configure anything see no behavior change.
+func applyOperatorPolicy(s *config.Settings, ircCfg *irc.Settings) error {
+	if ircCfg != nil && !s.HostnameAllowed(ircCfg.Hostname) {
+		return fmt.Errorf("runtime: IRC hostname %q is not in TURBORG_ALLOWED_NETWORKS=%s",
+			ircCfg.Hostname, strings.Join(s.AllowedNetworks, ","))
+	}
+
+	// Realname lock: template overrides whatever value arrived via
+	// TURBORG_IRC_REAL_NAME. Done before the connector is constructed so
+	// the constructor sees the locked value as its initial state.
+	if ircCfg != nil && s.RealnameLocked && s.RealnameTemplate != "" {
+		ircCfg.RealName = s.RealnameTemplate
+	}
+
+	return nil
 }
 
 func buildLLM(s *config.Settings) (llm.Provider, error) {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -488,6 +488,34 @@ func TestBuildLeavesRealnameAloneWhenLockUnset(t *testing.T) {
 	assert.Equal(t, "user-supplied custom name", ircCfg.RealName)
 }
 
+func TestBuildWiresOutboundThrottleWhenConfigured(t *testing.T) {
+	// OutboundMaxPerWindow > 0 + OutboundWindowSeconds > 0 → runtime
+	// constructs a throttle and attaches it to the connector so both the
+	// bouncer and the WS gateway can consult the same instance.
+	s := &config.Settings{
+		CommandPrefix:         "!",
+		OutboundMaxPerWindow:  5,
+		OutboundWindowSeconds: 30,
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.IRC)
+	assert.NotNil(t, b.IRC.OutboundThrottle(),
+		"OutboundThrottle must be wired when MaxPerWindow > 0")
+}
+
+func TestBuildLeavesOutboundThrottleNilWhenUnconfigured(t *testing.T) {
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	assert.Nil(t, b.IRC.OutboundThrottle(),
+		"unconfigured throttle stays nil (unrestricted)")
+}
+
 func TestBuildIgnoresRealnameTemplateWithoutLock(t *testing.T) {
 	// RealnameTemplate set but Locked=false: the template is purely
 	// advisory and must not overwrite the user's choice. Catches the

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -516,6 +516,22 @@ func TestBuildLeavesOutboundThrottleNilWhenUnconfigured(t *testing.T) {
 		"unconfigured throttle stays nil (unrestricted)")
 }
 
+func TestBuildWiresOwnerNudgeWhenConfigured(t *testing.T) {
+	// Both OwnerNick and OwnerDMNudgeEvery set → runtime constructs the
+	// nudge and attaches it. We can't observe the nudge directly (no
+	// getter on the connector), so this just exercises the wiring path
+	// for coverage.
+	s := &config.Settings{
+		CommandPrefix:     "!",
+		OwnerNick:         "alice",
+		OwnerDMNudgeEvery: 100,
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+
+	_, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+}
+
 func TestBuildIgnoresRealnameTemplateWithoutLock(t *testing.T) {
 	// RealnameTemplate set but Locked=false: the template is purely
 	// advisory and must not overwrite the user's choice. Catches the

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -60,6 +60,36 @@ func TestBuildWithGateway(t *testing.T) {
 	require.NotNil(t, b.Gateway)
 }
 
+func TestBuildActivityNoopWhenURLUnset(t *testing.T) {
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.Activity)
+	assert.False(t, b.Activity.Enabled(),
+		"activity notifier must be a no-op when TURBORG_ACTIVITY_URL is unset")
+}
+
+func TestBuildActivityEnabledWhenURLSet(t *testing.T) {
+	s := &config.Settings{
+		CommandPrefix:           "!",
+		ActivityURL:             "http://observer.local/mark",
+		ActivityToken:           "shh",
+		GatewayPassword:             "hunter2",
+		GatewayHost:                 "127.0.0.1",
+		GatewayPort:                 0,
+		GatewayMaxFailedAttempts:    5,
+		GatewayFailureWindowSeconds: 60,
+		GatewayLockoutSeconds:       300,
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.Activity)
+	assert.True(t, b.Activity.Enabled())
+	assert.NotNil(t, b.Gateway, "gateway must still wire when activity is enabled")
+}
+
 func TestBuildRejectsUnknownConnector(t *testing.T) {
 	s := &config.Settings{CommandPrefix: "!", Connectors: []string{"irc", "discord"}}
 	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -415,6 +415,99 @@ func TestRunWithGatewayUnwindsOnCtxCancel(t *testing.T) {
 	cancel()
 }
 
+func TestBuildRejectsHostnameOutsideAllowedNetworks(t *testing.T) {
+	// Self-host operator with an empty whitelist is unrestricted — no
+	// rejection. Set the whitelist to a value that doesn't include
+	// ircCfg.Hostname and Build must refuse to come up.
+	s := &config.Settings{
+		CommandPrefix:   "!",
+		AllowedNetworks: []string{"irc.libera.chat"},
+	}
+	ircCfg := &irc.Settings{Hostname: "irc.efnet.org", Nick: "turborg"}
+
+	_, err := runtime.Build(s, ircCfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ALLOWED_NETWORKS")
+	assert.Contains(t, err.Error(), "irc.efnet.org")
+}
+
+func TestBuildAcceptsHostnameInWhitelist(t *testing.T) {
+	s := &config.Settings{
+		CommandPrefix:   "!",
+		AllowedNetworks: []string{"irc.libera.chat", "irc.oftc.net"},
+	}
+	ircCfg := &irc.Settings{Hostname: "irc.oftc.net", Nick: "turborg"}
+
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.IRC)
+}
+
+func TestBuildAcceptsAnyHostnameWhenWhitelistEmpty(t *testing.T) {
+	// Empty AllowedNetworks = unrestricted (the self-host default). Bot
+	// must come up regardless of the hostname value.
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{Hostname: "irc.some-private.example", Nick: "turborg"}
+
+	_, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+}
+
+func TestBuildLocksRealnameToTemplate(t *testing.T) {
+	// RealnameLocked + RealnameTemplate set → realname overrides whatever
+	// arrived via TURBORG_IRC_REAL_NAME. Operators use this to force a
+	// fixed identity string regardless of per-deploy env wiring.
+	s := &config.Settings{
+		CommandPrefix:    "!",
+		RealnameLocked:   true,
+		RealnameTemplate: "fixed realname for this deployment",
+	}
+	ircCfg := &irc.Settings{
+		Hostname: "irc.libera.chat",
+		Nick:     "turborg",
+		RealName: "user-supplied custom name",
+	}
+
+	_, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "fixed realname for this deployment", ircCfg.RealName,
+		"locked realname must overwrite ircCfg.RealName at Build time")
+}
+
+func TestBuildLeavesRealnameAloneWhenLockUnset(t *testing.T) {
+	// No RealnameLocked flag → user-supplied realname survives unchanged.
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{
+		Hostname: "irc.libera.chat",
+		Nick:     "turborg",
+		RealName: "user-supplied custom name",
+	}
+
+	_, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "user-supplied custom name", ircCfg.RealName)
+}
+
+func TestBuildIgnoresRealnameTemplateWithoutLock(t *testing.T) {
+	// RealnameTemplate set but Locked=false: the template is purely
+	// advisory and must not overwrite the user's choice. Catches the
+	// foot-gun of someone wiring the template env without the lock flag.
+	s := &config.Settings{
+		CommandPrefix:    "!",
+		RealnameLocked:   false,
+		RealnameTemplate: "some advisory string",
+	}
+	ircCfg := &irc.Settings{
+		Hostname: "irc.libera.chat",
+		Nick:     "turborg",
+		RealName: "user-supplied",
+	}
+
+	_, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "user-supplied", ircCfg.RealName)
+}
+
 // --- fakeLLM stub --------------------------------------------------------
 
 type fakeLLM struct {

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -66,6 +66,12 @@ type Options struct {
 	// stop).
 	IdleShutdownSeconds int
 	OnIdleShutdown      func()
+
+	// OnClientAttached fires once per successful WS handshake, with a
+	// stable reason identifier. nil = disabled. Wired by runtime so an
+	// external observer can learn that a dashboard client is actively
+	// using this agent — distinct from "bot is alive" log signal.
+	OnClientAttached func(reason string)
 }
 
 // Gateway is an HTTP server exposing /ws (WebSocket), /health, /metrics,
@@ -290,6 +296,9 @@ func (g *Gateway) handleWS(w http.ResponseWriter, r *http.Request) {
 	g.metrics.connections++
 	g.metMu.Unlock()
 	g.log.Info("web auth success", "ip", ip)
+	if g.opts.OnClientAttached != nil {
+		g.opts.OnClientAttached("ws_attach")
+	}
 
 	connectedAt := time.Now()
 	defer func() {

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -28,11 +28,19 @@ const (
 
 // IRCBridge is the narrow slice of the IRC connector the gateway
 // depends on. Keeps the package boundary clean — the gateway never
-// reaches into IRC-specific internals beyond these four methods.
+// reaches into IRC-specific internals beyond these methods.
 type IRCBridge interface {
 	CurrentNick() string
 	State() *irc.ChannelState
 	SendRaw(line string) error
+	// ClientLimits returns the operator-policy struct the gateway
+	// consults before forwarding web-originated actions. Mirror of the
+	// bouncer's policy gate — same struct, two surfaces.
+	ClientLimits() irc.ClientLimits
+	// OutboundThrottle returns the per-target PRIVMSG throttle (may
+	// be nil = unrestricted). Shared with the bouncer so a user with
+	// both surfaces open shares one bucket per target.
+	OutboundThrottle() *irc.Throttle
 }
 
 // Sender is the agent surface for outbound envelopes — the gateway
@@ -401,14 +409,72 @@ func (g *Gateway) readLoop(ctx context.Context, c *client) {
 		if err := json.Unmarshal(raw, &payload); err != nil {
 			continue
 		}
-		g.dispatchInbound(payload)
+		g.dispatchInbound(ctx, c, payload)
 	}
+}
+
+// allowByPolicy consults the bridge's ClientLimits for the IRC command
+// the WS op maps to. Returns (true, "") when permitted, (false, reason)
+// when the gateway should drop the op and surface the rejection back to
+// the client via a policy_denied event.
+//
+// Mirrors irc.Bouncer's policy gate so the two client-action surfaces
+// (bouncer + WS) enforce the same rules.
+func (g *Gateway) allowByPolicy(ircCmd string) (allow bool, reason string, kind string) {
+	limits := g.bridge.ClientLimits()
+	currentChannels := 0
+	if ircCmd == irc.CmdJoin {
+		if st := g.bridge.State(); st != nil {
+			currentChannels = st.Count()
+		}
+	}
+	allow, reason = limits.AllowCommand(ircCmd, currentChannels)
+	kind = irc.CapHitKind(ircCmd)
+	return allow, reason, kind
+}
+
+// denyAction sends a policy_denied event to the originating client and
+// emits a cap_hit structured log line for telemetry pipelines. The log
+// line is the canonical signal a sidecar log-watcher (or any future
+// metrics scraper) consumes — never log the user-facing reason from any
+// other path, so cap_hit stays the single source of truth.
+func (g *Gateway) denyAction(ctx context.Context, c *client, sourceOp, kind, reason string) {
+	g.sendTo(ctx, c, map[string]any{
+		"op":        "policy_denied",
+		"source_op": sourceOp,
+		"kind":      kind,
+		"reason":    reason,
+	})
+	g.log.Info("cap_hit", "surface", "ws_gateway", "kind", kind, "source_op", sourceOp)
+}
+
+// rateLimited is the per-target outbound-throttle counterpart to
+// denyAction. Emits {op: "rate_limited", ...} so the UI can render an
+// inline "wait Ns" badge next to the user's message, plus the same
+// cap_hit telemetry line for aggregation.
+func (g *Gateway) rateLimited(ctx context.Context, c *client, target string, retryAfter time.Duration) {
+	seconds := int(retryAfter.Round(time.Second) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	g.sendTo(ctx, c, map[string]any{
+		"op":          "rate_limited",
+		"target":      target,
+		"retry_after": seconds,
+		"reason":      "outbound rate limit",
+	})
+	g.log.Info("cap_hit",
+		"surface", "ws_gateway",
+		"kind", "outbound_rate",
+		"target", target,
+		"retry_after_s", seconds,
+	)
 }
 
 // dispatchInbound is a per-op switch; complexity grows with the WS protocol.
 //
 //nolint:gocyclo
-func (g *Gateway) dispatchInbound(p map[string]any) {
+func (g *Gateway) dispatchInbound(ctx context.Context, c *client, p map[string]any) {
 	op, _ := p["op"].(string)
 	switch op {
 	case "say":
@@ -416,6 +482,15 @@ func (g *Gateway) dispatchInbound(p map[string]any) {
 		text, _ := p["text"].(string)
 		if ch == "" || text == "" {
 			return
+		}
+		// Per-target outbound throttle — shared with the bouncer's
+		// PRIVMSG path. Bucket key is the target so a chatty user
+		// pestering one channel doesn't deny their other channels.
+		if throttle := g.bridge.OutboundThrottle(); throttle != nil {
+			if res := throttle.AllowWithReason(ch); !res.Allow {
+				g.rateLimited(ctx, c, ch, res.RetryAfter)
+				return
+			}
 		}
 		if err := g.sender.Send(&agent.OutboundEnvelope{
 			Connector:         "irc",
@@ -450,6 +525,10 @@ func (g *Gateway) dispatchInbound(p map[string]any) {
 		}
 	case "join":
 		if ch, _ := p["channel"].(string); ch != "" {
+			if allow, reason, kind := g.allowByPolicy(irc.CmdJoin); !allow {
+				g.denyAction(ctx, c, op, kind, reason)
+				return
+			}
 			_ = g.bridge.SendRaw(irc.CmdJoin + " " + ch)
 		}
 	case "part":
@@ -458,6 +537,10 @@ func (g *Gateway) dispatchInbound(p map[string]any) {
 		}
 	case "nick":
 		if n, _ := p["nick"].(string); n != "" {
+			if allow, reason, kind := g.allowByPolicy(irc.CmdNick); !allow {
+				g.denyAction(ctx, c, op, kind, reason)
+				return
+			}
 			_ = g.bridge.SendRaw(irc.CmdNick + " " + n)
 		}
 	case "mode":

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -23,17 +23,21 @@ import (
 // --- test doubles ----------------------------------------------------------
 
 type fakeBridge struct {
-	nick   string
-	state  *irc.ChannelState
-	sentMu sync.Mutex
-	sent   []string
+	nick     string
+	state    *irc.ChannelState
+	sentMu   sync.Mutex
+	sent     []string
+	limits   irc.ClientLimits
+	throttle *irc.Throttle
 }
 
 func newFakeBridge(nick string) *fakeBridge {
 	return &fakeBridge{nick: nick, state: irc.NewChannelState()}
 }
-func (f *fakeBridge) CurrentNick() string       { return f.nick }
-func (f *fakeBridge) State() *irc.ChannelState  { return f.state }
+func (f *fakeBridge) CurrentNick() string            { return f.nick }
+func (f *fakeBridge) State() *irc.ChannelState       { return f.state }
+func (f *fakeBridge) ClientLimits() irc.ClientLimits { return f.limits }
+func (f *fakeBridge) OutboundThrottle() *irc.Throttle { return f.throttle }
 func (f *fakeBridge) SendRaw(line string) error {
 	f.sentMu.Lock()
 	defer f.sentMu.Unlock()
@@ -993,4 +997,131 @@ func TestServerNoticeBufferTrimsAtCap(t *testing.T) {
 		}
 	}
 	assert.LessOrEqual(t, replayed, 100, "server log must be capped at serverLogCap")
+}
+
+// --- Operator-policy / throttle gates -------------------------------------
+
+func TestInboundNickDeniedWhenLocked(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	bridge.limits = irc.ClientLimits{NickLocked: true}
+
+	g, _, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})
+	defer td()
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	_ = readJSON(t, conn) // state
+
+	body, _ := json.Marshal(map[string]any{"op": "nick", "nick": "newnick"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	got := readJSON(t, conn)
+	assert.Equal(t, "policy_denied", got["op"])
+	assert.Equal(t, "nick", got["source_op"])
+	assert.Equal(t, "nick_locked", got["kind"])
+	assert.Contains(t, got["reason"].(string), "nick")
+
+	// Nothing forwarded to the bridge.
+	assert.Empty(t, bridge.Sent(),
+		"NICK must not flow upstream when ClientLimits.NickLocked is set")
+}
+
+func TestInboundJoinDeniedAtChannelCap(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	bridge.limits = irc.ClientLimits{MaxChannels: 2}
+	bridge.state.OnSelfJoin("#a")
+	bridge.state.OnSelfJoin("#b")
+
+	g, _, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})
+	defer td()
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	_ = readJSON(t, conn) // state
+
+	body, _ := json.Marshal(map[string]any{"op": "join", "channel": "#c"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	got := readJSON(t, conn)
+	assert.Equal(t, "policy_denied", got["op"])
+	assert.Equal(t, "channels", got["kind"])
+	assert.Contains(t, got["reason"].(string), "2")
+
+	assert.Empty(t, bridge.Sent(),
+		"JOIN must not flow upstream when MaxChannels is reached")
+}
+
+func TestInboundJoinAllowedBelowChannelCap(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	bridge.limits = irc.ClientLimits{MaxChannels: 5}
+	bridge.state.OnSelfJoin("#a")
+
+	g, _, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})
+	defer td()
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	_ = readJSON(t, conn) // state
+
+	body, _ := json.Marshal(map[string]any{"op": "join", "channel": "#b"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	require.Eventually(t, func() bool { return len(bridge.Sent()) == 1 },
+		time.Second, 10*time.Millisecond)
+	assert.Equal(t, "JOIN #b", bridge.Sent()[0])
+}
+
+func TestInboundSayRateLimitedEmitsRateLimitedEvent(t *testing.T) {
+	throttle, err := irc.NewThrottle(2, 30*time.Second, nil)
+	require.NoError(t, err)
+	bridge := newFakeBridge("turborg")
+	bridge.throttle = throttle
+
+	sender := &fakeSender{}
+	g, _, td := startGateway(t, newOptions(t, "p"), bridge, sender)
+	defer td()
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	_ = readJSON(t, conn) // state
+
+	// First 2 sends pass the throttle and produce the MESSAGE_SENT echo.
+	for i := 0; i < 2; i++ {
+		body, _ := json.Marshal(map[string]any{"op": "say", "channel": "#x", "text": "hi"})
+		require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+		got := readJSON(t, conn)
+		require.Equal(t, "message", got["op"], "send %d should produce a message echo", i+1)
+	}
+
+	// Third send hits the cap and gets a rate_limited event back.
+	body, _ := json.Marshal(map[string]any{"op": "say", "channel": "#x", "text": "hi"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+	got := readJSON(t, conn)
+	assert.Equal(t, "rate_limited", got["op"])
+	assert.Equal(t, "#x", got["target"])
+	assert.GreaterOrEqual(t, got["retry_after"].(float64), 1.0)
+
+	// Sender saw only the first two — the throttled call short-circuits
+	// before reaching agent.Sender.
+	assert.Len(t, sender.Outbound(), 2)
+}
+
+func TestInboundSayPerTargetThrottleScopesIndependently(t *testing.T) {
+	throttle, err := irc.NewThrottle(1, 30*time.Second, nil)
+	require.NoError(t, err)
+	bridge := newFakeBridge("turborg")
+	bridge.throttle = throttle
+
+	g, _, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})
+	defer td()
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	_ = readJSON(t, conn) // state
+
+	// #a uses its bucket.
+	bodyA, _ := json.Marshal(map[string]any{"op": "say", "channel": "#a", "text": "hi"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, bodyA))
+	require.Equal(t, "message", readJSON(t, conn)["op"])
+
+	// #b is a different bucket — should NOT be throttled.
+	bodyB, _ := json.Marshal(map[string]any{"op": "say", "channel": "#b", "text": "hi"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, bodyB))
+	require.Equal(t, "message", readJSON(t, conn)["op"],
+		"per-target scope: chatty user pestering #a must not lock out #b")
 }

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -214,6 +214,48 @@ func TestWSAuthAcceptsBearerHeader(t *testing.T) {
 	_ = conn.Close(websocket.StatusNormalClosure, "")
 }
 
+func TestWSAttachHookFiresOnSuccessfulHandshake(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		reasons []string
+	)
+	opts := newOptions(t, "secret")
+	opts.OnClientAttached = func(reason string) {
+		mu.Lock()
+		reasons = append(reasons, reason)
+		mu.Unlock()
+	}
+	g, _, td := startGateway(t, opts, newFakeBridge("turborg"), &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "secret")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(reasons) == 1 && reasons[0] == "ws_attach"
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestWSAttachHookSilentOnAuthFailure(t *testing.T) {
+	var fired atomic.Bool
+	opts := newOptions(t, "right-secret")
+	opts.OnClientAttached = func(_ string) { fired.Store(true) }
+	g, _, td := startGateway(t, opts, newFakeBridge("turborg"), &fakeSender{})
+	defer td()
+
+	url := "ws://" + g.Addr() + "/ws?token=wrong"
+	_, resp, err := websocket.Dial(context.Background(), url, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err)
+	// Give the auth-fail path enough time that any errant hook would fire.
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, fired.Load(), "auth failure must not fire the attach hook")
+}
+
 // --- state op on connect -----------------------------------------------
 
 func TestWSSendsStateOnConnect(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds optional operator-policy envs on `config.Settings` so a deployment can pin parts of the agent's behavior without code changes. Every new env defaults to "unrestricted" when absent, so existing deployments see no behavior change.

| Env | What it does |
|---|---|
| `TURBORG_ALLOWED_NETWORKS` | hostname allowlist for the IRC upstream; refuses to start if IRC_HOSTNAME is outside it |
| `TURBORG_MAX_CHANNELS` | channel-count cap (consumed by the bouncer command policy in a follow-up) |
| `TURBORG_NICK_LOCKED` | flag consumed by the bouncer command policy |
| `TURBORG_REALNAME_LOCKED` + `TURBORG_REALNAME_TEMPLATE` | overwrites `ircCfg.RealName` at boot |
| `TURBORG_MAX_CONNECTORS_PER_AGENT` | how many distinct connector types the agent will wire up |
| `TURBORG_OUTBOUND_MAX_PER_WINDOW` + `TURBORG_OUTBOUND_WINDOW_SECONDS` | per-target outbound message throttle |
| `TURBORG_LLM_*_TOKENS_PER_DAY`, `TURBORG_ALLOWED_LLM_MODELS` | per-day LLM token budgets + model allowlist |
| `TURBORG_CUSTOM_COMMANDS_MAX` | cap on the dynamic command registry |
| `TURBORG_OWNER_DM_NUDGE_EVERY` | owner DM after every N outbound messages |
| `TURBORG_PLAN` | free-form deployment label (informational) |

`runtime.Build` gains `applyOperatorPolicy` for cross-cutting checks the env-tag layer can't express:
- Rejects startup when `ircCfg.Hostname` is outside `ALLOWED_NETWORKS`
- Overwrites `ircCfg.RealName` when realname is locked + template is set

Both checks are no-ops when the corresponding policy env is unset.

`Settings.normalize()` cleans the allowlist / model list of stray whitespace and validates that windows are positive when their counterparts are set, that caps are non-negative.

## What's NOT in this PR

The runtime enforcement of caps that need a hook into the bouncer + outbound paths (channel-count rejection, `RATE_LIMITED` event, nick-lock policy from bouncer-attached clients) lands in a follow-up — this PR is just the env contract + boot-time validation + realname mutation.

LLM caps are validated and stored but not yet enforced at runtime because no LLM-backed commands currently live in turborg.

## Test plan

- [x] Unit tests cover: defaults are unrestricted, full env stack loads round-trip, allowlist trim, model-list trim, negative-LLM rejection, negative-channels rejection, negative-connectors-cap rejection, outbound-window-zero rejection, `HostnameAllowed` allow/deny matrix.
- [x] Runtime tests cover: hostname outside allowlist rejected at Build, hostname inside allowlist accepted, empty allowlist accepts any hostname, realname template overwrites at Build when locked, realname survives when lock unset, advisory template (lock unset) does NOT overwrite.
- [x] `make lint test cover-gate` green. Coverage: config 98.1%, runtime 93.0%, total 95.1% — above the per-package + total thresholds.