### PR TITLE
feat(statepush): state webhook emitter — debounced per-connector snapshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,3 +192,24 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 # Empty URL = disabled (no posts, no goroutines).
 # TURBORG_ACTIVITY_URL=http://observer.local/turborg/activity
 # TURBORG_ACTIVITY_TOKEN=...                              # sent as Authorization: Bearer ...
+
+
+# =============================================================================
+# State webhook (optional)
+# =============================================================================
+# Idempotent state mirror: the agent PUTs a full snapshot of its
+# authoritative per-connector state (current connection status,
+# joined channels with any cached +k keys, preferred nick) to the
+# configured webhook URL whenever that state changes. Receivers
+# overwrite-on-write — each PUT is the latest known truth. Pair this
+# with a status dashboard or supervisor that wants a live view of the
+# agent without parsing logs.
+#
+# Empty URL = disabled (no PUTs, no goroutine spawned).
+# TURBORG_STATE_WEBHOOK_URL=http://observer.local/turborg/state
+# TURBORG_STATE_WEBHOOK_TOKEN=...                         # sent as Authorization: Bearer ...
+#
+# Bursty changes (e.g. /join #a,#b,#c) are coalesced into a single
+# PUT via a debounce window. Default 250 ms; 0 disables the debounce.
+# Range 0..5000.
+# TURBORG_STATE_WEBHOOK_DEBOUNCE_MS=250

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -129,6 +129,29 @@ type Settings struct {
 	// ActivityToken is sent as a bearer Authorization header on every
 	// activity webhook POST. Optional.
 	ActivityToken string `env:"ACTIVITY_TOKEN"`
+
+	// StateWebhookURL is the endpoint the agent PUTs authoritative
+	// per-connector state to (current connection status, joined
+	// channels with any cached +k keys, preferred nick) whenever
+	// that state changes. Payload is an idempotent JSON snapshot —
+	// receivers overwrite-on-write. Empty = no PUTs, no goroutine
+	// spawned. Distinct from ACTIVITY_URL: that one carries
+	// fire-and-forget event signals; this one carries a full state
+	// mirror.
+	StateWebhookURL string `env:"STATE_WEBHOOK_URL"`
+
+	// StateWebhookToken is sent as a bearer Authorization header on
+	// every state-webhook PUT. Optional.
+	StateWebhookToken string `env:"STATE_WEBHOOK_TOKEN"`
+
+	// StateWebhookDebounceMs is the debounce window applied to the
+	// state-webhook emitter. A bursty client mutation (e.g.
+	// /join #a,#b,#c) coalesces into a single PUT so receivers see
+	// one snapshot per change, not one per channel. 0 disables the
+	// debounce (every state change fires immediately); the upper
+	// bound keeps a misconfigured value from making a dashboard
+	// view feel laggy.
+	StateWebhookDebounceMs int `env:"STATE_WEBHOOK_DEBOUNCE_MS" envDefault:"250"`
 }
 
 // Load parses TURBORG_* env vars into a Settings, normalizing the
@@ -149,6 +172,18 @@ func (s *Settings) normalize() error {
 	if s.CommandPrefix == "" {
 		return errors.New("config: COMMAND_PREFIX must not be empty")
 	}
+	if err := s.normalizeConnectors(); err != nil {
+		return err
+	}
+	if err := s.validatePolicyBounds(); err != nil {
+		return err
+	}
+	s.AllowedNetworks = trimDropEmpties(s.AllowedNetworks)
+	s.AllowedLLMModels = trimDropEmpties(s.AllowedLLMModels)
+	return nil
+}
+
+func (s *Settings) normalizeConnectors() error {
 	seen := map[string]bool{}
 	out := s.Connectors[:0]
 	for _, c := range s.Connectors {
@@ -163,9 +198,16 @@ func (s *Settings) normalize() error {
 		out = append(out, c)
 	}
 	s.Connectors = out
+	// Cap-exceeded branch will land once a second valid connector exists.
+	// Today the dedup loop above keeps len(s.Connectors) <= 1 with "irc"
+	// the only ValidConnectors entry, so a cap-vs-count compare is unreachable.
+	return nil
+}
 
-	// Plan-tier consistency. Hostname-vs-AllowedNetworks lives in
-	// runtime.Build (needs ircCfg).
+// validatePolicyBounds runs the numeric/range checks on operator-policy
+// fields. Each check is independent — the function fails on the first
+// error so the operator gets pointed at one problem at a time.
+func (s *Settings) validatePolicyBounds() error {
 	if s.OutboundMaxPerWindow > 0 && s.OutboundWindowSeconds <= 0 {
 		return errors.New("config: OUTBOUND_WINDOW_SECONDS must be > 0 when OUTBOUND_MAX_PER_WINDOW is set")
 	}
@@ -181,36 +223,24 @@ func (s *Settings) normalize() error {
 	if s.MaxConnectorsPerAgent < 0 {
 		return errors.New("config: MAX_CONNECTORS_PER_AGENT must be >= 0 (0 = unrestricted)")
 	}
-	// Cap-exceeded branch will land once a second valid connector exists.
-	// Today the dedup loop above keeps len(s.Connectors) <= 1 with "irc"
-	// the only ValidConnectors entry, so a cap-vs-count compare is unreachable.
-
-	// AllowedNetworks: trim entries, drop empties. The hostname check
-	// itself runs in runtime.Build.
-	if len(s.AllowedNetworks) > 0 {
-		cleaned := make([]string, 0, len(s.AllowedNetworks))
-		for _, n := range s.AllowedNetworks {
-			n = strings.TrimSpace(n)
-			if n != "" {
-				cleaned = append(cleaned, n)
-			}
-		}
-		s.AllowedNetworks = cleaned
+	if s.StateWebhookDebounceMs < 0 || s.StateWebhookDebounceMs > 5000 {
+		return errors.New("config: STATE_WEBHOOK_DEBOUNCE_MS must be in [0, 5000]")
 	}
-
-	// AllowedLLMModels: same trim-and-drop-empties pass.
-	if len(s.AllowedLLMModels) > 0 {
-		cleaned := make([]string, 0, len(s.AllowedLLMModels))
-		for _, m := range s.AllowedLLMModels {
-			m = strings.TrimSpace(m)
-			if m != "" {
-				cleaned = append(cleaned, m)
-			}
-		}
-		s.AllowedLLMModels = cleaned
-	}
-
 	return nil
+}
+
+func trimDropEmpties(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // HostnameAllowed reports whether the given upstream hostname satisfies

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -216,6 +216,27 @@ func TestNormalizeTrimsAllowedLLMModelsWhitespace(t *testing.T) {
 	assert.Equal(t, []string{"claude-sonnet-4-6", "claude-opus-4-7"}, s.AllowedLLMModels)
 }
 
+func TestNormalizeRejectsNegativeStateWebhookDebounce(t *testing.T) {
+	t.Setenv("TURBORG_STATE_WEBHOOK_DEBOUNCE_MS", "-1")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STATE_WEBHOOK_DEBOUNCE_MS")
+}
+
+func TestNormalizeRejectsExcessiveStateWebhookDebounce(t *testing.T) {
+	t.Setenv("TURBORG_STATE_WEBHOOK_DEBOUNCE_MS", "5001")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "STATE_WEBHOOK_DEBOUNCE_MS")
+}
+
+func TestStateWebhookDebounceDefault(t *testing.T) {
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, 250, s.StateWebhookDebounceMs,
+		"default debounce coalesces bursty channel mutations into one PUT")
+}
+
 func TestNormalizeTrimsAllowedNetworksWhitespace(t *testing.T) {
 	t.Setenv("TURBORG_ALLOWED_NETWORKS", " irc.libera.chat , , irc.oftc.net ")
 	s, err := config.Load()

--- a/internal/connector/irc/bouncer_detached_test.go
+++ b/internal/connector/irc/bouncer_detached_test.go
@@ -223,6 +223,26 @@ func TestPreferredNickConsumedOnNextRegister(t *testing.T) {
 	assert.Empty(t, conn.PreferredNick())
 }
 
+// TestSetPreferredNickFiresChangeHookOnlyOnRealChange covers the
+// change-detection inside SetPreferredNick: idempotent set-to-same
+// must not refire the hook, but every real value transition must.
+func TestSetPreferredNickFiresChangeHookOnlyOnRealChange(t *testing.T) {
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Nick:     "turborg",
+	}, nil, nil)
+
+	var calls int
+	conn.SetPreferredNickChangeHook(func() { calls++ })
+
+	conn.SetPreferredNick("alpha")
+	conn.SetPreferredNick("alpha") // no-op
+	conn.SetPreferredNick("beta")
+	conn.SetPreferredNick("") // back to empty also counts
+	conn.SetPreferredNick("") // no-op
+	assert.Equal(t, 3, calls)
+}
+
 // TestDetachedPrivmsgRejectionStillFlows confirms commit 2's PRIVMSG
 // reject path still works after the per-command dispatcher landed
 // (regression coverage for the refactor).

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -107,8 +107,9 @@ type Connector struct {
 	// during detached-state NICK handling so the supervisor's next
 	// register() uses the queued nick instead of settings.Nick.
 	// Cleared after the supervisor consumes it on the next handshake.
-	preferredNickMu sync.RWMutex
-	preferredNick   string
+	preferredNickMu       sync.RWMutex
+	preferredNick         string
+	preferredNickChangeCB func()
 
 	stopOnce sync.Once
 }
@@ -222,10 +223,29 @@ func (c *Connector) SetUpstreamWarnHook(hook func(serverReason string, dwell tim
 // upstream — the supervisor's next bringUp picks it up via
 // effectiveNick(). Passing the empty string clears any pending queued
 // nick.
+//
+// Fires the change callback (when one is installed via
+// SetPreferredNickChangeHook) when the stored value actually moves.
+// Repeated SetPreferredNick("x") calls with the same x don't refire.
 func (c *Connector) SetPreferredNick(nick string) {
 	c.preferredNickMu.Lock()
-	defer c.preferredNickMu.Unlock()
+	changed := c.preferredNick != nick
 	c.preferredNick = nick
+	cb := c.preferredNickChangeCB
+	c.preferredNickMu.Unlock()
+	if changed && cb != nil {
+		cb()
+	}
+}
+
+// SetPreferredNickChangeHook installs a callback fired whenever
+// SetPreferredNick changes the queued nick (no-op on calls that
+// leave it unchanged). Pass nil to disable. Used by the state-sync
+// emitter to learn when the snapshot's "nick" field needs re-pushing.
+func (c *Connector) SetPreferredNickChangeHook(hook func()) {
+	c.preferredNickMu.Lock()
+	defer c.preferredNickMu.Unlock()
+	c.preferredNickChangeCB = hook
 }
 
 // PreferredNick returns the currently-queued preferred nick, or empty

--- a/internal/connector/irc/upstream_state.go
+++ b/internal/connector/irc/upstream_state.go
@@ -191,6 +191,16 @@ func (m *UpstreamStateMachine) DurationIn() time.Duration {
 	return time.Since(m.enteredAt)
 }
 
+// EnteredAt returns the wall-clock time the machine entered its current
+// state. Snapshot consumers (state-mirror emitter, status dashboards)
+// use it to label the active state with an absolute timestamp rather
+// than a relative duration.
+func (m *UpstreamStateMachine) EnteredAt() time.Time {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.enteredAt
+}
+
 // Transition moves the machine to a new state and notifies subscribers.
 // Transitioning to the current state is a no-op (no subscriber fire, no
 // enteredAt reset) — keeps repeated "still transient" announcements from

--- a/internal/connector/irc/upstream_state_test.go
+++ b/internal/connector/irc/upstream_state_test.go
@@ -275,6 +275,19 @@ func TestUpstreamStateMachineDurationIn(t *testing.T) {
 	assert.Less(t, d, 5*time.Second)
 }
 
+func TestUpstreamStateMachineEnteredAtMovesOnTransition(t *testing.T) {
+	t.Parallel()
+	m := irc.NewUpstreamStateMachine(nil)
+	first := m.EnteredAt()
+	require.False(t, first.IsZero(), "EnteredAt is set at construction")
+
+	time.Sleep(10 * time.Millisecond)
+	m.Transition(irc.UpstreamStateConnecting)
+	second := m.EnteredAt()
+	assert.True(t, second.After(first),
+		"EnteredAt must advance on a real transition")
+}
+
 func TestUpstreamStateMachineSubscribeNilFnReturnsInertHandle(t *testing.T) {
 	t.Parallel()
 	m := irc.NewUpstreamStateMachine(nil)

--- a/internal/connector/irc/wanted.go
+++ b/internal/connector/irc/wanted.go
@@ -33,18 +33,40 @@ type WantedChannels struct {
 	mu       sync.RWMutex
 	channels map[string]WantedChannel // lowercased name → entry
 	order    []string                 // insertion order for deterministic replay
+
+	// onChange fires after every mutation that actually changed the set
+	// (a no-op Add of an already-present name with no new key, or a
+	// Remove of an absent name, does NOT fire). Read under mu, called
+	// outside the lock so handlers can call back into the set without
+	// deadlocking.
+	onChange func()
 }
 
 // NewWantedChannels returns a set seeded with the given channel list.
 // Each seed entry starts with an empty key — the operator-configured
 // list never carries credentials. Pass nil/empty for an empty starting
 // set.
+//
+// The OnChange callback is not fired for seed entries — seeding is
+// startup wiring, not a runtime mutation, and observers shouldn't see
+// a flurry of "channel added" events for what is effectively the
+// initial state.
 func NewWantedChannels(seed []string) *WantedChannels {
 	w := &WantedChannels{channels: map[string]WantedChannel{}}
 	for _, name := range seed {
 		w.Add(name, "")
 	}
 	return w
+}
+
+// SetOnChange installs a callback fired after every mutation that
+// changes the set. Pass nil to disable. Must be called after seeding
+// (typically right after NewWantedChannels) so seed entries don't
+// fire the callback. Concurrent-safe with Add/Remove.
+func (w *WantedChannels) SetOnChange(fn func()) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.onChange = fn
 }
 
 // Add inserts or updates an entry. The "update" semantics are biased
@@ -55,26 +77,40 @@ func NewWantedChannels(seed []string) *WantedChannels {
 //
 // First insert wins on case preservation — repeated Adds keep the
 // originally-cased Name so display matches what the user first typed.
+//
+// Fires the OnChange callback when (and only when) the set actually
+// changed: a fresh insert, or a key update on an existing entry.
+// Repeated no-op Adds don't fire — keeps observer chatter proportional
+// to real state changes.
 func (w *WantedChannels) Add(name, key string) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return
 	}
 	w.mu.Lock()
-	defer w.mu.Unlock()
+	changed := false
 	lc := strings.ToLower(name)
 	if existing, ok := w.channels[lc]; ok {
-		if key != "" {
+		if key != "" && existing.Key != key {
 			existing.Key = key
 			w.channels[lc] = existing
+			changed = true
 		}
-		return
+	} else {
+		w.channels[lc] = WantedChannel{Name: name, Key: key}
+		w.order = append(w.order, lc)
+		changed = true
 	}
-	w.channels[lc] = WantedChannel{Name: name, Key: key}
-	w.order = append(w.order, lc)
+	cb := w.onChange
+	w.mu.Unlock()
+	if changed && cb != nil {
+		cb()
+	}
 }
 
 // Remove drops an entry. No-op when the entry isn't present.
+// Fires the OnChange callback when (and only when) an entry was
+// actually removed.
 func (w *WantedChannels) Remove(name string) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -82,8 +118,8 @@ func (w *WantedChannels) Remove(name string) {
 	}
 	lc := strings.ToLower(name)
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	if _, ok := w.channels[lc]; !ok {
+		w.mu.Unlock()
 		return
 	}
 	delete(w.channels, lc)
@@ -92,6 +128,11 @@ func (w *WantedChannels) Remove(name string) {
 			w.order = append(w.order[:i], w.order[i+1:]...)
 			break
 		}
+	}
+	cb := w.onChange
+	w.mu.Unlock()
+	if cb != nil {
+		cb()
 	}
 }
 

--- a/internal/connector/irc/wanted_test.go
+++ b/internal/connector/irc/wanted_test.go
@@ -88,6 +88,54 @@ func TestWantedChannelsRemoveMissingIsNoOp(t *testing.T) {
 	assert.Equal(t, 1, w.Len())
 }
 
+func TestWantedChannelsOnChangeFiresOnInsertAndRemove(t *testing.T) {
+	t.Parallel()
+	w := irc.NewWantedChannels(nil)
+	var calls int
+	w.SetOnChange(func() { calls++ })
+
+	w.Add("#a", "")
+	w.Add("#b", "")
+	w.Remove("#a")
+	assert.Equal(t, 3, calls, "fresh insert + insert + remove = 3 fires")
+}
+
+func TestWantedChannelsOnChangeFiresOnKeyRotationOnly(t *testing.T) {
+	t.Parallel()
+	w := irc.NewWantedChannels(nil)
+	var calls int
+	w.SetOnChange(func() { calls++ })
+
+	w.Add("#a", "old") // fresh insert → fires
+	w.Add("#a", "old") // same key → no fire
+	w.Add("#a", "")    // empty key with existing entry → no fire (preserves stored key)
+	w.Add("#a", "new") // key rotation → fires
+	assert.Equal(t, 2, calls)
+}
+
+func TestWantedChannelsOnChangeNotFiredForSeedEntries(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	// Seed during construction — callback isn't installed yet, so
+	// seed entries don't fire. Install the callback *after*
+	// construction (the documented contract).
+	w := irc.NewWantedChannels([]string{"#a", "#b"})
+	w.SetOnChange(func() { calls++ })
+	assert.Equal(t, 0, calls)
+	// Sanity: a post-seed mutation still fires.
+	w.Add("#c", "")
+	assert.Equal(t, 1, calls)
+}
+
+func TestWantedChannelsOnChangeNotFiredOnNoOpRemove(t *testing.T) {
+	t.Parallel()
+	w := irc.NewWantedChannels(nil)
+	var calls int
+	w.SetOnChange(func() { calls++ })
+	w.Remove("#nothere")
+	assert.Equal(t, 0, calls)
+}
+
 func TestWantedChannelsConcurrentMutationIsSafe(t *testing.T) {
 	t.Parallel()
 	w := irc.NewWantedChannels(nil)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -26,6 +26,7 @@ import (
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/llm/anthropic"
+	"github.com/turborg/turborg/internal/statepush"
 	"github.com/turborg/turborg/internal/version"
 	"github.com/turborg/turborg/internal/web"
 )
@@ -41,11 +42,12 @@ const AskSystemPrompt = "You are turborg, an IRC chatbot. Keep replies short and
 // connectors are added; built-in commands are registered; the owner +
 // throttle guard is installed.
 type Built struct {
-	Agent    *agent.Agent
-	IRC      *irc.Connector
-	Gateway  *web.Gateway
-	LLM      llm.Provider       // nil when Anthropic is not configured
-	Activity *activity.Notifier // never nil; no-op when ACTIVITY_URL is unset
+	Agent        *agent.Agent
+	IRC          *irc.Connector
+	Gateway      *web.Gateway
+	LLM          llm.Provider        // nil when Anthropic is not configured
+	Activity     *activity.Notifier  // never nil; no-op when ACTIVITY_URL is unset
+	StatePush    *statepush.Emitter  // never nil; inert no-op when STATE_WEBHOOK_URL is unset
 }
 
 // Build wires the agent + connectors + gateway from settings. Callers
@@ -108,6 +110,21 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		ircConn.SetOwnerNudge(nudge)
 	}
 
+	// State-webhook emitter. Mirrors authoritative per-connector
+	// state (current connection status + joined channels + preferred
+	// nick) to the configured STATE_WEBHOOK_URL endpoint whenever
+	// that state changes. When STATE_WEBHOOK_URL is unset the
+	// emitter is an inert no-op (no goroutine, no PUTs); the
+	// snapshot builder closure is harmless either way.
+	stateClient := statepush.NewClient(s.StateWebhookURL, s.StateWebhookToken, log)
+	stateEmitter := statepush.NewEmitter(
+		stateClient,
+		buildIRCSnapshot(ircConn),
+		time.Duration(s.StateWebhookDebounceMs)*time.Millisecond,
+		log,
+	)
+	wireStatePushEmitter(ircConn, stateEmitter)
+
 	a.AddConnector(ircConn)
 
 	if len(s.Connectors) > 1 {
@@ -124,7 +141,13 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	RegisterBuiltinCommands(a, provider)
 	a.Commands.SetGuard(BuildCommandGuard(s))
 
-	built := &Built{Agent: a, IRC: ircConn, LLM: provider, Activity: notifier}
+	built := &Built{
+		Agent:     a,
+		IRC:       ircConn,
+		LLM:       provider,
+		Activity:  notifier,
+		StatePush: stateEmitter,
+	}
 
 	if s.GatewayEnabled() {
 		gw, err := buildGateway(s, ircConn, a, log, notifier)
@@ -303,6 +326,55 @@ func BuildCommandGuard(s *config.Settings) agent.CommandGuard {
 	}
 }
 
+// buildIRCSnapshot returns a snapshot builder closed over ircConn. The
+// builder is called by the state-webhook emitter each time the
+// debounce window fires; the value reflects the connector's
+// authoritative state at that moment.
+//
+// Nick precedence: the queued preferred-nick wins when non-empty (it
+// represents the user's stated intent for the next registration);
+// fall through to the live current-nick otherwise.
+func buildIRCSnapshot(ircConn *irc.Connector) statepush.SnapshotBuilder {
+	return func() statepush.Snapshot {
+		machine := ircConn.UpstreamState()
+		nick := ircConn.PreferredNick()
+		if nick == "" {
+			nick = ircConn.CurrentNick()
+		}
+		wanted := ircConn.WantedChannels().Snapshot()
+		channels := make([]statepush.ChannelSnapshot, 0, len(wanted))
+		for _, w := range wanted {
+			channels = append(channels, statepush.NewChannelSnapshot(w.Name, w.Key))
+		}
+		return statepush.Snapshot{
+			Connectors: map[string]statepush.ConnectorSnapshot{
+				ircConn.Name(): {
+					State:    string(machine.State()),
+					Since:    machine.EnteredAt().UTC(),
+					Channels: channels,
+					Nick:     nick,
+				},
+			},
+		}
+	}
+}
+
+// wireStatePushEmitter attaches the emitter's NotifyChange to the
+// three authoritative-state sources on the IRC connector: state-
+// machine transitions, wanted-channels mutations, and preferred-nick
+// changes. Safe to call even when the emitter is inert (no-op
+// NotifyChange is fine, and the subscriptions register but never
+// fire anything useful).
+func wireStatePushEmitter(ircConn *irc.Connector, emitter *statepush.Emitter) {
+	if ircConn == nil || emitter == nil {
+		return
+	}
+	notify := emitter.NotifyChange
+	ircConn.UpstreamState().Subscribe(func(irc.UpstreamStateChange) { notify() })
+	ircConn.WantedChannels().SetOnChange(notify)
+	ircConn.SetPreferredNickChangeHook(notify)
+}
+
 // LoadIRCSettings wraps irc.LoadSettings with a helpful error that
 // names the TURBORG_IRC_ prefix the user is expected to set.
 func LoadIRCSettings() (*irc.Settings, error) {
@@ -320,6 +392,9 @@ func LoadIRCSettings() (*irc.Settings, error) {
 // returning (cleanly or with an error) cancels the shared context, so
 // the other unwinds in milliseconds. Returns the first non-nil error.
 func Run(ctx context.Context, b *Built) error {
+	if b.StatePush != nil {
+		defer b.StatePush.Stop()
+	}
 	if b.Gateway == nil {
 		return b.Agent.Run(ctx)
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -562,6 +562,33 @@ func TestBuildWiresOwnerNudgeWhenConfigured(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBuildStatePushInertWhenWebhookURLUnset(t *testing.T) {
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.StatePush, "StatePush field is always non-nil")
+	// Inert emitter must not spawn a goroutine; calling NotifyChange
+	// + Stop on it is safe.
+	b.StatePush.NotifyChange()
+	b.StatePush.Stop()
+}
+
+func TestBuildStatePushEnabledWhenWebhookURLSet(t *testing.T) {
+	s := &config.Settings{
+		CommandPrefix:          "!",
+		StateWebhookURL:        "http://obs/c/abc/state",
+		StateWebhookToken:      "shh",
+		StateWebhookDebounceMs: 1,
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.StatePush)
+	// Goroutine started: Stop must be called to keep goleak clean.
+	b.StatePush.Stop()
+}
+
 func TestBuildIgnoresRealnameTemplateWithoutLock(t *testing.T) {
 	// RealnameTemplate set but Locked=false: the template is purely
 	// advisory and must not overwrite the user's choice. Catches the

--- a/internal/runtime/state_push_test.go
+++ b/internal/runtime/state_push_test.go
@@ -1,0 +1,176 @@
+package runtime_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/turborg/turborg/internal/config"
+	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/runtime"
+	"github.com/turborg/turborg/internal/statepush"
+)
+
+// captureServer records every PUT body the test server received.
+type captureServer struct {
+	mu     sync.Mutex
+	bodies [][]byte
+	paths  []string
+	auths  []string
+}
+
+func (c *captureServer) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		c.mu.Lock()
+		c.bodies = append(c.bodies, body)
+		c.paths = append(c.paths, r.URL.Path)
+		c.auths = append(c.auths, r.Header.Get("Authorization"))
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func (c *captureServer) bodyCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.bodies)
+}
+
+func (c *captureServer) lastSnapshot() (statepush.Snapshot, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.bodies) == 0 {
+		return statepush.Snapshot{}, ""
+	}
+	var snap statepush.Snapshot
+	_ = json.Unmarshal(c.bodies[len(c.bodies)-1], &snap)
+	return snap, c.paths[len(c.paths)-1]
+}
+
+// TestStatePushWiringEndToEnd verifies the full flow: runtime.Build
+// constructs an emitter, wires it to the IRC connector's three state
+// sources (state machine, wanted-channels, preferred-nick), and each
+// mutation produces a PUT against the configured webhook URL with
+// the bearer auth applied.
+func TestStatePushWiringEndToEnd(t *testing.T) {
+	cap := &captureServer{}
+	server := httptest.NewServer(cap.handler())
+	t.Cleanup(server.Close)
+
+	s := &config.Settings{
+		CommandPrefix:          "!",
+		StateWebhookURL:        server.URL + "/c/abc/state",
+		StateWebhookToken:      "tok",
+		StateWebhookDebounceMs: 0, // zero = fire immediately
+	}
+	ircCfg := &irc.Settings{
+		Hostname: "fake",
+		Nick:     "turborg",
+		Channels: []string{"#seeded"},
+	}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.StatePush)
+	t.Cleanup(b.StatePush.Stop)
+
+	// Mutate wanted-channels — fires NotifyChange.
+	b.IRC.WantedChannels().Add("#runtime-added", "secret")
+
+	require.Eventually(t, func() bool { return cap.bodyCount() >= 1 },
+		2*time.Second, 5*time.Millisecond,
+		"expected at least one PUT after wanted-channel mutation")
+
+	snap, path := cap.lastSnapshot()
+	assert.Equal(t, "/c/abc/state", path,
+		"PUT lands at the configured STATE_WEBHOOK_URL path")
+	require.Contains(t, snap.Connectors, "irc")
+	conn := snap.Connectors["irc"]
+	assert.NotEmpty(t, conn.State,
+		"snapshot state must reflect the connector's state machine")
+
+	// Check the bearer token reached the server.
+	cap.mu.Lock()
+	lastAuth := cap.auths[len(cap.auths)-1]
+	cap.mu.Unlock()
+	assert.Equal(t, "Bearer tok", lastAuth)
+
+	// Trigger a preferred-nick change → another PUT, this time with
+	// the queued nick reflected.
+	b.IRC.SetPreferredNick("queued-nick")
+	require.Eventually(t, func() bool {
+		snap, _ := cap.lastSnapshot()
+		c, ok := snap.Connectors["irc"]
+		return ok && c.Nick == "queued-nick"
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// State-machine transition → another PUT, with the new state.
+	b.IRC.UpstreamState().Transition(irc.UpstreamStateConnecting)
+	require.Eventually(t, func() bool {
+		snap, _ := cap.lastSnapshot()
+		c, ok := snap.Connectors["irc"]
+		return ok && c.State == string(irc.UpstreamStateConnecting)
+	}, 2*time.Second, 5*time.Millisecond)
+}
+
+// TestStatePushChannelKeyNullableEncoding verifies the wire-level
+// distinction between "no key" (encoded as JSON null) and an
+// explicit key — the receiver uses this to format JOIN replays.
+func TestStatePushChannelKeyNullableEncoding(t *testing.T) {
+	cap := &captureServer{}
+	server := httptest.NewServer(cap.handler())
+	t.Cleanup(server.Close)
+
+	s := &config.Settings{
+		CommandPrefix:          "!",
+		StateWebhookURL:        server.URL + "/state",
+		StateWebhookDebounceMs: 0,
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	t.Cleanup(b.StatePush.Stop)
+
+	b.IRC.WantedChannels().Add("#nokey", "")
+	b.IRC.WantedChannels().Add("#keyed", "hunter2")
+
+	require.Eventually(t, func() bool { return cap.bodyCount() >= 1 },
+		2*time.Second, 5*time.Millisecond)
+
+	// The last PUT body should have both channels with the right
+	// key encoding.
+	cap.mu.Lock()
+	lastBody := cap.bodies[len(cap.bodies)-1]
+	cap.mu.Unlock()
+	assert.Contains(t, string(lastBody), `"name":"#nokey","key":null`)
+	assert.Contains(t, string(lastBody), `"name":"#keyed","key":"hunter2"`)
+}
+
+// TestStatePushStopReleasesGoroutine confirms the emitter's
+// background goroutine terminates when StatePush.Stop fires. A leak
+// here would surface as a hung shutdown in production, since the
+// CLI's defer Stop chain would never return.
+func TestStatePushStopReleasesGoroutine(t *testing.T) {
+	cap := &captureServer{}
+	server := httptest.NewServer(cap.handler())
+	t.Cleanup(server.Close)
+
+	s := &config.Settings{
+		CommandPrefix:          "!",
+		StateWebhookURL:        server.URL + "/state",
+		StateWebhookDebounceMs: 1,
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+
+	b.IRC.WantedChannels().Add("#x", "")
+	b.StatePush.Stop()
+}

--- a/internal/statepush/client.go
+++ b/internal/statepush/client.go
@@ -1,0 +1,209 @@
+// Package statepush holds the HTTP plumbing turborg uses to mirror
+// authoritative per-connector state to a configured webhook endpoint.
+// The contract is documented at the env-var level — operators point
+// TURBORG_STATE_WEBHOOK_URL at any HTTP receiver that wants an
+// idempotent overwrite-on-write view of the agent's current state.
+//
+// Two concerns live here:
+//
+//   - Client: the shared HTTP primitive (PUT with bearer auth, JSON
+//     body, retry policy). Future emitters that need the same
+//     idempotent-overwrite semantics can reuse it instead of
+//     reimplementing the retry/auth/timeout dance.
+//   - Emitter: the debounced per-connector snapshot pusher built on
+//     top of Client. Subscribes to the connector's state machine,
+//     wanted-channels set, and preferred-nick slot, coalescing
+//     bursts into a single PUT.
+//
+// Both surfaces are no-ops when no webhook URL is configured —
+// self-host operators who don't run an observer see zero side
+// effects.
+package statepush
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HTTPDoer is the minimal slice of *http.Client the client consumes.
+// Pulled out so tests can install a stub without spinning a real
+// server.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// defaultHTTPTimeout caps a single PUT attempt. Retries within the
+// retry policy each get their own fresh timeout — the overall
+// worst-case wall time is roughly attempts*defaultHTTPTimeout +
+// sum(backoff).
+const defaultHTTPTimeout = 5 * time.Second
+
+// retryBackoffs is the per-retry sleep between attempts on transient
+// failure. Two retries → three total attempts (initial + 2). The
+// policy is "give a flapping observer two short chances and then
+// drop"; the next change will fire a fresh PUT anyway, so dropping
+// a stale snapshot is safe.
+var retryBackoffs = []time.Duration{1 * time.Second, 2 * time.Second}
+
+// Client posts JSON bodies to a configured webhook URL with bearer
+// auth and a small retry policy. Construct one per emitter (or share
+// — Put is safe for concurrent use).
+type Client struct {
+	url   string
+	token string
+	http  HTTPDoer
+	log   *slog.Logger
+
+	// authErrLogMu / lastAuthErrLog rate-limit the warning emitted on
+	// 401/403 responses so a misconfigured token doesn't flood the log
+	// with one line per PUT attempt for the lifetime of the process.
+	authErrLogMu   sync.Mutex
+	lastAuthErrLog time.Time
+}
+
+// NewClient wires a client to the given webhook URL. token is sent
+// as a bearer Authorization header when non-empty. A nil log
+// defaults to slog.Default. The internal *http.Client uses
+// defaultHTTPTimeout per attempt; install an HTTPDoer via
+// SetHTTPClient for tests that want to capture requests.
+func NewClient(url, token string, log *slog.Logger) *Client {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Client{
+		url:   url,
+		token: token,
+		http:  &http.Client{Timeout: defaultHTTPTimeout},
+		log:   log,
+	}
+}
+
+// SetHTTPClient swaps the underlying HTTP doer. Used by tests;
+// production callers leave the default *http.Client in place.
+func (c *Client) SetHTTPClient(d HTTPDoer) {
+	if c == nil {
+		return
+	}
+	c.http = d
+}
+
+// URL returns the webhook URL the client posts to. Useful for tests
+// and for log-line context.
+func (c *Client) URL() string {
+	if c == nil {
+		return ""
+	}
+	return c.url
+}
+
+// Put marshals body to JSON and pushes it to the configured webhook
+// with the configured retry policy. Returns nil on success (2xx) or
+// on a non-retryable 4xx (logged and treated as "delivered" so the
+// caller doesn't fall into a tight retry loop on a misconfigured
+// observer). Returns the last error after retries are exhausted on
+// transient failures.
+//
+// ctx bounds the whole attempt sequence: passing ctx.Done() shortens
+// the wait between retries.
+func (c *Client) Put(ctx context.Context, body any) error {
+	if c == nil || c.url == "" {
+		return nil
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("statepush: marshal: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= len(retryBackoffs); attempt++ {
+		if attempt > 0 {
+			sleep := retryBackoffs[attempt-1]
+			t := time.NewTimer(sleep)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return ctx.Err()
+			case <-t.C:
+			}
+		}
+		done, err := c.attempt(ctx, buf)
+		if done {
+			return err
+		}
+		lastErr = err
+	}
+	c.log.Warn("state webhook PUT dropped after retries",
+		"url", c.url,
+		"err", lastErr,
+	)
+	return lastErr
+}
+
+// attempt fires a single PUT. Returns (done=true, nil) on a
+// successful 2xx, (done=true, err) on a non-retryable response,
+// (done=false, err) on a transient error worth retrying.
+func (c *Client) attempt(ctx context.Context, body []byte) (bool, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, defaultHTTPTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPut, c.url, bytes.NewReader(body))
+	if err != nil {
+		// Bad URL or context-level failure — not retryable.
+		return true, fmt.Errorf("statepush: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		// Treat transport failures (including request-context timeout)
+		// as transient — the next retry might succeed.
+		if errors.Is(err, context.Canceled) {
+			return true, err
+		}
+		return false, fmt.Errorf("statepush: transport: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		// Misconfigured token or stale URL — retrying won't help.
+		// Rate-limit the log to once per minute so a chronically
+		// misconfigured deployment doesn't drown its log stream.
+		c.logAuthError(resp.StatusCode)
+		return true, fmt.Errorf("statepush: auth rejected with status %d", resp.StatusCode)
+	}
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		// Other 4xx — payload was malformed or endpoint refused.
+		// Log and treat as delivered so we don't tight-loop.
+		c.log.Warn("state webhook PUT non-retryable response",
+			"url", c.url,
+			"status", resp.StatusCode,
+		)
+		return true, fmt.Errorf("statepush: rejected with status %d", resp.StatusCode)
+	}
+	// 5xx — retry.
+	return false, fmt.Errorf("statepush: server error %d", resp.StatusCode)
+}
+
+func (c *Client) logAuthError(status int) {
+	c.authErrLogMu.Lock()
+	defer c.authErrLogMu.Unlock()
+	now := time.Now()
+	if now.Sub(c.lastAuthErrLog) < time.Minute {
+		return
+	}
+	c.lastAuthErrLog = now
+	c.log.Warn("state webhook auth rejected",
+		"url", c.url,
+		"status", status,
+	)
+}

--- a/internal/statepush/client_test.go
+++ b/internal/statepush/client_test.go
@@ -1,0 +1,249 @@
+package statepush_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/turborg/turborg/internal/statepush"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestClient_PutSendsJSONWithBearer(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		bodies [][]byte
+		auths  []string
+		paths  []string
+		ctypes []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, body)
+		auths = append(auths, r.Header.Get("Authorization"))
+		paths = append(paths, r.URL.Path)
+		ctypes = append(ctypes, r.Header.Get("Content-Type"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	c := statepush.NewClient(server.URL+"/state", "secret", nil)
+	err := c.Put(context.Background(), map[string]string{"hello": "world"})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, bodies, 1)
+	assert.Equal(t, "Bearer secret", auths[0])
+	assert.Equal(t, "/state", paths[0])
+	assert.Equal(t, "application/json", ctypes[0])
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(bodies[0], &got))
+	assert.Equal(t, "world", got["hello"])
+}
+
+func TestClient_PutNoAuthHeaderWhenTokenEmpty(t *testing.T) {
+	var auth atomic.Value
+	auth.Store("")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	c := statepush.NewClient(server.URL, "", nil)
+	require.NoError(t, c.Put(context.Background(), map[string]string{"x": "y"}))
+	assert.Empty(t, auth.Load().(string))
+}
+
+func TestClient_PutIsNoOpWhenURLEmpty(t *testing.T) {
+	c := statepush.NewClient("", "", nil)
+	// Must not error, must not panic.
+	require.NoError(t, c.Put(context.Background(), struct{}{}))
+}
+
+func TestClient_PutIsNoOpOnNilReceiver(t *testing.T) {
+	var c *statepush.Client
+	require.NoError(t, c.Put(context.Background(), struct{}{}))
+	assert.Empty(t, c.URL())
+}
+
+// stubDoer captures every Do attempt and returns canned responses.
+type stubDoer struct {
+	mu       sync.Mutex
+	calls    int
+	statuses []int // pulled in order; last value persists once exhausted
+	errs     []error
+	lastBody []byte
+}
+
+func (s *stubDoer) Do(req *http.Request) (*http.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if req.Body != nil {
+		s.lastBody, _ = io.ReadAll(req.Body)
+	}
+	var err error
+	if len(s.errs) > 0 {
+		err = s.errs[0]
+		if len(s.errs) > 1 {
+			s.errs = s.errs[1:]
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	status := http.StatusOK
+	if len(s.statuses) > 0 {
+		status = s.statuses[0]
+		if len(s.statuses) > 1 {
+			s.statuses = s.statuses[1:]
+		}
+	}
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(http.NoBody),
+	}, nil
+}
+
+func (s *stubDoer) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func TestClient_PutRetriesTransientFailures(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})()
+
+	doer := &stubDoer{statuses: []int{500, 500, 204}}
+	c := statepush.NewClient("http://obs/state", "", nil)
+	c.SetHTTPClient(doer)
+
+	require.NoError(t, c.Put(context.Background(), struct{}{}))
+	assert.Equal(t, 3, doer.count())
+}
+
+func TestClient_PutGivesUpAfterTwoRetries(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})()
+
+	doer := &stubDoer{statuses: []int{500, 502, 503}}
+	c := statepush.NewClient("http://obs/state", "", nil)
+	c.SetHTTPClient(doer)
+
+	err := c.Put(context.Background(), struct{}{})
+	require.Error(t, err)
+	assert.Equal(t, 3, doer.count())
+}
+
+func TestClient_PutDoesNotRetry4xx(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})()
+
+	doer := &stubDoer{statuses: []int{http.StatusBadRequest}}
+	c := statepush.NewClient("http://obs/state", "", nil)
+	c.SetHTTPClient(doer)
+
+	err := c.Put(context.Background(), struct{}{})
+	require.Error(t, err)
+	assert.Equal(t, 1, doer.count())
+}
+
+func TestClient_PutDoesNotRetryAuthFailure(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})()
+
+	doer := &stubDoer{statuses: []int{http.StatusUnauthorized}}
+	c := statepush.NewClient("http://obs/state", "stale", nil)
+	c.SetHTTPClient(doer)
+
+	err := c.Put(context.Background(), struct{}{})
+	require.Error(t, err)
+	assert.Equal(t, 1, doer.count())
+}
+
+func TestClient_PutRetriesTransportErrors(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})()
+
+	doer := &stubDoer{
+		errs:     []error{errStub("transport down"), errStub("transport down"), nil},
+		statuses: []int{200, 200, 204},
+	}
+	c := statepush.NewClient("http://obs/state", "", nil)
+	c.SetHTTPClient(doer)
+
+	require.NoError(t, c.Put(context.Background(), struct{}{}))
+	assert.Equal(t, 3, doer.count())
+}
+
+func TestClient_PutHonorsContextCancel(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{
+		50 * time.Millisecond,
+		50 * time.Millisecond,
+	})()
+
+	doer := &stubDoer{statuses: []int{500, 500, 500}}
+	c := statepush.NewClient("http://obs/state", "", nil)
+	c.SetHTTPClient(doer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	err := c.Put(ctx, struct{}{})
+	require.Error(t, err)
+	// Should bail after the first 500 instead of finishing all 3 attempts.
+	assert.LessOrEqual(t, doer.count(), 2)
+}
+
+func TestClient_SetHTTPClientOnNilReceiverIsSafe(t *testing.T) {
+	var c *statepush.Client
+	c.SetHTTPClient(&stubDoer{})
+}
+
+func TestClient_AuthErrorLogRateLimited(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})()
+
+	// Two consecutive auth rejections within a minute should log only
+	// once (the second falls under the per-minute rate limit). The test
+	// asserts the second call still returns an error and doesn't crash.
+	doer := &stubDoer{statuses: []int{http.StatusUnauthorized, http.StatusForbidden}}
+	c := statepush.NewClient("http://obs/state", "stale", nil)
+	c.SetHTTPClient(doer)
+
+	require.Error(t, c.Put(context.Background(), struct{}{}))
+	require.Error(t, c.Put(context.Background(), struct{}{}))
+	assert.Equal(t, 2, doer.count())
+}
+
+func TestClient_PutContextCancelDuringTransport(t *testing.T) {
+	defer statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})()
+
+	doer := &stubDoer{errs: []error{context.Canceled}}
+	c := statepush.NewClient("http://obs/state", "", nil)
+	c.SetHTTPClient(doer)
+
+	err := c.Put(context.Background(), struct{}{})
+	require.Error(t, err)
+	// Context-canceled mid-transport is treated as a terminal cancel,
+	// not a retryable transport blip — exactly one attempt fires.
+	assert.Equal(t, 1, doer.count())
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/internal/statepush/export_test.go
+++ b/internal/statepush/export_test.go
@@ -1,0 +1,22 @@
+package statepush
+
+import (
+	"testing"
+	"time"
+)
+
+// OverrideBackoffsForTesting swaps the package-level retry-backoff
+// schedule for the duration of a test. Returns a restore func; pair
+// it with a `defer restore()` so the production schedule comes back
+// before the next test runs.
+//
+// Lives in this file (only built under `go test`) so production
+// builds can't reach the override. Exported because external test
+// packages (statepush_test) need to call it across the package
+// boundary.
+func OverrideBackoffsForTesting(t *testing.T, replacement []time.Duration) func() {
+	t.Helper()
+	original := retryBackoffs
+	retryBackoffs = replacement
+	return func() { retryBackoffs = original }
+}

--- a/internal/statepush/state_emitter.go
+++ b/internal/statepush/state_emitter.go
@@ -1,0 +1,226 @@
+package statepush
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// defaultDebounce is the debounce window applied to bursty state
+// changes — a /join #a,#b,#c,#d,#e fans into one PUT, not five. 0
+// disables the debounce (every NotifyChange fires immediately, useful
+// in tests).
+const defaultDebounce = 250 * time.Millisecond
+
+// SnapshotBuilder returns the authoritative state snapshot to send.
+// Called inside the emitter goroutine immediately before the PUT —
+// the returned value is the latest known truth at that moment.
+type SnapshotBuilder func() Snapshot
+
+// Snapshot is the per-emit payload shape. Keys in the connectors map
+// are connector names ("irc"); values are the per-connector state.
+//
+// Wire shape:
+//
+//	{
+//	  "connectors": {
+//	    "irc": {
+//	      "state": "registered",
+//	      "since": "2026-05-17T15:30:00Z",
+//	      "channels": [{"name": "#x", "key": null}, ...],
+//	      "nick": "stefan"
+//	    }
+//	  }
+//	}
+type Snapshot struct {
+	Connectors map[string]ConnectorSnapshot `json:"connectors"`
+}
+
+// ConnectorSnapshot describes one connector's authoritative state.
+// Channels is always non-nil on the wire (empty slice → []), nick is
+// always a string (empty when neither preferred nor live is known).
+// state is the string form of the connector's state machine value.
+// since is an ISO-8601 UTC timestamp.
+type ConnectorSnapshot struct {
+	State    string            `json:"state"`
+	Since    time.Time         `json:"since"`
+	Channels []ChannelSnapshot `json:"channels"`
+	Nick     string            `json:"nick"`
+}
+
+// ChannelSnapshot is one wanted-channel entry. Key is nullable on the
+// wire so receivers can distinguish "no key" (channel has no +k) from
+// "explicit empty key" — encoded as *string so empty becomes JSON
+// null rather than "".
+type ChannelSnapshot struct {
+	Name string  `json:"name"`
+	Key  *string `json:"key"`
+}
+
+// NewChannelSnapshot is a helper that constructs a ChannelSnapshot
+// with the JSON-null semantics: empty key → Key field is nil → encoded
+// as `"key": null`. Non-empty key → encoded as `"key": "<value>"`.
+func NewChannelSnapshot(name, key string) ChannelSnapshot {
+	out := ChannelSnapshot{Name: name}
+	if key != "" {
+		k := key
+		out.Key = &k
+	}
+	return out
+}
+
+// Emitter coalesces a stream of NotifyChange calls into debounced
+// snapshot PUTs against a Client. Construct one per agent and wire
+// NotifyChange to the connector's state-machine subscription,
+// wanted-channels OnChange, and preferred-nick setter.
+//
+// The emitter owns one background goroutine which runs the debounce
+// timer and fires the PUT. Stop terminates it and blocks until the
+// goroutine returns — call from the agent's shutdown path so goleak
+// stays clean.
+//
+// All methods are safe on a nil receiver and on an emitter built
+// against a disabled (empty-URL) client — both are no-ops.
+type Emitter struct {
+	client   *Client
+	build    SnapshotBuilder
+	debounce time.Duration
+	log      *slog.Logger
+
+	notify chan struct{}
+	done   chan struct{}
+	wg     sync.WaitGroup
+}
+
+// NewEmitter wires an Emitter to the given client and snapshot
+// builder. When client is nil or its URL is empty, the returned
+// emitter is a working but inert no-op — calls to NotifyChange and
+// Stop are safe but produce no HTTP traffic.
+//
+// debounce <= 0 → no debounce; every NotifyChange call fires a PUT
+// directly. Values larger than a few seconds defeat the "real-time
+// status dot" intent and are clamped by the operator-policy caller,
+// not here.
+func NewEmitter(client *Client, build SnapshotBuilder, debounce time.Duration, log *slog.Logger) *Emitter {
+	if log == nil {
+		log = slog.Default()
+	}
+	if debounce < 0 {
+		debounce = defaultDebounce
+	}
+	e := &Emitter{
+		client:   client,
+		build:    build,
+		debounce: debounce,
+		log:      log,
+		notify:   make(chan struct{}, 1),
+		done:     make(chan struct{}),
+	}
+	if !e.enabled() {
+		// Inert emitter: leave the goroutine unstarted. Stop and
+		// NotifyChange both short-circuit via the enabled() check.
+		return e
+	}
+	e.wg.Add(1)
+	go e.run()
+	return e
+}
+
+// enabled reports whether the emitter has a real destination to PUT
+// to. False for nil receivers, missing clients, or clients with empty
+// URLs (the operator didn't wire a webhook).
+func (e *Emitter) enabled() bool {
+	return e != nil && e.client != nil && e.client.url != "" && e.build != nil
+}
+
+// NotifyChange marks the emitter dirty and (re)arms the debounce
+// timer. Safe to call from any goroutine and on a nil/disabled
+// emitter. The actual PUT runs after the debounce window elapses
+// without another NotifyChange.
+func (e *Emitter) NotifyChange() {
+	if !e.enabled() {
+		return
+	}
+	// Non-blocking send: an already-queued tick coalesces this call.
+	select {
+	case e.notify <- struct{}{}:
+	default:
+	}
+}
+
+// Stop terminates the emitter goroutine and blocks until it returns.
+// Safe to call on a nil or disabled emitter. After Stop, NotifyChange
+// remains safe but is a no-op (the goroutine is gone).
+func (e *Emitter) Stop() {
+	if !e.enabled() {
+		return
+	}
+	// close(done) is the cancel signal; idempotent guard handles the
+	// case where Stop is called twice on a real shutdown path.
+	select {
+	case <-e.done:
+		// already stopped
+	default:
+		close(e.done)
+	}
+	e.wg.Wait()
+}
+
+func (e *Emitter) run() {
+	defer e.wg.Done()
+
+	for {
+		select {
+		case <-e.done:
+			return
+		case <-e.notify:
+			if e.debounce <= 0 {
+				e.send()
+				continue
+			}
+			if !e.collect() {
+				return
+			}
+			e.send()
+		}
+	}
+}
+
+// collect waits out the debounce window after the first notify, eating
+// any further notifies and re-arming the timer each time. Returns
+// false when done was closed (caller should return), true when the
+// timer fired clean.
+func (e *Emitter) collect() bool {
+	timer := time.NewTimer(e.debounce)
+	for {
+		select {
+		case <-e.done:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return false
+		case <-e.notify:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(e.debounce)
+		case <-timer.C:
+			return true
+		}
+	}
+}
+
+func (e *Emitter) send() {
+	snapshot := e.build()
+	// Bound the whole PUT (including retries) by a generous ceiling so
+	// a chronically wedged webhook cannot stall NotifyChange callers
+	// indefinitely. Each individual attempt is already capped by
+	// defaultHTTPTimeout in Client; this is a belt-and-braces parent
+	// deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := e.client.Put(ctx, snapshot); err != nil {
+		e.log.Debug("state webhook PUT failed", "err", err)
+	}
+}

--- a/internal/statepush/state_emitter_test.go
+++ b/internal/statepush/state_emitter_test.go
@@ -1,0 +1,265 @@
+package statepush_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/turborg/turborg/internal/statepush"
+)
+
+// recorder collects every PUT body the test server saw, with mu
+// guarding both the slice and the optional callback that fires after
+// each request.
+type recorder struct {
+	mu      sync.Mutex
+	bodies  [][]byte
+	onWrite func()
+}
+
+func (r *recorder) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		r.mu.Lock()
+		r.bodies = append(r.bodies, body)
+		cb := r.onWrite
+		r.mu.Unlock()
+		if cb != nil {
+			cb()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func (r *recorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.bodies)
+}
+
+func (r *recorder) bodyAt(i int) []byte {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if i >= len(r.bodies) {
+		return nil
+	}
+	return r.bodies[i]
+}
+
+func TestNewChannelSnapshot_KeyEncodedAsNullWhenEmpty(t *testing.T) {
+	withKey := statepush.NewChannelSnapshot("#a", "hunter2")
+	noKey := statepush.NewChannelSnapshot("#b", "")
+
+	got, err := json.Marshal(withKey)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"name":"#a","key":"hunter2"}`, string(got))
+
+	got, err = json.Marshal(noKey)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"name":"#b","key":null}`, string(got))
+}
+
+func TestStateEmitter_DisabledWhenClientNil(t *testing.T) {
+	// Disabled emitters must not spawn a goroutine (goleak in TestMain
+	// would catch a leak even between sub-tests).
+	e := statepush.NewEmitter(nil, nil, 0, nil)
+	e.NotifyChange()
+	e.Stop()
+}
+
+func TestStateEmitter_DisabledWhenURLEmpty(t *testing.T) {
+	c := statepush.NewClient("", "", nil)
+	called := atomic.Int32{}
+	e := statepush.NewEmitter(c, func() statepush.Snapshot {
+		called.Add(1)
+		return statepush.Snapshot{}
+	}, 0, nil)
+	e.NotifyChange()
+	e.NotifyChange()
+	e.Stop()
+	assert.Equal(t, int32(0), called.Load(), "snapshot builder must not run when URL empty")
+}
+
+func TestStateEmitter_DisabledWhenBuilderNil(t *testing.T) {
+	c := statepush.NewClient("http://obs/state", "", nil)
+	e := statepush.NewEmitter(c, nil, 0, nil)
+	// Without a builder the emitter is inert.
+	e.NotifyChange()
+	e.Stop()
+}
+
+func TestStateEmitter_NotifyChangeFiresPutWithZeroDebounce(t *testing.T) {
+	rec := &recorder{}
+	done := make(chan struct{}, 1)
+	rec.onWrite = func() {
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+	server := httptest.NewServer(rec.handler())
+	t.Cleanup(server.Close)
+
+	c := statepush.NewClient(server.URL+"/state", "", nil)
+	e := statepush.NewEmitter(c, func() statepush.Snapshot {
+		return statepush.Snapshot{
+			Connectors: map[string]statepush.ConnectorSnapshot{
+				"irc": {
+					State:    "registered",
+					Since:    time.Unix(0, 0).UTC(),
+					Channels: []statepush.ChannelSnapshot{statepush.NewChannelSnapshot("#a", "")},
+					Nick:     "stefan",
+				},
+			},
+		}
+	}, 0, nil)
+	t.Cleanup(e.Stop)
+
+	e.NotifyChange()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a PUT within 2s")
+	}
+	require.Equal(t, 1, rec.count())
+
+	var got statepush.Snapshot
+	require.NoError(t, json.Unmarshal(rec.bodyAt(0), &got))
+	require.Contains(t, got.Connectors, "irc")
+	assert.Equal(t, "registered", got.Connectors["irc"].State)
+	assert.Equal(t, "stefan", got.Connectors["irc"].Nick)
+	require.Len(t, got.Connectors["irc"].Channels, 1)
+	assert.Equal(t, "#a", got.Connectors["irc"].Channels[0].Name)
+}
+
+func TestStateEmitter_BurstCoalescesIntoOnePut(t *testing.T) {
+	rec := &recorder{}
+	done := make(chan struct{}, 1)
+	rec.onWrite = func() {
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+	server := httptest.NewServer(rec.handler())
+	t.Cleanup(server.Close)
+
+	c := statepush.NewClient(server.URL+"/state", "", nil)
+	debounce := 50 * time.Millisecond
+	e := statepush.NewEmitter(c, func() statepush.Snapshot {
+		return statepush.Snapshot{}
+	}, debounce, nil)
+	t.Cleanup(e.Stop)
+
+	// Fire five notifies in rapid succession — they should collapse
+	// into a single PUT after the debounce window elapses.
+	for i := 0; i < 5; i++ {
+		e.NotifyChange()
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected at least one PUT")
+	}
+
+	// Wait a bit more than the debounce to make sure no extra PUT
+	// trickles in.
+	time.Sleep(debounce * 3)
+	assert.Equal(t, 1, rec.count(), "burst must coalesce to one PUT")
+}
+
+func TestStateEmitter_NewNotifyAfterFireRearmsTimer(t *testing.T) {
+	rec := &recorder{}
+	server := httptest.NewServer(rec.handler())
+	t.Cleanup(server.Close)
+
+	c := statepush.NewClient(server.URL+"/state", "", nil)
+	debounce := 20 * time.Millisecond
+	e := statepush.NewEmitter(c, func() statepush.Snapshot {
+		return statepush.Snapshot{}
+	}, debounce, nil)
+	t.Cleanup(e.Stop)
+
+	// First burst → one PUT.
+	e.NotifyChange()
+	require.Eventually(t, func() bool { return rec.count() == 1 }, time.Second, 5*time.Millisecond)
+
+	// Second notify after the first fire should arm a fresh timer
+	// and produce a second PUT.
+	e.NotifyChange()
+	require.Eventually(t, func() bool { return rec.count() == 2 }, time.Second, 5*time.Millisecond)
+}
+
+func TestStateEmitter_StopIsIdempotent(t *testing.T) {
+	rec := &recorder{}
+	server := httptest.NewServer(rec.handler())
+	t.Cleanup(server.Close)
+
+	c := statepush.NewClient(server.URL+"/state", "", nil)
+	e := statepush.NewEmitter(c, func() statepush.Snapshot { return statepush.Snapshot{} }, 5*time.Millisecond, nil)
+
+	e.NotifyChange()
+	e.Stop()
+	// Second Stop on an already-stopped emitter must not panic or
+	// block — the agent shutdown path may call Stop more than once
+	// via overlapping cleanup paths.
+	e.Stop()
+}
+
+func TestEmitter_NegativeDebounceResetsToDefault(t *testing.T) {
+	c := statepush.NewClient("http://obs/state", "", nil)
+	// Negative debounce gets clamped to the package default. We can't
+	// observe the field directly; the behavior under test is "doesn't
+	// panic and starts the goroutine clean", which Stop verifies.
+	e := statepush.NewEmitter(c, func() statepush.Snapshot { return statepush.Snapshot{} }, -1, nil)
+	e.Stop()
+}
+
+func TestEmitter_SendLogsPutFailure(t *testing.T) {
+	// 5xx from the receiver → retry exhaustion → debug-level failure
+	// log inside send(). Exercises the err != nil branch.
+	//
+	// Stop is called explicitly before the deferred restore runs, so
+	// the goroutine has stopped reading retryBackoffs by the time the
+	// override is rolled back.
+	restoreBackoffs := statepush.OverrideBackoffsForTesting(t, []time.Duration{0, 0})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := statepush.NewClient(server.URL, "", nil)
+	e := statepush.NewEmitter(c, func() statepush.Snapshot { return statepush.Snapshot{} }, 0, nil)
+
+	e.NotifyChange()
+	// Give the emitter goroutine time to attempt all three tries +
+	// log the debug-level failure.
+	time.Sleep(100 * time.Millisecond)
+	e.Stop()
+	restoreBackoffs()
+}
+
+func TestStateEmitter_StopDrainsPendingNotify(t *testing.T) {
+	rec := &recorder{}
+	server := httptest.NewServer(rec.handler())
+	t.Cleanup(server.Close)
+
+	c := statepush.NewClient(server.URL+"/state", "", nil)
+	// Long debounce → notify is pending in the collect() loop when
+	// Stop fires. Goroutine must exit cleanly without leaking.
+	e := statepush.NewEmitter(c, func() statepush.Snapshot { return statepush.Snapshot{} }, 5*time.Second, nil)
+	e.NotifyChange()
+	// Small delay to let the goroutine enter collect().
+	time.Sleep(10 * time.Millisecond)
+	e.Stop()
+}


### PR DESCRIPTION
## Summary

Adds an optional state-mirror surface that sits alongside the existing activity webhook. When `TURBORG_STATE_WEBHOOK_URL` is set, the agent PUTs an idempotent snapshot of its authoritative per-connector state (current connection status, joined channels with any cached +k keys, preferred nick) to the configured endpoint whenever that state changes. Receivers treat each PUT as the latest known truth — overwrite-on-write, no diff/event semantics on the wire.

- New package `internal/statepush/` with `Client` (HTTP plumbing — PUT with bearer auth, JSON body, 5s per-attempt timeout, 2 retries on 5xx / transport failures with 1s/2s backoff, non-retryable 4xx, 401/403 log rate-limited to once per minute) and `Emitter` (debounced snapshot pusher built on Client).
- New envs: `TURBORG_STATE_WEBHOOK_URL`, `TURBORG_STATE_WEBHOOK_TOKEN`, `TURBORG_STATE_WEBHOOK_DEBOUNCE_MS` (default 250, range 0–5000).
- Three subscription points wired in `runtime.Build`: state-machine transitions (existing `UpstreamState().Subscribe`), wanted-channels mutations (new `WantedChannels.SetOnChange` callback), preferred-nick changes (new `Connector.SetPreferredNickChangeHook`).
- Bursty mutations (e.g. `/join #a,#b,#c,#d,#e`) coalesce into a single PUT via the debounce window.
- Self-host operators who don't set `STATE_WEBHOOK_URL` see zero side effects (inert emitter, no goroutine spawned).

## Wire shape

```
PUT $TURBORG_STATE_WEBHOOK_URL
Authorization: Bearer $TURBORG_STATE_WEBHOOK_TOKEN
Content-Type: application/json

{
  \"connectors\": {
    \"irc\": {
      \"state\": \"registered\",
      \"since\": \"2026-05-17T15:30:00Z\",
      \"channels\": [
        {\"name\": \"#a\", \"key\": null},
        {\"name\": \"#private\", \"key\": \"hunter2\"}
      ],
      \"nick\": \"stefan\"
    }
  }
}
```

`channel.key` is nullable on the wire (encoded as JSON `null` when no +k key is known) so receivers can distinguish \"no key\" from \"explicit empty key\" when replaying JOIN.

## Test plan
- [x] `make lint` clean
- [x] `make test` clean with `-race -count=1`
- [x] `make cover-gate` passes — total 94.5%, statepush 93.5%, runtime 93.4%, irc 93.6%, config 98.3%
- [x] Unit tests cover client retry policy, URL/token handling, auth rate-limit, debounce coalescing, snapshot shape, inert-emitter no-op
- [x] Integration test wires the full chain via `runtime.Build` + `httptest.Server` and asserts the snapshot reaches the receiver with the right path + bearer auth on each of the three trigger paths
- [ ] Manual smoke (after merge): point `TURBORG_STATE_WEBHOOK_URL` at a netcat listener, drive a `/join` and a `/nick`, observe coalesced PUTs