### PR TITLE
feat(connector/irc): active PING/PONG roundtrip watchdog

### DIFF
--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -10,12 +10,26 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/version"
 	"golang.org/x/sync/errgroup"
 )
+
+// pongTimeoutError is the sentinel returned from the pong-watchdog when
+// no PONG arrived within Settings.PongTimeout. Implements net.Error so
+// the supervisor's ClassifyError path maps it to DisconnectedTransient
+// even when the eager state transition loses a race.
+type pongTimeoutError struct{ age time.Duration }
+
+func (e *pongTimeoutError) Error() string {
+	return fmt.Sprintf("irc pong timeout: outstanding for %s", e.age)
+}
+
+func (e *pongTimeoutError) Timeout() bool   { return true }
+func (e *pongTimeoutError) Temporary() bool { return true }
 
 // Connector is the IRC adapter: TLS dial + IRCv3 CAP / SASL handshake,
 // supervised read+ping loop, channel-state cache, optional bouncer.
@@ -110,6 +124,13 @@ type Connector struct {
 	preferredNickMu       sync.RWMutex
 	preferredNick         string
 	preferredNickChangeCB func()
+
+	// pingLedgerRef is the per-session outstanding-PING ledger,
+	// installed by runSession at session start and cleared on session
+	// exit. dispatchLine reads it on each inbound PONG to record the
+	// roundtrip; a nil value (between sessions, or under test fixtures
+	// that bypass runSession) makes the ack a no-op.
+	pingLedgerRef atomic.Pointer[pingLedger]
 
 	stopOnce sync.Once
 }
@@ -255,6 +276,18 @@ func (c *Connector) PreferredNick() string {
 	c.preferredNickMu.RLock()
 	defer c.preferredNickMu.RUnlock()
 	return c.preferredNick
+}
+
+// setPingLedger installs (or clears, with nil) the per-session ledger
+// the dispatch loop acks PONGs into. Idempotent.
+func (c *Connector) setPingLedger(l *pingLedger) {
+	c.pingLedgerRef.Store(l)
+}
+
+// pongLedger returns the per-session ledger, or nil if no session is
+// currently running. dispatchLine consults this on every inbound PONG.
+func (c *Connector) pongLedger() *pingLedger {
+	return c.pingLedgerRef.Load()
 }
 
 // effectiveNick returns the nick the supervisor should register with:
@@ -909,6 +942,25 @@ func (c *Connector) runSession(ctx context.Context) error {
 	g, gctx := errgroup.WithContext(ctx)
 	lines := make(chan string, 64)
 
+	// Per-session PING/PONG ledger: the ping-writer Adds a token before
+	// every PING write; the dispatch goroutine Acks it on the matching
+	// PONG; the pong-watchdog (below) fails the session when an entry
+	// outlives PongTimeout. Fresh per runSession iteration so a reconnect
+	// starts with a clean slate.
+	ledger := newPingLedger()
+	c.setPingLedger(ledger)
+	defer c.setPingLedger(nil)
+
+	// Monotonic counter for PING token assignment. The previous time-
+	// based token risked collisions when two ticks fired within the same
+	// second (e.g. an unconfigured 0-or-1s ClientPingInterval); a counter
+	// makes every token globally unique within the session.
+	var pingSeq uint64
+	nextToken := func() string {
+		n := atomic.AddUint64(&pingSeq, 1)
+		return "tb-" + strconv.FormatUint(n, 36)
+	}
+
 	g.Go(func() error {
 		<-gctx.Done()
 		_ = cli.Unblock()
@@ -958,7 +1010,9 @@ func (c *Connector) runSession(ctx context.Context) error {
 	// SOMETHING (a PONG) at a predictable cadence so NAT mappings stay
 	// warm and a stalled socket trips the idle timeout above instead of
 	// hanging forever. Cadence must be lower than ReadIdleTimeout (the
-	// Settings.Validate cross-check enforces this).
+	// Settings.Validate cross-check enforces this). Every tick records
+	// the token in the ledger BEFORE the WriteLine so a write that
+	// races a pong arrival can never be acked-before-tracked.
 	g.Go(func() error {
 		interval := c.settings.ClientPingInterval
 		if interval <= 0 {
@@ -971,13 +1025,67 @@ func (c *Connector) runSession(ctx context.Context) error {
 			case <-gctx.Done():
 				return nil
 			case <-ticker.C:
-				token := strconv.FormatInt(time.Now().Unix(), 10)
+				token := nextToken()
+				ledger.Add(token, time.Now())
 				if err := cli.WriteLine(CmdPing + " :" + token); err != nil {
 					if gctx.Err() != nil {
 						return nil
 					}
 					return fmt.Errorf("irc client ping: %w", err)
 				}
+			}
+		}
+	})
+
+	// Pong-watchdog: actively probes upstream liveness. When the oldest
+	// outstanding PING is older than PongTimeout the session is failed
+	// with a transient classification — the supervisor's existing
+	// backoff + bringUp path takes over, and the state-emitter +
+	// bouncer state-subscription surface the disconnect to attached
+	// clients well before ReadIdleTimeout would have caught the
+	// silently-dead socket.
+	g.Go(func() error {
+		timeout := c.settings.PongTimeout
+		if timeout <= 0 || c.settings.ClientPingInterval <= 0 {
+			return nil
+		}
+		// Cadence: timeout/2 so an expired token is observed within ~1.5x
+		// the timeout in the worst case. Capped at 1s so production
+		// (timeout=30s) doesn't bother polling at 15s granularity; and
+		// floored at 10ms so millisecond-scale test timings stay
+		// responsive.
+		tickEvery := timeout / 2
+		if tickEvery > time.Second {
+			tickEvery = time.Second
+		}
+		if tickEvery < 10*time.Millisecond {
+			tickEvery = 10 * time.Millisecond
+		}
+		ticker := time.NewTicker(tickEvery)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-gctx.Done():
+				return nil
+			case <-ticker.C:
+				oldest, ok := ledger.Oldest()
+				if !ok {
+					continue
+				}
+				age := time.Since(oldest)
+				if age <= timeout {
+					continue
+				}
+				// Eagerly transition so the state-emitter PUT and the
+				// bouncer's channel-targeted NOTICE both fire before
+				// the reconnect supervisor cycles. ClassifyError also
+				// maps our returned error to transient — both paths
+				// are idempotent under Transition's same-state no-op.
+				c.machine.Transition(
+					UpstreamStateDisconnectedTransient,
+					WithServerReason(fmt.Sprintf("no PONG for %s", timeout)),
+				)
+				return &pongTimeoutError{age: age}
 			}
 		}
 	})
@@ -1174,6 +1282,20 @@ func (c *Connector) dispatchLine(ctx context.Context, line string) {
 	switch msg.Command {
 	case CmdPing:
 		c.respondPong(msg)
+	case CmdPong:
+		// Match the token back to the outstanding-PING ledger so the
+		// pong-watchdog sees a fresh oldest-entry on its next tick.
+		// Servers vary: some put the token in the trailing slot
+		// (PONG :token), some in the param slot (PONG server token).
+		if ledger := c.pongLedger(); ledger != nil {
+			token := msg.Trailing
+			if token == "" && len(msg.Params) > 0 {
+				token = msg.Params[len(msg.Params)-1]
+			}
+			if token != "" {
+				ledger.Ack(token)
+			}
+		}
 	case RplWelcome:
 		// :server 001 <actualnick> :Welcome to the [...] network <actualnick>
 		// The first param is the nick the server actually assigned.

--- a/internal/connector/irc/connector_pong_timeout_test.go
+++ b/internal/connector/irc/connector_pong_timeout_test.go
@@ -1,0 +1,258 @@
+package irc_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/tests/fixtures/fakeirc"
+)
+
+// TestPongTimeoutTransitionsTransient: fake server completes the
+// handshake but silently swallows every PING. Within
+// ~ClientPingInterval + PongTimeout the connector must classify the
+// upstream as silently dead and emit the transient transition. The
+// ReadIdleTimeout is held large enough that it cannot be the cause.
+func TestPongTimeoutTransitionsTransient(t *testing.T) {
+	fs := fakeirc.New(t) // no WithPongResponses → server drops PINGs
+	defer fs.Close()
+
+	conn := irc.New(&irc.Settings{
+		Hostname:           "127.0.0.1",
+		Port:               fs.Port(),
+		Nick:               "turborg",
+		Channels:           []string{"#test"},
+		ClientPingInterval: 80 * time.Millisecond,
+		PongTimeout:        40 * time.Millisecond,
+		ReadIdleTimeout:    10 * time.Second,
+	}, nil, nil)
+
+	transients := make(chan irc.UpstreamStateChange, 8)
+	sub := conn.UpstreamState().Subscribe(func(c irc.UpstreamStateChange) {
+		if c.To == irc.UpstreamStateDisconnectedTransient {
+			select {
+			case transients <- c:
+			default:
+			}
+		}
+	})
+	defer sub.Unsubscribe()
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	// Worst case: one PING cadence (80ms) + PongTimeout (40ms) + a watchdog
+	// tick (≤ 20ms). 1s is generous and well under ReadIdleTimeout.
+	select {
+	case ch := <-transients:
+		assert.Contains(t, ch.ServerReason, "no PONG",
+			"transition reason must surface the active-probe cause so attached clients see it via DescribeUpstreamState")
+	case <-time.After(2 * time.Second):
+		t.Fatal("pong-watchdog did not transition to disconnected_transient within 2s")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down within 2s of ctx cancel")
+	}
+}
+
+// TestPongAckResetsLedger: server echoes PONGs back so every PING is
+// matched within the timeout window. Run for 3x PongTimeout and assert
+// the connector stays Registered (no transient transition emitted).
+func TestPongAckResetsLedger(t *testing.T) {
+	fs := fakeirc.New(t, fakeirc.WithPongResponses(true))
+	defer fs.Close()
+
+	conn := irc.New(&irc.Settings{
+		Hostname:           "127.0.0.1",
+		Port:               fs.Port(),
+		Nick:               "turborg",
+		Channels:           []string{"#test"},
+		ClientPingInterval: 50 * time.Millisecond,
+		PongTimeout:        30 * time.Millisecond,
+		ReadIdleTimeout:    10 * time.Second,
+	}, nil, nil)
+
+	var (
+		mu             sync.Mutex
+		sawTransient   bool
+		registeredOnce bool
+	)
+	sub := conn.UpstreamState().Subscribe(func(c irc.UpstreamStateChange) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch c.To {
+		case irc.UpstreamStateRegistered:
+			registeredOnce = true
+		case irc.UpstreamStateDisconnectedTransient:
+			sawTransient = true
+		}
+	})
+	defer sub.Unsubscribe()
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	// Hold the session for several ping cycles. Acks should keep the
+	// ledger drained continuously — no transient transition.
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	gotRegistered := registeredOnce
+	gotTransient := sawTransient
+	mu.Unlock()
+
+	assert.True(t, gotRegistered, "handshake should have reached registered before the soak window")
+	assert.False(t, gotTransient,
+		"server PONGed every PING — watchdog must NOT transition to transient")
+
+	// Sanity: server actually saw PINGs go by. Without this, a logic bug
+	// that suppresses PINGs entirely would make the test pass vacuously.
+	sawPing := false
+	for _, line := range fs.Received() {
+		if strings.HasPrefix(line, "PING ") {
+			sawPing = true
+			break
+		}
+	}
+	assert.True(t, sawPing, "expected at least one PING in fs.Received() during soak window")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down within 2s of ctx cancel")
+	}
+}
+
+// TestPongTimeoutDisabled: PongTimeout=0 disables the active probe. The
+// server drops PINGs silently, but the watchdog must not fire — only
+// the existing ReadIdleTimeout backstop should surface the dead socket.
+// Asserts that the read-idle path is still the one to fire (the
+// connector did NOT regress on the legacy detector).
+func TestPongTimeoutDisabled(t *testing.T) {
+	fs := fakeirc.New(t) // no PONG handling
+	defer fs.Close()
+
+	conn := irc.New(&irc.Settings{
+		Hostname:           "127.0.0.1",
+		Port:               fs.Port(),
+		Nick:               "turborg",
+		Channels:           []string{"#test"},
+		ClientPingInterval: 30 * time.Millisecond,
+		PongTimeout:        0,                      // disabled
+		ReadIdleTimeout:    150 * time.Millisecond, // legacy backstop
+	}, nil, nil)
+
+	transients := make(chan irc.UpstreamStateChange, 8)
+	sub := conn.UpstreamState().Subscribe(func(c irc.UpstreamStateChange) {
+		if c.To == irc.UpstreamStateDisconnectedTransient {
+			select {
+			case transients <- c:
+			default:
+			}
+		}
+	})
+	defer sub.Unsubscribe()
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	// Read-idle must surface within a couple of cycles. The reason
+	// string must NOT mention "no PONG" (that's the active probe).
+	select {
+	case ch := <-transients:
+		assert.NotContains(t, ch.ServerReason, "no PONG",
+			"with PongTimeout=0 the active probe is disabled — the transition reason must come from the read-idle path, not the watchdog")
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadIdleTimeout did not surface a transient transition within 2s — the legacy backstop must still work")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down within 2s of ctx cancel")
+	}
+}
+
+// TestPongTimeoutSurfacesServerReason: when the watchdog fires, the
+// transition's ServerReason flows through DescribeUpstreamState so
+// attached clients see the cause in their NOTICE body / event payload.
+// PR #17 wires the bouncer to call DescribeUpstreamState on each
+// transition; this test asserts the wiring stays intact across the new
+// transient cause.
+func TestPongTimeoutSurfacesServerReason(t *testing.T) {
+	fs := fakeirc.New(t) // silent server
+	defer fs.Close()
+
+	conn := irc.New(&irc.Settings{
+		Hostname:           "127.0.0.1",
+		Port:               fs.Port(),
+		Nick:               "turborg",
+		Channels:           []string{"#test"},
+		ClientPingInterval: 50 * time.Millisecond,
+		PongTimeout:        30 * time.Millisecond,
+		ReadIdleTimeout:    10 * time.Second,
+	}, nil, nil)
+
+	reasons := make(chan string, 8)
+	sub := conn.UpstreamState().Subscribe(func(c irc.UpstreamStateChange) {
+		if c.To == irc.UpstreamStateDisconnectedTransient {
+			select {
+			case reasons <- c.ServerReason:
+			default:
+			}
+		}
+	})
+	defer sub.Unsubscribe()
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	var captured string
+	select {
+	case captured = <-reasons:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pong-watchdog did not transition within 2s")
+	}
+
+	require.Contains(t, captured, "no PONG")
+	described := irc.DescribeUpstreamState(irc.UpstreamStateDisconnectedTransient, "127.0.0.1", captured)
+	assert.Contains(t, described, "no PONG",
+		"DescribeUpstreamState must thread the watchdog reason into the operator-visible body")
+	assert.Contains(t, described, "Currently disconnected",
+		"description must keep the existing transient framing operators rely on")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down within 2s of ctx cancel")
+	}
+}

--- a/internal/connector/irc/pingledger.go
+++ b/internal/connector/irc/pingledger.go
@@ -1,0 +1,74 @@
+package irc
+
+import (
+	"sync"
+	"time"
+)
+
+// pingLedger tracks outstanding client-initiated PING tokens awaiting
+// matching PONGs. All methods are safe for concurrent use.
+//
+// The ledger is per-session — runSession creates a fresh one each
+// iteration so a reconnect starts with a clean slate.
+type pingLedger struct {
+	mu      sync.Mutex
+	pending map[string]time.Time
+}
+
+func newPingLedger() *pingLedger {
+	return &pingLedger{pending: map[string]time.Time{}}
+}
+
+// Add records a sent PING token with the wall-clock send time. If the
+// token is already pending the timestamp is overwritten — should never
+// happen in practice (tokens come from a monotonic counter) but the
+// behavior is defined for safety.
+func (l *pingLedger) Add(token string, sentAt time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.pending[token] = sentAt
+}
+
+// Ack removes the token if present. Returns true when the ack matched
+// an outstanding PING (i.e. we initiated this one) and false otherwise.
+// Server-initiated PINGs prompt a PONG from us, but those PONGs travel
+// out — never appear in our inbound stream — so we'll never see them
+// here. An unknown token is therefore an unmatched server echo or an
+// already-acked duplicate; either way, harmless.
+func (l *pingLedger) Ack(token string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if _, ok := l.pending[token]; !ok {
+		return false
+	}
+	delete(l.pending, token)
+	return true
+}
+
+// Oldest returns the send time of the oldest outstanding PING and
+// whether the ledger has anything outstanding. The pong-watchdog uses
+// this to compare against `now - PongTimeout`.
+func (l *pingLedger) Oldest() (time.Time, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.pending) == 0 {
+		return time.Time{}, false
+	}
+	var oldest time.Time
+	first := true
+	for _, t := range l.pending {
+		if first || t.Before(oldest) {
+			oldest = t
+			first = false
+		}
+	}
+	return oldest, true
+}
+
+// Len is the number of outstanding PINGs. Exposed for tests; no
+// production caller needs it.
+func (l *pingLedger) Len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.pending)
+}

--- a/internal/connector/irc/pingledger_test.go
+++ b/internal/connector/irc/pingledger_test.go
@@ -1,0 +1,99 @@
+package irc
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPingLedgerAddAck(t *testing.T) {
+	l := newPingLedger()
+	now := time.Now()
+
+	l.Add("tb-1", now)
+	assert.Equal(t, 1, l.Len())
+
+	assert.True(t, l.Ack("tb-1"), "Ack on a pending token returns true")
+	assert.Equal(t, 0, l.Len(), "Ack must remove the token from pending")
+}
+
+func TestPingLedgerAckUnknownReturnsFalse(t *testing.T) {
+	l := newPingLedger()
+	assert.False(t, l.Ack("never-sent"),
+		"Ack on a token we never recorded returns false (server echo or duplicate)")
+}
+
+func TestPingLedgerAckIsIdempotent(t *testing.T) {
+	l := newPingLedger()
+	l.Add("tb-1", time.Now())
+
+	assert.True(t, l.Ack("tb-1"))
+	assert.False(t, l.Ack("tb-1"),
+		"a second Ack for an already-removed token must report no-match")
+}
+
+func TestPingLedgerOldestReturnsEarliest(t *testing.T) {
+	l := newPingLedger()
+	t0 := time.Now()
+	t1 := t0.Add(50 * time.Millisecond)
+	t2 := t0.Add(100 * time.Millisecond)
+
+	l.Add("late", t2)
+	l.Add("first", t0)
+	l.Add("middle", t1)
+
+	oldest, ok := l.Oldest()
+	assert.True(t, ok)
+	assert.Equal(t, t0, oldest, "Oldest must surface the earliest sentAt regardless of insertion order")
+}
+
+func TestPingLedgerOldestEmpty(t *testing.T) {
+	l := newPingLedger()
+	_, ok := l.Oldest()
+	assert.False(t, ok, "Oldest on an empty ledger returns ok=false")
+}
+
+func TestPingLedgerOldestAdvancesAfterAck(t *testing.T) {
+	l := newPingLedger()
+	t0 := time.Now()
+	t1 := t0.Add(200 * time.Millisecond)
+
+	l.Add("a", t0)
+	l.Add("b", t1)
+
+	l.Ack("a")
+	oldest, ok := l.Oldest()
+	assert.True(t, ok)
+	assert.Equal(t, t1, oldest, "after acking the oldest, the next-oldest becomes Oldest()")
+}
+
+func TestPingLedgerConcurrentAddAckOldest(t *testing.T) {
+	// Drive Add/Ack/Oldest from many goroutines so `go test -race`
+	// flags any unguarded map access. The assertion is intentionally
+	// weak — we only care that the ledger is internally consistent
+	// (no panic, no data race) under contention.
+	l := newPingLedger()
+	const workers = 16
+	const perWorker = 200
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				token := "w" + strconv.Itoa(w) + "-" + strconv.Itoa(i)
+				l.Add(token, time.Now())
+				_, _ = l.Oldest()
+				l.Ack(token)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	assert.Equal(t, 0, l.Len(),
+		"every Add was paired with an Ack — ledger must end empty")
+}

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -35,6 +35,17 @@ type Settings struct {
 	ReadIdleTimeout    time.Duration `env:"READ_IDLE_TIMEOUT"    envDefault:"300s"`
 	ClientPingInterval time.Duration `env:"CLIENT_PING_INTERVAL" envDefault:"120s"`
 
+	// PongTimeout is the maximum time the connector will wait for a PONG
+	// response to its most recent client-initiated PING before classifying
+	// the upstream as dead and unwinding the session. Independent of
+	// ReadIdleTimeout (which catches the "no inbound data at all" case) —
+	// PongTimeout actively probes liveness on a schedule, dropping
+	// silently-dead socket detection from ~ReadIdleTimeout to
+	// ~ClientPingInterval + PongTimeout. 0 disables the active probe and
+	// falls back to ReadIdleTimeout only. When ClientPingInterval is 0
+	// the probe is also functionally disabled (no PINGs to time out).
+	PongTimeout time.Duration `env:"PONG_TIMEOUT" envDefault:"30s"`
+
 	BouncerPassword              string        `env:"BOUNCER_PASSWORD"`
 	BouncerHost                  string        `env:"BOUNCER_HOST" envDefault:"127.0.0.1"`
 	BouncerPort                  int           `env:"BOUNCER_PORT" envDefault:"31337"`
@@ -143,6 +154,9 @@ func (s *Settings) BouncerEnabled() bool {
 func (s *Settings) Validate() error {
 	if s.ClientPingInterval > 0 && s.ReadIdleTimeout > 0 && s.ClientPingInterval >= s.ReadIdleTimeout {
 		return errors.New("irc: client_ping_interval must be less than read_idle_timeout")
+	}
+	if s.PongTimeout > 0 && s.ClientPingInterval > 0 && s.PongTimeout >= s.ClientPingInterval {
+		return errors.New("irc: pong_timeout must be less than client_ping_interval")
 	}
 	return nil
 }

--- a/internal/connector/irc/settings_test.go
+++ b/internal/connector/irc/settings_test.go
@@ -34,6 +34,8 @@ func TestLoadSettingsFromEnv(t *testing.T) {
 	assert.Equal(t, "turborg", s.EffectiveUsername())
 	assert.Equal(t, 60*time.Second, s.ReadIdleTimeout)
 	assert.Equal(t, 30*time.Second, s.ClientPingInterval)
+	assert.Equal(t, 30*time.Second, s.PongTimeout,
+		"PongTimeout defaults to 30s when no env override is supplied")
 }
 
 func TestLoadSettingsDefaults(t *testing.T) {
@@ -89,6 +91,48 @@ func TestValidateAllowsZeroSentinels(t *testing.T) {
 }
 
 func TestValidateAcceptsHealthyConfig(t *testing.T) {
-	s := &irc.Settings{ClientPingInterval: 120 * time.Second, ReadIdleTimeout: 300 * time.Second}
+	s := &irc.Settings{
+		ClientPingInterval: 120 * time.Second,
+		ReadIdleTimeout:    300 * time.Second,
+		PongTimeout:        30 * time.Second,
+	}
+	assert.NoError(t, s.Validate())
+}
+
+func TestValidateRejectsPongTimeoutGEPingInterval(t *testing.T) {
+	// A pong timeout >= the ping cadence lets the next tick race past
+	// an already-stale outstanding token. Operators should narrow
+	// PongTimeout below ClientPingInterval (default 30s vs 120s).
+	s := &irc.Settings{
+		ClientPingInterval: 30 * time.Second,
+		ReadIdleTimeout:    300 * time.Second,
+		PongTimeout:        30 * time.Second,
+	}
+	err := s.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pong_timeout")
+}
+
+func TestValidateAllowsPongTimeoutZero(t *testing.T) {
+	// Zero disables the active probe; ReadIdleTimeout is still the
+	// backstop. Operators who want the old detection envelope use this.
+	s := &irc.Settings{
+		ClientPingInterval: 120 * time.Second,
+		ReadIdleTimeout:    300 * time.Second,
+		PongTimeout:        0,
+	}
+	assert.NoError(t, s.Validate())
+}
+
+func TestValidateAllowsPongTimeoutWithoutPingInterval(t *testing.T) {
+	// PongTimeout > 0 with ClientPingInterval == 0 is functionally
+	// inert (no PINGs being sent → nothing to time out) but must not
+	// trip validation. The connector handles the inert case at
+	// goroutine-start time.
+	s := &irc.Settings{
+		ClientPingInterval: 0,
+		ReadIdleTimeout:    300 * time.Second,
+		PongTimeout:        30 * time.Second,
+	}
 	assert.NoError(t, s.Validate())
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -300,12 +300,15 @@ func TestLoadIRCSettingsHappyPath(t *testing.T) {
 	t.Setenv("TURBORG_IRC_NICK", "turborg")
 	t.Setenv("TURBORG_IRC_READ_IDLE_TIMEOUT", "300s")
 	t.Setenv("TURBORG_IRC_CLIENT_PING_INTERVAL", "120s")
+	t.Setenv("TURBORG_IRC_PONG_TIMEOUT", "15s")
 
 	s, err := runtime.LoadIRCSettings()
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	assert.Equal(t, "fake", s.Hostname)
 	assert.Equal(t, "turborg", s.Nick)
+	assert.Equal(t, 15*time.Second, s.PongTimeout,
+		"TURBORG_IRC_PONG_TIMEOUT must be parsed off the env")
 }
 
 func TestLoadIRCSettingsMissingRequiredFields(t *testing.T) {

--- a/tests/fixtures/fakeirc/server.go
+++ b/tests/fixtures/fakeirc/server.go
@@ -33,6 +33,7 @@ type Server struct {
 	tb       testing.TB
 	listener net.Listener
 	sasl     SASLResult
+	pongPing bool
 
 	wmu  sync.Mutex
 	conn net.Conn
@@ -47,6 +48,14 @@ type Option func(*Server)
 
 func WithSASL(r SASLResult) Option {
 	return func(s *Server) { s.sasl = r }
+}
+
+// WithPongResponses makes the server reply to every client-initiated
+// `PING :token` with a matching `:fake PONG fake :token`. Off by default
+// so existing tests (which don't drive a non-zero ClientPingInterval
+// against a fake that wouldn't matter either way) behave as before.
+func WithPongResponses(enabled bool) Option {
+	return func(s *Server) { s.pongPing = enabled }
 }
 
 func New(tb testing.TB, opts ...Option) *Server {
@@ -160,6 +169,12 @@ func (s *Server) handleLine(line string) {
 		nick := s.firstNick()
 		_ = s.SendLine(fmt.Sprintf(":fake 001 %s :Welcome", nick))
 		_ = s.SendLine(fmt.Sprintf(":fake 376 %s :End of MOTD", nick))
+	case strings.HasPrefix(line, "PING "):
+		if s.pongPing {
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "PING"))
+			payload = strings.TrimPrefix(payload, ":")
+			_ = s.SendLine(":fake PONG fake :" + payload)
+		}
 	case strings.HasPrefix(line, "JOIN "):
 		// Real servers echo the client's own JOIN back so it can update
 		// its membership state. fakeirc mirrors that — without it, the


### PR DESCRIPTION
## Summary

Active PING/PONG roundtrip watchdog detects silently-dead upstream TCP
sockets within ~30s of the next scheduled PING (was up to 5 min via
`ReadIdleTimeout` only).

- New setting: `TURBORG_IRC_PONG_TIMEOUT` (default `30s`). Set `0s` to
  disable the active probe and fall back to read-idle.
- No behaviour change for sessions where every PING gets a matching
  PONG within the window (the common case).

## Details

The previous keep-alive was fire-and-forget: the connector wrote a
`PING :token` on `ClientPingInterval` but never verified the matching
PONG came back. Half-dead NAT'd / peer-stalled sockets therefore went
undetected until `ReadIdleTimeout` (default 5m) fired — during which
the bouncer state gate still let client `PRIVMSG`s through against the
zombie socket, messages were silently dropped on the floor, and the
state-emitter kept reporting `registered` to sidecar / appui.

This PR adds a per-session outstanding-PING ledger and a pong-watchdog
goroutine alongside the existing reader / ping-writer / dispatch
goroutines in `runSession`. The watchdog ticks at `PongTimeout / 2`
(capped 10ms–1s) and fails the session with a `net.Error`-shaped
transient sentinel when the oldest entry exceeds the timeout — the
existing supervisor backoff + `bringUp` + JOIN replay path handles
everything else automatically.

Implementation order followed the plan:

1. `pingledger.go` + tests (Add / Ack / Oldest / Len, concurrent-safe).
2. `settings.go` — added `PongTimeout` field (`envDefault:\"30s\"`) plus
   a cross-field `Validate` check (`PongTimeout < ClientPingInterval`
   when both > 0). Tests extended in `settings_test.go` +
   `runtime_test.go` (env-load).
3. `connector.go` — switched ping-writer to a monotonic-counter token
   (the previous Unix-second token could collide on sub-second
   cadences), called `ledger.Add` before `WriteLine`, acked inbound
   PONGs in `dispatchLine`, and added the pong-watchdog goroutine
   with the eager state transition.
4. `connector_pong_timeout_test.go` — four scenarios: transition on
   miss, ack resets ledger, probe-disabled (`PongTimeout=0`) falls
   back to read-idle, server-reason threads through `DescribeUpstreamState`.

`ReadIdleTimeout` is unchanged and remains the defense-in-depth
backstop for the rare case where neither read nor write surfaces a
failure and `ClientPingInterval` is also disabled.

Sidecar / accounts-api / appui require zero changes — the state-emitter
will pick up the new transition automatically and downstream consumers
already render `connectors[].state`.

Closes follow-up #26 update.

## Test plan

- [x] `make test` (race + 120s timeout) — all packages green
- [x] `make lint` — 0 issues
- [x] `make cover-gate` — 94.6% total (94% threshold); IRC at 93.9%
  (93% threshold); both above floor
- [x] Backwards-compat: `TURBORG_IRC_PONG_TIMEOUT=0s` reverts to the
  pre-PR detection envelope (covered by `TestPongTimeoutDisabled`)