### PR TITLE
feat(irc): configurable QUIT body via TURBORG_IRC_QUIT_MESSAGE

### DIFF
--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1633,7 +1633,7 @@ func (c *Connector) Stop(_ context.Context) error {
 	}
 	var err error
 	c.stopOnce.Do(func() {
-		_ = cli.WriteLine(CmdQuit + " :bye")
+		_ = cli.WriteLine(CmdQuit + " :" + c.settings.EffectiveQuitMessage())
 		err = cli.Close()
 		c.setClient(nil)
 		c.machine.Transition(UpstreamStateStopped)

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -46,6 +46,15 @@ type Settings struct {
 	// the probe is also functionally disabled (no PINGs to time out).
 	PongTimeout time.Duration `env:"PONG_TIMEOUT" envDefault:"30s"`
 
+	// QuitMessage is the body sent on the IRC QUIT command during a
+	// graceful shutdown. Renders inside parentheses on every channel
+	// the agent was in (`* nick has quit (<reason>)`). Operators running
+	// a hosted turborg fleet usually set this to a service-identifying
+	// string so observers can tell which host / platform the bot was
+	// running on; the default keeps it project-attributed for self-
+	// hosted users.
+	QuitMessage string `env:"QUIT_MESSAGE" envDefault:"bye from turborg"`
+
 	BouncerPassword              string        `env:"BOUNCER_PASSWORD"`
 	BouncerHost                  string        `env:"BOUNCER_HOST" envDefault:"127.0.0.1"`
 	BouncerPort                  int           `env:"BOUNCER_PORT" envDefault:"31337"`
@@ -137,6 +146,17 @@ func (s *Settings) EffectiveUsername() string {
 		return s.Username
 	}
 	return s.Nick
+}
+
+// EffectiveQuitMessage returns QuitMessage if set, otherwise the
+// project-attributed fallback. Used so tests that build Settings by
+// hand (bypassing LoadSettings + envDefault) still emit a sensible
+// QUIT body instead of `QUIT :` with an empty trailing parameter.
+func (s *Settings) EffectiveQuitMessage() string {
+	if s.QuitMessage != "" {
+		return s.QuitMessage
+	}
+	return "bye from turborg"
 }
 
 // SASLEnabled is true when both credentials are present.

--- a/internal/connector/irc/settings_test.go
+++ b/internal/connector/irc/settings_test.go
@@ -20,6 +20,7 @@ func TestLoadSettingsFromEnv(t *testing.T) {
 	t.Setenv("TURBORG_IRC_PORT", "6667")
 	t.Setenv("TURBORG_IRC_READ_IDLE_TIMEOUT", "60s")
 	t.Setenv("TURBORG_IRC_CLIENT_PING_INTERVAL", "30s")
+	t.Setenv("TURBORG_IRC_QUIT_MESSAGE", "see ya")
 
 	s, err := irc.LoadSettings()
 	require.NoError(t, err)
@@ -36,6 +37,8 @@ func TestLoadSettingsFromEnv(t *testing.T) {
 	assert.Equal(t, 30*time.Second, s.ClientPingInterval)
 	assert.Equal(t, 30*time.Second, s.PongTimeout,
 		"PongTimeout defaults to 30s when no env override is supplied")
+	assert.Equal(t, "see ya", s.QuitMessage)
+	assert.Equal(t, "see ya", s.EffectiveQuitMessage())
 }
 
 func TestLoadSettingsDefaults(t *testing.T) {
@@ -54,6 +57,21 @@ func TestLoadSettingsDefaults(t *testing.T) {
 	assert.Equal(t, 120*time.Second, s.ClientPingInterval)
 	assert.True(t, s.CTCPAutoReply)
 	assert.Equal(t, 3, s.CTCPMaxPerWindow)
+	assert.Equal(t, "bye from turborg", s.QuitMessage,
+		"default QUIT body is project-attributed for self-hosted users")
+	assert.Equal(t, "bye from turborg", s.EffectiveQuitMessage())
+}
+
+func TestEffectiveQuitMessageFallsBackWhenEmpty(t *testing.T) {
+	// Tests that build Settings by hand (bypassing LoadSettings + envDefault)
+	// still get a sensible fallback rather than an empty trailing parameter.
+	s := &irc.Settings{}
+	assert.Equal(t, "bye from turborg", s.EffectiveQuitMessage())
+}
+
+func TestEffectiveQuitMessageOverride(t *testing.T) {
+	s := &irc.Settings{QuitMessage: "turborg @ www.xshellz.com"}
+	assert.Equal(t, "turborg @ www.xshellz.com", s.EffectiveQuitMessage())
 }
 
 func TestLoadSettingsRejectsBadInt(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace the hardcoded `"bye"` QUIT body in `Connector.Stop()` with a configurable `Settings.QuitMessage` (env `TURBORG_IRC_QUIT_MESSAGE`).
- New default is `"bye from turborg"` — keeps the project attribution that the previous `"bye"` was missing on every channel the agent was in.
- Operators running a hosted fleet override the env per container (e.g. `"turborg @ <host>.example.com"`); self-hosted users get the new branded default with no config change.

## Why

The graceful-shutdown body surfaces inside parentheses on every channel (`* nick has quit (<reason>)`). The current `"bye"` loses the chance to identify the project on shutdown — both for promotion AND for users wondering "what bot was that".

## Test plan

- [x] `TestLoadSettingsFromEnv` extended — `TURBORG_IRC_QUIT_MESSAGE=see ya` round-trips through `LoadSettings()`.
- [x] `TestLoadSettingsDefaults` extended — default is `"bye from turborg"`.
- [x] New `TestEffectiveQuitMessageFallsBackWhenEmpty` covers the test-built-Settings path.
- [x] New `TestEffectiveQuitMessageOverride` confirms the getter returns the override.
- [x] `go vet ./...` clean, `go test ./internal/connector/irc/...` green.