### PR TITLE
fix: upstream reconnect sync (backoff, members, gateway initial state) + devirc dev tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ Thumbs.db
 # Local-only plans + Claude notes
 PLAN-*.md
 CLAUDE.md
+# Compiled devirc binary; leading slash so it doesn't shadow cmd/devirc/ source.
+/devirc

--- a/cmd/devirc/main.go
+++ b/cmd/devirc/main.go
@@ -1,0 +1,364 @@
+// Command devirc is a minimal IRC stub for local dev. It speaks just
+// enough IRC (CAP / NICK / USER / AUTHENTICATE / JOIN / PING) for a
+// turborg agent to complete its handshake and look "registered", then
+// exposes an HTTP control plane on a separate port so you can trigger
+// netsplit-shaped failures from the shell.
+//
+// Listens plain TCP only — disable TLS in the bot's connector config
+// (TURBORG_IRC_USE_TLS=false) when pointing it here.
+//
+// HTTP control endpoints (POST):
+//
+//	/kill    close the active client connection (simulate a netsplit
+//	         drop — bot's read loop sees EOF, supervisor reconnects)
+//	/pause   /kill, plus stop accepting new connections until /resume
+//	         (simulate a fully unreachable upstream — bot churns through
+//	         the backoff schedule)
+//	/resume  re-open the listener
+//	/status  return current state (clients, totalAccepted, paused)
+//
+// Example:
+//
+//	go run ./cmd/devirc -irc :16667 -ctrl :16668
+//	# wait until the bot connects (see status)
+//	curl -X POST localhost:16668/kill
+//	# bot reconnects on its own — kill again to bounce, /pause to stall
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+func main() {
+	ircAddr := flag.String("irc", ":16667", "IRC listen address (plain TCP, no TLS)")
+	ctrlAddr := flag.String("ctrl", ":16668", "HTTP control-plane listen address")
+	serverName := flag.String("server", "devirc", "Server name used in server-originated lines")
+	flag.Parse()
+
+	s := newServer(*serverName)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go s.runIRC(ctx, *ircAddr)
+	go s.runCtrl(ctx, *ctrlAddr)
+
+	log.Printf("devirc: IRC=%s ctrl=%s server=%s", *ircAddr, *ctrlAddr, *serverName)
+	log.Printf("devirc: try `curl -X POST localhost%s/kill` to simulate a netsplit", *ctrlAddr)
+	<-ctx.Done()
+	log.Printf("devirc: shutting down")
+	s.shutdown()
+}
+
+type server struct {
+	serverName string
+
+	mu             sync.Mutex
+	listener       net.Listener
+	clients        map[*client]struct{}
+	paused         bool
+	totalAccepted  int64
+	totalDropped   int64
+	totalHandshake int64
+}
+
+type client struct {
+	conn  net.Conn
+	nick  string
+	w     *bufio.Writer
+	wmu   sync.Mutex
+	saslState string // "", "PLAIN", "done"
+	capLS bool
+	registered bool
+}
+
+func newServer(name string) *server {
+	return &server{
+		serverName: name,
+		clients:    make(map[*client]struct{}),
+	}
+}
+
+func (s *server) runIRC(ctx context.Context, addr string) {
+	for {
+		if err := s.listenIRC(ctx, addr); err != nil && ctx.Err() == nil {
+			log.Printf("devirc IRC listener: %v — retrying in 1s", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		return
+	}
+}
+
+func (s *server) listenIRC(ctx context.Context, addr string) error {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.listener = l
+	s.mu.Unlock()
+	go func() { <-ctx.Done(); _ = l.Close() }()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			// Paused/closed listener will surface here as ErrClosed; outer
+			// loop sleeps + retries until /resume re-opens.
+			if errors.Is(err, net.ErrClosed) {
+				return err
+			}
+			log.Printf("devirc accept: %v", err)
+			continue
+		}
+		s.mu.Lock()
+		s.totalAccepted++
+		s.mu.Unlock()
+		c := &client{conn: conn, w: bufio.NewWriter(conn)}
+		s.mu.Lock()
+		s.clients[c] = struct{}{}
+		s.mu.Unlock()
+		log.Printf("devirc: client connected %s", conn.RemoteAddr())
+		go s.serveClient(c)
+	}
+}
+
+func (s *server) serveClient(c *client) {
+	defer func() {
+		_ = c.conn.Close()
+		s.mu.Lock()
+		delete(s.clients, c)
+		s.mu.Unlock()
+		log.Printf("devirc: client gone (nick=%q registered=%v)", c.nick, c.registered)
+	}()
+	r := bufio.NewReader(c.conn)
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			continue
+		}
+		s.handle(c, line)
+	}
+}
+
+// handle dispatches one IRC line. The branch count is naturally high
+// (one case per supported command); splitting into per-command methods
+// would be more noise than signal for a 200-line stub.
+//
+//nolint:gocyclo // intentional: dispatch table for a dev IRC stub
+func (s *server) handle(c *client, line string) {
+	upper := strings.ToUpper(line)
+	switch {
+	case strings.HasPrefix(upper, "CAP LS"):
+		c.send(":" + s.serverName + " CAP * LS :sasl message-tags server-time multi-prefix")
+		c.capLS = true
+	case strings.HasPrefix(upper, "CAP REQ"):
+		idx := strings.Index(line, ":")
+		caps := ""
+		if idx >= 0 && idx+1 < len(line) {
+			caps = strings.TrimSpace(line[idx+1:])
+		}
+		c.send(":" + s.serverName + " CAP * ACK :" + caps)
+	case upper == "CAP END":
+		// no-op; client signals end of CAP negotiation
+	case strings.HasPrefix(upper, "AUTHENTICATE PLAIN"):
+		c.saslState = "PLAIN"
+		c.send("AUTHENTICATE +")
+	case strings.HasPrefix(upper, "AUTHENTICATE "):
+		if c.saslState == "PLAIN" {
+			c.send(":" + s.serverName + " 903 " + nz(c.nick, "*") + " :SASL successful")
+			c.saslState = "done"
+		}
+	case strings.HasPrefix(upper, "NICK "):
+		c.nick = strings.TrimSpace(line[5:])
+	case strings.HasPrefix(upper, "USER "):
+		if c.nick == "" {
+			c.nick = "guest"
+		}
+		nick := c.nick
+		c.send(":" + s.serverName + " 001 " + nick + " :Welcome to devirc")
+		c.send(":" + s.serverName + " 002 " + nick + " :Your host is " + s.serverName)
+		c.send(":" + s.serverName + " 003 " + nick + " :This server was created today")
+		c.send(":" + s.serverName + " 004 " + nick + " " + s.serverName + " devirc-1 o o")
+		c.send(":" + s.serverName + " 005 " + nick + " PREFIX=(ohv)@%+ CHANTYPES=# :are supported by this server")
+		c.send(":" + s.serverName + " 375 " + nick + " :- devirc MOTD -")
+		c.send(":" + s.serverName + " 372 " + nick + " :- this is a dev IRC stub")
+		c.send(":" + s.serverName + " 376 " + nick + " :End of MOTD command")
+		c.registered = true
+		s.mu.Lock()
+		s.totalHandshake++
+		s.mu.Unlock()
+	case strings.HasPrefix(upper, "PING "):
+		token := strings.TrimSpace(line[5:])
+		token = strings.TrimPrefix(token, ":")
+		c.send(":" + s.serverName + " PONG " + s.serverName + " :" + token)
+	case strings.HasPrefix(upper, "JOIN "):
+		ch := strings.TrimSpace(line[5:])
+		// Channel can be "#foo" or "#foo key"
+		if sp := strings.IndexByte(ch, ' '); sp >= 0 {
+			ch = ch[:sp]
+		}
+		nick := nz(c.nick, "*")
+		c.send(":" + nick + "!~u@host JOIN " + ch)
+		c.send(":" + s.serverName + " 332 " + nick + " " + ch + " :devirc topic")
+		c.send(":" + s.serverName + " 353 " + nick + " = " + ch + " :@" + nick)
+		c.send(":" + s.serverName + " 366 " + nick + " " + ch + " :End of NAMES list")
+	}
+	// Lines we don't pattern-match (PRIVMSG, NOTICE, QUIT, ...) silently
+	// fall through. QUIT in particular doesn't need a handler — the bot
+	// closes its side after sending it; the read loop hits EOF and
+	// serveClient unwinds.
+}
+
+func (c *client) send(line string) {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	_, _ = c.w.WriteString(line + "\r\n")
+	_ = c.w.Flush()
+}
+
+// runCtrl serves the HTTP control plane.
+func (s *server) runCtrl(ctx context.Context, addr string) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/kill", s.handleKill)
+	mux.HandleFunc("/pause", s.handlePause)
+	mux.HandleFunc("/resume", s.handleResume)
+	mux.HandleFunc("/status", s.handleStatus)
+
+	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go func() {
+		<-ctx.Done()
+		// Detach the shutdown deadline from the parent ctx — it's
+		// already cancelled, so srv.Shutdown would return immediately
+		// with ctx.Err. WithoutCancel + WithTimeout gives the graceful
+		// shutdown a real 2s budget independent of the trigger ctx.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Printf("devirc control: %v", err)
+	}
+}
+
+func (s *server) handleKill(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	n := s.killAll()
+	log.Printf("devirc: /kill dropped %d client(s)", n)
+	respondJSON(w, map[string]any{"dropped": n})
+}
+
+func (s *server) handlePause(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.Lock()
+	s.paused = true
+	l := s.listener
+	s.listener = nil
+	s.mu.Unlock()
+	if l != nil {
+		_ = l.Close()
+	}
+	n := s.killAll()
+	log.Printf("devirc: /pause — listener closed, %d client(s) dropped", n)
+	respondJSON(w, map[string]any{"paused": true, "dropped": n})
+}
+
+func (s *server) handleResume(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	s.mu.Lock()
+	wasPaused := s.paused
+	s.paused = false
+	s.mu.Unlock()
+	if wasPaused {
+		log.Printf("devirc: /resume — listener will re-open on the next outer-loop tick")
+	}
+	respondJSON(w, map[string]any{"paused": false, "was_paused": wasPaused})
+}
+
+func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	clients := make([]map[string]any, 0, len(s.clients))
+	for c := range s.clients {
+		clients = append(clients, map[string]any{
+			"remote":     c.conn.RemoteAddr().String(),
+			"nick":       c.nick,
+			"registered": c.registered,
+		})
+	}
+	resp := map[string]any{
+		"paused":          s.paused,
+		"clients":         clients,
+		"total_accepted":  s.totalAccepted,
+		"total_handshake": s.totalHandshake,
+		"total_dropped":   s.totalDropped,
+	}
+	s.mu.Unlock()
+	respondJSON(w, resp)
+}
+
+func (s *server) killAll() int {
+	s.mu.Lock()
+	conns := make([]net.Conn, 0, len(s.clients))
+	for c := range s.clients {
+		conns = append(conns, c.conn)
+	}
+	s.totalDropped += int64(len(conns))
+	s.mu.Unlock()
+	for _, c := range conns {
+		_ = c.Close()
+	}
+	return len(conns)
+}
+
+func (s *server) shutdown() {
+	s.mu.Lock()
+	l := s.listener
+	s.listener = nil
+	s.mu.Unlock()
+	if l != nil {
+		_ = l.Close()
+	}
+	s.killAll()
+}
+
+func respondJSON(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func nz(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}
+
+var _ = fmt.Sprintf

--- a/internal/connector/irc/codes.go
+++ b/internal/connector/irc/codes.go
@@ -8,6 +8,14 @@ const (
 	RplYourHost      = "002"
 	RplCreated       = "003"
 	RplMyInfo        = "004"
+	RplISupport      = "005"
+	RplLUserClient   = "251"
+	RplLUserOp       = "252"
+	RplLUserUnknown  = "253"
+	RplLUserChannels = "254"
+	RplLUserMe       = "255"
+	RplMOTD          = "372"
+	RplMOTDStart     = "375"
 	RplWhoisUser     = "311"
 	RplWhoisServer   = "312"
 	RplWhoisOperator = "313"
@@ -72,6 +80,7 @@ const (
 	CmdList          = "LIST"
 	CmdWho           = "WHO"
 	CmdAuthenticate  = "AUTHENTICATE"
+	CmdError         = "ERROR"
 )
 
 // IsHandshakeComplete reports whether the given numeric reply signals the

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -791,9 +791,32 @@ func (c *Connector) awaitHandshake(ctx context.Context) error {
 		case ErrNotRegistered:
 			return fmt.Errorf("irc handshake: server rejected pre-registration command (451)")
 		}
+		// Welcome / info / MOTD numerics all arrive during the handshake
+		// window — before runSession's main dispatcher takes over. Mirror
+		// them to the server tab here so the SPA's Server view shows them
+		// streaming in instead of staying empty until the next runtime
+		// notice (which on a healthy bot may never come).
+		c.maybePublishHandshakeServerNotice(hctx, msg)
 		if IsHandshakeComplete(msg.Command) {
 			return nil
 		}
+	}
+}
+
+// maybePublishHandshakeServerNotice forwards welcome / info / MOTD
+// numerics seen during awaitHandshake to the agent bus so the gateway
+// can replay them to attached SPA clients. Mirrors the parallel cases
+// in the main runSession dispatcher; the duplication is intentional
+// because handshake-window lines never reach that dispatcher.
+func (c *Connector) maybePublishHandshakeServerNotice(ctx context.Context, msg Message) {
+	switch msg.Command {
+	case RplWelcome:
+		c.publishServerNotice(ctx, "welcome", msg.Trailing)
+	case RplYourHost, RplCreated, RplMyInfo, RplISupport,
+		RplLUserClient, RplLUserOp, RplLUserUnknown, RplLUserChannels, RplLUserMe:
+		c.publishServerNotice(ctx, "info", serverNoticeText(msg))
+	case RplMOTDStart, RplMOTD, RplEndOfMOTD, ErrNoMOTD:
+		c.publishServerNotice(ctx, "motd", serverNoticeText(msg))
 	}
 }
 

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1328,6 +1328,39 @@ func (c *Connector) dispatchLine(ctx context.Context, line string) {
 		if len(msg.Params) > 0 {
 			c.setCurrentNick(msg.Params[0])
 		}
+		c.publishServerNotice(ctx, "welcome", msg.Trailing)
+	case RplYourHost, RplCreated, RplMyInfo, RplISupport,
+		RplLUserClient, RplLUserOp, RplLUserUnknown, RplLUserChannels, RplLUserMe:
+		// Connection-info numerics (server name, version, user counts,
+		// supported features). Forward as `info` to the server tab so
+		// users see something land during the handshake instead of a
+		// blank Server tab. Trailing carries the human-readable text
+		// for these; if a server pulls a non-RFC shape that puts the
+		// content in params, fall back to the joined params.
+		c.publishServerNotice(ctx, "info", serverNoticeText(msg))
+	case RplMOTDStart, RplMOTD, RplEndOfMOTD, ErrNoMOTD:
+		// The MOTD block. RPL_MOTDSTART (375) / RPL_MOTD (372) /
+		// RPL_ENDOFMOTD (376) are the standard shape; ERR_NOMOTD (422)
+		// stands in for servers that have no MOTD configured.
+		c.publishServerNotice(ctx, "motd", serverNoticeText(msg))
+	case CmdError:
+		// :server ERROR :<reason> — pre-disconnect server-originated
+		// failure (banned, throttled, etc.). The supervisor's
+		// ClassifyERRORLine already drives the upstream state machine
+		// for this; mirror the body to the server tab so the user
+		// sees the reason in the chat surface too.
+		c.publishServerNotice(ctx, "error", serverNoticeText(msg))
+	case CmdNotice:
+		// Server-originated NOTICE (no `!user@host` in the prefix) —
+		// pre-registration "NOTICE AUTH :*** Looking up your
+		// hostname" lines, services bot greetings, etc. — flow into
+		// the server tab. Client-originated NOTICEs (with a user
+		// hostmask prefix) are intentionally left unhandled here:
+		// the bot has no PRIVMSG-equivalent path for NOTICE today,
+		// and silently dropping matches the pre-existing behaviour.
+		if isServerPrefix(msg.Prefix) {
+			c.publishServerNotice(ctx, "notice", serverNoticeText(msg))
+		}
 	case CmdPrivmsg:
 		c.handlePrivmsg(ctx, msg, line)
 	case CmdJoin:
@@ -1658,6 +1691,56 @@ func (c *Connector) publish(ctx context.Context, ev agent.Event) {
 		return
 	}
 	c.events.Publish(ctx, &ev)
+}
+
+// publishServerNotice fans a server-originated line out to the agent
+// event bus for the gateway to broadcast as `op:server` to attached
+// WS clients. Used for welcome, MOTD, info numerics, server NOTICEs
+// and pre-disconnect ERROR lines — the content that lands in the
+// SPA's synthetic "server" tab on connect.
+func (c *Connector) publishServerNotice(ctx context.Context, kind, text string) {
+	if text == "" {
+		return
+	}
+	c.publish(ctx, agent.Event{
+		Type: agent.EventServerNotice,
+		Fields: map[string]any{
+			"connector": c.Name(),
+			"kind":      kind,
+			"text":      text,
+		},
+	})
+}
+
+// serverNoticeText pulls a human-readable body out of a server message.
+// Most server numerics carry their description in the trailing parameter
+// (`:Welcome to the network`), but a few RFC-loose servers stuff the
+// content into space-separated params instead. Fall back to joining the
+// non-target params so 002/003/004-style messages still render
+// something useful.
+func serverNoticeText(msg Message) string {
+	if msg.Trailing != "" {
+		return msg.Trailing
+	}
+	// Skip the first param when it looks like the bot's own nick (a
+	// recipient identifier most numerics emit). Without this we'd
+	// surface "alice" prefixed to every line.
+	params := msg.Params
+	if len(params) > 1 {
+		params = params[1:]
+	}
+	return strings.TrimSpace(strings.Join(params, " "))
+}
+
+// isServerPrefix reports whether a message prefix identifies a server
+// rather than a user. User prefixes carry `!user@host`; server prefixes
+// are a bare hostname like `irc.libera.chat`. Empty prefix also counts
+// as server-originated (some servers omit it for global notices).
+func isServerPrefix(prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	return !strings.ContainsRune(prefix, '!')
 }
 
 func (c *Connector) Stop(_ context.Context) error {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1398,6 +1398,8 @@ func (c *Connector) dispatchLine(ctx context.Context, line string) {
 		c.handleNickChange(ctx, msg)
 	case CmdTopic:
 		c.handleTopic(ctx, msg)
+	case CmdMode:
+		c.handleMode(ctx, msg)
 	case RplTopic:
 		// :server 332 nick #ch :topic
 		if len(msg.Params) >= 2 {
@@ -1669,6 +1671,118 @@ func (c *Connector) handleNickChange(ctx context.Context, msg Message) {
 			"new":       newNick,
 		},
 	})
+}
+
+// handleMode handles `:setter MODE #channel <modes> [args...]` lines.
+// It does two things:
+//
+//  1. Update the bot's local ChannelState so prefix changes (q/a/o/h/v)
+//     are reflected in member.Mode for the next sendState snapshot —
+//     otherwise newly-attaching WS clients see a stale view until the
+//     next NAMES sync.
+//  2. Publish EventModeChanged so the gateway can broadcast op:mode_changed
+//     to currently-attached clients. The wire payload mirrors what the
+//     SPA's mode_changed dispatcher already consumes (channel + modes
+//     + args + setBy).
+//
+// User-targeted modes (where param[0] doesn't look like a channel) are
+// ignored — they're personal flags on the bot, not channel state.
+func (c *Connector) handleMode(ctx context.Context, msg Message) {
+	if len(msg.Params) < 2 {
+		return
+	}
+	channel := msg.Params[0]
+	if !startsWithChannelSigil(channel) {
+		return
+	}
+	modes := msg.Params[1]
+	args := msg.Params[2:]
+
+	// Walk the mode string. For each prefix-mode letter (q/a/o/h/v)
+	// we consume one arg and update the affected member's displayed
+	// prefix. Non-prefix arg-consuming modes (b/e/I/k/l/f/j) also
+	// consume args; we skip them but advance the cursor so subsequent
+	// prefix-mode-arg alignment stays correct.
+	applyPrefixModesToState(c.state, channel, modes, args)
+
+	c.publish(ctx, agent.Event{
+		Type: agent.EventModeChanged,
+		Fields: map[string]any{
+			"connector": c.Name(),
+			"channel":   channel,
+			"modes":     modes,
+			"args":      strings.Join(args, " "),
+			"by":        Nick(msg.Prefix),
+		},
+	})
+}
+
+// applyPrefixModesToState mutates `state` in place for any prefix-mode
+// (q/a/o/h/v) changes carried by the MODE line. Mirrors the SPA-side
+// applyPrefixModeChange so the bot's view and the SPA's view converge
+// on the same displayed prefix after the same input. Only the highest
+// active prefix is stored (the displayed one) — the lower modes a
+// user may also hold are not tracked separately, the next NAMES sync
+// is the authoritative source if it matters.
+func applyPrefixModesToState(state *ChannelState, channel, modes string, args []string) {
+	if state == nil {
+		return
+	}
+	prefixForLetter := map[byte]string{'q': "~", 'a': "&", 'o': "@", 'h': "%", 'v': "+"}
+	prefixRank := map[string]int{"~": 0, "&": 1, "@": 2, "%": 3, "+": 4, "": 5}
+	// Modes that consume an arg in BOTH + and - (prefix modes plus
+	// list modes plus always-arg chan modes). `l` is the only common
+	// arg-on-set-only mode worth modeling.
+	argBoth := map[byte]bool{
+		'q': true, 'a': true, 'o': true, 'h': true, 'v': true,
+		'b': true, 'e': true, 'I': true, 'k': true, 'f': true, 'j': true,
+	}
+	argAddOnly := map[byte]bool{'l': true}
+
+	info := state.Get(channel)
+	if info == nil {
+		return
+	}
+
+	argIdx := 0
+	adding := true
+	for i := 0; i < len(modes); i++ {
+		c := modes[i]
+		if c == '+' {
+			adding = true
+			continue
+		}
+		if c == '-' {
+			adding = false
+			continue
+		}
+		consumesArg := argBoth[c] || (adding && argAddOnly[c])
+		var arg string
+		if consumesArg && argIdx < len(args) {
+			arg = args[argIdx]
+			argIdx++
+		}
+		prefix, isPrefixMode := prefixForLetter[c]
+		if !isPrefixMode || arg == "" {
+			continue
+		}
+		current, present := info.Members[arg]
+		if !present {
+			continue
+		}
+		if adding {
+			// Promote only if the new prefix outranks the displayed
+			// one. Granting +v to an op shouldn't visually demote.
+			if prefixRank[prefix] < prefixRank[current] {
+				state.SetMemberPrefix(channel, arg, prefix)
+			}
+		} else if current == prefix {
+			// Removing the displayed prefix: drop to empty. A subsequent
+			// NAMES sync restores any lower prefix the user may still
+			// hold (we don't track multi-prefix membership in real-time).
+			state.SetMemberPrefix(channel, arg, "")
+		}
+	}
 }
 
 func (c *Connector) handleTopic(ctx context.Context, msg Message) {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1546,11 +1546,28 @@ func (c *Connector) handleQuit(ctx context.Context, msg Message) {
 	if nick == "" {
 		return
 	}
+	// Snapshot which channels the nick was in BEFORE the state mutation,
+	// so we can fan out a per-channel EventUserLeave for each. The web
+	// gateway translates EventUserLeave → op:part on the wire, and the
+	// SPA's part handler looks up the channel by name. Without a
+	// channel field the SPA can't find the channel and silently no-ops,
+	// leaving the QUITting nick ghosted in every member list it was
+	// in. IRC QUIT is network-wide; the user-facing model in clients
+	// is per-channel removal.
+	affected := c.state.ChannelsContaining(nick)
 	c.state.OnMemberQuit(nick)
-	c.publish(ctx, agent.Event{
-		Type:   agent.EventUserLeave,
-		Fields: map[string]any{"connector": c.Name(), "nick": nick, "reason": msg.Trailing},
-	})
+	reason := msg.Trailing
+	for _, channel := range affected {
+		c.publish(ctx, agent.Event{
+			Type: agent.EventUserLeave,
+			Fields: map[string]any{
+				"connector": c.Name(),
+				"channel":   channel,
+				"nick":      nick,
+				"reason":    reason,
+			},
+		})
+	}
 }
 
 func (c *Connector) handleKick(ctx context.Context, msg Message) {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -39,7 +39,7 @@ func (e *pongTimeoutError) Temporary() bool { return true }
 //     RPL_ENDOFMOTD or ERR_NOMOTD, JOIN configured channels, send
 //     NickServ IDENTIFY if configured, start the bouncer if configured.
 //   - Run: long-lived supervised loop owned by Agent's errgroup. Reader
-//     + dispatcher, all unwound on ctx cancel via SetReadDeadline.
+//   - dispatcher, all unwound on ctx cancel via SetReadDeadline.
 //   - Stop: send QUIT, close the upstream, stop the bouncer. Idempotent.
 type Connector struct {
 	settings *Settings
@@ -61,9 +61,9 @@ type Connector struct {
 	// paused. Initialised in New so callers can subscribe before Start.
 	machine *UpstreamStateMachine
 
-	state    *ChannelState
-	bouncer  *Bouncer
-	ctcp     *Throttle
+	state   *ChannelState
+	bouncer *Bouncer
+	ctcp    *Throttle
 
 	// wanted is the "channels I want to be in" set the reconnect
 	// supervisor replays JOINs from. Seeded at construction from the
@@ -132,7 +132,75 @@ type Connector struct {
 	// that bypass runSession) makes the ack a no-op.
 	pingLedgerRef atomic.Pointer[pingLedger]
 
+	// whoisInFlight accumulates the multi-numeric WHOIS response (311/
+	// 312/313/317/319/330/671) keyed by lower-case target nick. Cleared
+	// on RPL_ENDOFWHOIS (318) or ERR_NOSUCHNICK (401) once the
+	// EventWhoisResult is published. Concurrent /whois on different
+	// nicks are isolated by the map key; same-nick interleaving merges
+	// into a single result (last-write-wins for any duplicated field).
+	whoisMu       sync.Mutex
+	whoisInFlight map[string]*whoisBuilder
+
+	// listInFlight accumulates RPL_LIST (322) items between 321 (start)
+	// or first 322 and 323 (end). Single buffer because IRC /LIST is
+	// network-global, not per-target — two concurrent calls overlap on
+	// the same numeric stream so we have no signal to split them.
+	listMu       sync.Mutex
+	listInFlight []listChannelEntry
+
+	// whoInFlight accumulates RPL_WHOREPLY (352) items keyed by lower-
+	// case query target (channel or mask). Cleared on RPL_ENDOFWHO
+	// (315) when the EventWhoResult is published. Per-target keying so
+	// /who #a and /who #b running simultaneously stay isolated.
+	whoMu       sync.Mutex
+	whoInFlight map[string]*whoBuilder
+
 	stopOnce sync.Once
+}
+
+// whoisBuilder accumulates a WHOIS response across the 311/312/313/317/
+// 319/330/671 numerics. Optional fields default to their zero value;
+// the publisher only adds them to the agent.Event map when they were
+// populated, so the SPA's WhoisResultEvent retains its
+// undefined-vs-empty-string distinction.
+type whoisBuilder struct {
+	nick        string
+	user        string
+	host        string
+	realName    string
+	server      string
+	serverInfo  string
+	account     string
+	idleSeconds int64
+	signonAt    int64
+	secure      bool
+	isOperator  bool
+	channels    []string
+}
+
+// listChannelEntry mirrors one RPL_LIST (322) row aggregated into the
+// EventListResult payload. Optional users/topic stay empty when the
+// server omits them (some IRCDs send only the channel name).
+type listChannelEntry struct {
+	name  string
+	users int
+	topic string
+}
+
+// whoBuilder accumulates RPL_WHOREPLY (352) rows for a /WHO target
+// until RPL_ENDOFWHO (315) closes the request.
+type whoBuilder struct {
+	target string
+	users  []whoUserEntry
+}
+
+// whoUserEntry mirrors one row of a /WHO reply.
+type whoUserEntry struct {
+	nick     string
+	user     string
+	host     string
+	realName string
+	flags    string
 }
 
 // New constructs an IRC Connector. Pass nil for events when the agent is
@@ -182,10 +250,10 @@ func (c *Connector) setClient(cli *Client) {
 // lifetime of the Connector.
 func (c *Connector) UpstreamState() *UpstreamStateMachine { return c.machine }
 
-func (c *Connector) Name() string                          { return "irc" }
+func (c *Connector) Name() string                           { return "irc" }
 func (c *Connector) Inbound() <-chan *agent.InboundEnvelope { return c.inbox }
-func (c *Connector) ClaimSupervision() bool                { return true }
-func (c *Connector) State() *ChannelState                  { return c.state }
+func (c *Connector) ClaimSupervision() bool                 { return true }
+func (c *Connector) State() *ChannelState                   { return c.state }
 
 // SetClientLimits installs the operator-policy struct that gates
 // client-initiated commands (NICK, USER realname, JOIN-vs-channel-cap).
@@ -1450,6 +1518,29 @@ func (c *Connector) dispatchLine(ctx context.Context, line string) {
 	case ErrBannedFromChan, ErrBadChannelKey, ErrChannelIsFull,
 		ErrInviteOnlyChan, ErrBadChanMask:
 		c.handleJoinFailure(ctx, msg)
+	case RplWhoisUser,
+		RplWhoisServer,
+		RplWhoisOperator,
+		RplWhoisIdle,
+		RplWhoisChannels,
+		RplWhoisAccount,
+		RplWhoisSecure,
+		RplEndOfWhois:
+		c.handleWhoisNumeric(ctx, msg)
+	case RplListStart, RplList, RplListEnd:
+		c.handleListNumeric(ctx, msg)
+	case RplWhoReply, RplEndOfWho:
+		c.handleWhoNumeric(ctx, msg)
+	case ErrNoSuchNick:
+		// `WHOIS phantom` → server replies with 401. If we have a
+		// whois in flight for that nick, finalise it with an error so
+		// the SPA's modal renders a friendly "no such nick" instead
+		// of staying empty. Standalone 401s (the bot is told it sent
+		// PRIVMSG/NOTICE to a vanished nick) hit this too — harmless
+		// no-op when no whois is in flight.
+		if len(msg.Params) >= 2 {
+			c.handleWhoisNoSuchNick(ctx, msg.Params[1], msg.Trailing)
+		}
 	}
 }
 
@@ -1783,6 +1874,288 @@ func applyPrefixModesToState(state *ChannelState, channel, modes string, args []
 			state.SetMemberPrefix(channel, arg, "")
 		}
 	}
+}
+
+// handleWhoisNumeric accumulates one WHOIS numeric into the in-flight
+// builder for the target nick. On RPL_ENDOFWHOIS (318) the builder is
+// snapshotted into an EventWhoisResult and cleared. The map key uses
+// case-folded nicks so 311/318 from servers that send the original
+// casing both target the same in-flight entry.
+//
+// All numerics share the shape `:server NNN mynick targetnick ...rest`.
+// Param indexing assumes that; defensively bails when params are too
+// short rather than panicking.
+func (c *Connector) handleWhoisNumeric(ctx context.Context, msg Message) {
+	if len(msg.Params) < 2 {
+		return
+	}
+	targetNick := msg.Params[1]
+	b := c.whoisBuilderFor(targetNick)
+	if b.nick == "" {
+		b.nick = targetNick
+	}
+	switch msg.Command {
+	case RplWhoisUser:
+		// 311 mynick target user host * :realname
+		if len(msg.Params) >= 4 {
+			b.user = msg.Params[2]
+			b.host = msg.Params[3]
+		}
+		b.realName = msg.Trailing
+	case RplWhoisServer:
+		// 312 mynick target server :serverInfo
+		if len(msg.Params) >= 3 {
+			b.server = msg.Params[2]
+		}
+		b.serverInfo = msg.Trailing
+	case RplWhoisOperator:
+		b.isOperator = true
+	case RplWhoisIdle:
+		// 317 mynick target idle_seconds [signon_unix] :seconds idle
+		if len(msg.Params) >= 3 {
+			b.idleSeconds = parseUnixSeconds(msg.Params[2])
+		}
+		if len(msg.Params) >= 4 {
+			b.signonAt = parseUnixSeconds(msg.Params[3])
+		}
+	case RplWhoisChannels:
+		// 319 mynick target :@#foo +#bar #baz
+		if msg.Trailing != "" {
+			for _, ch := range strings.Fields(msg.Trailing) {
+				// Strip prefix glyphs (~ & @ % +) so the SPA gets a
+				// clean channel name to render — modes are surfaced
+				// separately if/when the user opens that channel.
+				b.channels = append(b.channels, strings.TrimLeft(ch, "~&@%+"))
+			}
+		}
+	case RplWhoisAccount:
+		// 330 mynick target account :is logged in as
+		if len(msg.Params) >= 3 {
+			b.account = msg.Params[2]
+		}
+	case RplWhoisSecure:
+		b.secure = true
+	case RplEndOfWhois:
+		c.publishWhoisResult(ctx, targetNick, b, "")
+	}
+}
+
+// handleWhoisNoSuchNick finalises an in-flight whois with an error and
+// publishes. If no whois is in flight for this nick the 401 is unrelated
+// (e.g. a stale PRIVMSG target) and we silently no-op.
+func (c *Connector) handleWhoisNoSuchNick(ctx context.Context, targetNick, reason string) {
+	c.whoisMu.Lock()
+	b, ok := c.whoisInFlight[strings.ToLower(targetNick)]
+	c.whoisMu.Unlock()
+	if !ok {
+		return
+	}
+	c.publishWhoisResult(ctx, targetNick, b, reason)
+}
+
+// whoisBuilderFor returns (creating if needed) the in-flight builder
+// for the target nick. Concurrent /whois calls on different nicks are
+// safely isolated by the map.
+func (c *Connector) whoisBuilderFor(targetNick string) *whoisBuilder {
+	key := strings.ToLower(targetNick)
+	c.whoisMu.Lock()
+	defer c.whoisMu.Unlock()
+	if c.whoisInFlight == nil {
+		c.whoisInFlight = make(map[string]*whoisBuilder)
+	}
+	b, ok := c.whoisInFlight[key]
+	if !ok {
+		b = &whoisBuilder{}
+		c.whoisInFlight[key] = b
+	}
+	return b
+}
+
+func (c *Connector) publishWhoisResult(ctx context.Context, targetNick string, b *whoisBuilder, errReason string) {
+	c.whoisMu.Lock()
+	delete(c.whoisInFlight, strings.ToLower(targetNick))
+	c.whoisMu.Unlock()
+
+	fields := map[string]any{
+		"connector": c.Name(),
+		"nick":      targetNick,
+	}
+	if errReason != "" {
+		fields["error"] = errReason
+	} else {
+		// Only emit populated fields so the SPA's WhoisResultEvent
+		// retains its undefined-vs-empty distinction. The renderer
+		// short-circuits rows whose value is undefined.
+		if b.user != "" {
+			fields["user"] = b.user
+		}
+		if b.host != "" {
+			fields["host"] = b.host
+		}
+		if b.realName != "" {
+			fields["realName"] = b.realName
+		}
+		if b.account != "" {
+			fields["account"] = b.account
+		}
+		if b.server != "" {
+			fields["server"] = b.server
+		}
+		if b.serverInfo != "" {
+			fields["serverInfo"] = b.serverInfo
+		}
+		if b.idleSeconds > 0 {
+			fields["idleSeconds"] = b.idleSeconds
+		}
+		if b.signonAt > 0 {
+			fields["signonAt"] = b.signonAt
+		}
+		if b.secure {
+			fields["secure"] = true
+		}
+		if b.isOperator {
+			fields["isOperator"] = true
+		}
+		if len(b.channels) > 0 {
+			fields["channels"] = b.channels
+		}
+	}
+	c.publish(ctx, agent.Event{
+		Type:   agent.EventWhoisResult,
+		Fields: fields,
+	})
+}
+
+// handleListNumeric accumulates RPL_LIST (322) rows and flushes on
+// RPL_LISTENED (323). RPL_LISTSTART (321) is informational only; some
+// servers omit it. /LIST is network-global so we share one buffer.
+func (c *Connector) handleListNumeric(ctx context.Context, msg Message) {
+	switch msg.Command {
+	case RplListStart:
+		c.listMu.Lock()
+		c.listInFlight = c.listInFlight[:0]
+		c.listMu.Unlock()
+	case RplList:
+		// 322 mynick channel #users :topic
+		if len(msg.Params) < 3 {
+			return
+		}
+		entry := listChannelEntry{name: msg.Params[1], topic: msg.Trailing}
+		if n, err := strconv.Atoi(msg.Params[2]); err == nil {
+			entry.users = n
+		}
+		c.listMu.Lock()
+		c.listInFlight = append(c.listInFlight, entry)
+		c.listMu.Unlock()
+	case RplListEnd:
+		c.listMu.Lock()
+		channels := make([]map[string]any, 0, len(c.listInFlight))
+		for _, e := range c.listInFlight {
+			row := map[string]any{"name": e.name}
+			if e.users > 0 {
+				row["users"] = e.users
+			}
+			if e.topic != "" {
+				row["topic"] = e.topic
+			}
+			channels = append(channels, row)
+		}
+		c.listInFlight = nil
+		c.listMu.Unlock()
+		c.publish(ctx, agent.Event{
+			Type: agent.EventListResult,
+			Fields: map[string]any{
+				"connector": c.Name(),
+				"channels":  channels,
+			},
+		})
+	}
+}
+
+// handleWhoNumeric accumulates RPL_WHOREPLY (352) rows and flushes on
+// RPL_ENDOFWHO (315). Keyed by lower-case query target so /who #a and
+// /who #b in flight at the same time don't smear into each other.
+func (c *Connector) handleWhoNumeric(ctx context.Context, msg Message) {
+	switch msg.Command {
+	case RplWhoReply:
+		// 352 mynick target user host server nick flags :hopcount realname
+		if len(msg.Params) < 7 {
+			return
+		}
+		target := msg.Params[1]
+		entry := whoUserEntry{
+			user:  msg.Params[2],
+			host:  msg.Params[3],
+			nick:  msg.Params[5],
+			flags: msg.Params[6],
+		}
+		// Trailing is `<hopcount> <realname>` — split on first space.
+		// Defensively handle malformed shapes that omit hopcount.
+		if msg.Trailing != "" {
+			if sp := strings.IndexByte(msg.Trailing, ' '); sp >= 0 {
+				entry.realName = msg.Trailing[sp+1:]
+			} else {
+				entry.realName = msg.Trailing
+			}
+		}
+		b := c.whoBuilderFor(target)
+		b.users = append(b.users, entry)
+	case RplEndOfWho:
+		// 315 mynick target :End of /WHO list
+		if len(msg.Params) < 2 {
+			return
+		}
+		target := msg.Params[1]
+		c.whoMu.Lock()
+		b, ok := c.whoInFlight[strings.ToLower(target)]
+		if ok {
+			delete(c.whoInFlight, strings.ToLower(target))
+		}
+		c.whoMu.Unlock()
+		if !ok {
+			b = &whoBuilder{target: target}
+		}
+		users := make([]map[string]any, 0, len(b.users))
+		for _, u := range b.users {
+			row := map[string]any{"nick": u.nick}
+			if u.user != "" {
+				row["user"] = u.user
+			}
+			if u.host != "" {
+				row["host"] = u.host
+			}
+			if u.realName != "" {
+				row["realName"] = u.realName
+			}
+			if u.flags != "" {
+				row["flags"] = u.flags
+			}
+			users = append(users, row)
+		}
+		c.publish(ctx, agent.Event{
+			Type: agent.EventWhoResult,
+			Fields: map[string]any{
+				"connector": c.Name(),
+				"target":    target,
+				"users":     users,
+			},
+		})
+	}
+}
+
+func (c *Connector) whoBuilderFor(target string) *whoBuilder {
+	key := strings.ToLower(target)
+	c.whoMu.Lock()
+	defer c.whoMu.Unlock()
+	if c.whoInFlight == nil {
+		c.whoInFlight = make(map[string]*whoBuilder)
+	}
+	b, ok := c.whoInFlight[key]
+	if !ok {
+		b = &whoBuilder{target: target}
+		c.whoInFlight[key] = b
+	}
+	return b
 }
 
 func (c *Connector) handleTopic(ctx context.Context, msg Message) {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -843,6 +843,17 @@ func (c *Connector) Run(ctx context.Context) error {
 	}
 
 	backoff := NewBackoffSchedule()
+	// sessionStart is the moment the current upstream session became
+	// active (last successful bringUp). Used to gate backoff.Reset on a
+	// minimum-stable-session window: without this gate, networks that
+	// accept the IRC handshake and then immediately tear the connection
+	// down (Libera's drone-BL post-register KILL, a forwarded K-line,
+	// etc.) keep the supervisor pinned at the start of the schedule and
+	// reconnecting every ~1s in a tight loop. Initialised to now because
+	// Start() runs bringUp once before Run() takes over, so the first
+	// runSession iteration corresponds to that already-active session.
+	sessionStart := time.Now()
+	const sessionStableWindow = 30 * time.Second
 
 	watchdogCtx, cancelWatchdog := context.WithCancel(ctx)
 	defer cancelWatchdog()
@@ -895,6 +906,16 @@ func (c *Connector) Run(ctx context.Context) error {
 			return exitTerminal(err)
 		}
 
+		// Only credit a backoff reset if the session that just ended ran
+		// long enough to look healthy — see sessionStart comment at the
+		// top of Run for why. A nil sessionStart means the previous
+		// bringUp failed (no session ran at all) and the schedule must
+		// keep advancing.
+		if !sessionStart.IsZero() && time.Since(sessionStart) >= sessionStableWindow {
+			backoff.Reset()
+		}
+		sessionStart = time.Time{}
+
 		// Recoverable: sleep with backoff, then bring upstream back up.
 		// runCtx cancels mid-sleep when the watchdog transitions to
 		// paused_idle — that surfaces as runCtx.Done.
@@ -923,7 +944,7 @@ func (c *Connector) Run(ctx context.Context) error {
 			c.log.Warn("irc reconnect failed", "err", err)
 			continue
 		}
-		backoff.Reset()
+		sessionStart = time.Now()
 	}
 }
 

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -1401,3 +1401,151 @@ func TestStartListenErrorSurfaces(t *testing.T) {
 	err = b.Start(context.Background())
 	require.Error(t, err, "negative port must surface a listen error")
 }
+
+func TestHumanReadableJoinFailure(t *testing.T) {
+	cases := []struct {
+		code string
+		want string
+	}{
+		{ErrBannedFromChan, "banned from channel"},
+		{ErrBadChannelKey, "channel key required or incorrect"},
+		{ErrChannelIsFull, "channel is full"},
+		{ErrInviteOnlyChan, "channel is invite-only"},
+		{ErrBadChanMask, "channel name not accepted by the network"},
+		{"999", "rejected by network"},
+		{"", "rejected by network"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			assert.Equal(t, tc.want, humanReadableJoinFailure(tc.code))
+		})
+	}
+}
+
+func TestHandleModePublishesEventAndUpdatesState(t *testing.T) {
+	c, ch := connectorWithBus(t, agent.EventModeChanged)
+	c.state.OnSelfJoin("#chan")
+	c.state.OnNamesReply("#chan", []string{"alice", "bob", "carol"})
+	c.state.OnNamesEnd("#chan")
+
+	c.handleMode(context.Background(), Message{
+		Prefix:  "op!u@h",
+		Command: CmdMode,
+		Params:  []string{"#chan", "+o-v", "alice", "bob"},
+	})
+
+	ev := <-ch
+	require.NotNil(t, ev)
+	assert.Equal(t, "#chan", ev.Fields["channel"])
+	assert.Equal(t, "+o-v", ev.Fields["modes"])
+	assert.Equal(t, "alice bob", ev.Fields["args"])
+	assert.Equal(t, "op", ev.Fields["by"])
+
+	info := c.state.Get("#chan")
+	require.NotNil(t, info)
+	assert.Equal(t, "@", info.Members["alice"], "+o on alice promotes to op prefix")
+}
+
+func TestHandleModeIgnoresMalformedLines(t *testing.T) {
+	c, ch := connectorWithBus(t, agent.EventModeChanged)
+
+	// Fewer than 2 params: no channel/modes pair, must early-out.
+	c.handleMode(context.Background(), Message{Command: CmdMode, Params: []string{"#chan"}})
+	// Target that isn't a channel sigil — MODE on a nick (umode) is not
+	// our concern here and must not publish a channel-mode event.
+	c.handleMode(context.Background(), Message{Command: CmdMode, Params: []string{"alice", "+i"}})
+
+	select {
+	case ev := <-ch:
+		t.Fatalf("EventModeChanged published for malformed MODE: %+v", ev)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestApplyPrefixModesToStatePrefixRules(t *testing.T) {
+	state := NewChannelState()
+	state.OnSelfJoin("#chan")
+	state.OnNamesReply("#chan", []string{"@alice", "+bob", "carol"})
+	state.OnNamesEnd("#chan")
+
+	// +v on an op must not visually demote (op outranks voice).
+	applyPrefixModesToState(state, "#chan", "+v", []string{"alice"})
+	info := state.Get("#chan")
+	require.NotNil(t, info)
+	assert.Equal(t, "@", info.Members["alice"], "+v on op leaves displayed @")
+
+	// +o on a plain member promotes to @.
+	applyPrefixModesToState(state, "#chan", "+o", []string{"carol"})
+	info = state.Get("#chan")
+	assert.Equal(t, "@", info.Members["carol"])
+
+	// -v on someone currently displayed as + drops to "".
+	applyPrefixModesToState(state, "#chan", "-v", []string{"bob"})
+	info = state.Get("#chan")
+	assert.Equal(t, "", info.Members["bob"])
+
+	// -v on alice (displayed @) is a no-op for the displayed prefix —
+	// only the equal-rank removal clears the slot.
+	applyPrefixModesToState(state, "#chan", "-v", []string{"alice"})
+	info = state.Get("#chan")
+	assert.Equal(t, "@", info.Members["alice"], "removing a lower mode mustn't clear the displayed higher one")
+}
+
+func TestApplyPrefixModesToStateSkipsNonPrefixArgModes(t *testing.T) {
+	state := NewChannelState()
+	state.OnSelfJoin("#chan")
+	state.OnNamesReply("#chan", []string{"alice"})
+	state.OnNamesEnd("#chan")
+
+	// "+bo banmask alice" — `b` consumes one arg (banmask) which must
+	// be skipped so the `o` flag aligns with `alice`, not banmask.
+	applyPrefixModesToState(state, "#chan", "+bo", []string{"*!*@evil", "alice"})
+
+	info := state.Get("#chan")
+	require.NotNil(t, info)
+	assert.Equal(t, "@", info.Members["alice"], "b-mode arg must advance the cursor so o lands on alice")
+}
+
+func TestApplyPrefixModesToStateAddOnlyArgMode(t *testing.T) {
+	state := NewChannelState()
+	state.OnSelfJoin("#chan")
+	state.OnNamesReply("#chan", []string{"alice"})
+	state.OnNamesEnd("#chan")
+
+	// `+l 50 +o alice` — `l` consumes the `50` arg only when adding;
+	// `o` then aligns with `alice`. With a `-l` form (no arg), the
+	// next arg-cursor must stay put.
+	applyPrefixModesToState(state, "#chan", "+l+o", []string{"50", "alice"})
+	info := state.Get("#chan")
+	require.NotNil(t, info)
+	assert.Equal(t, "@", info.Members["alice"])
+
+	// `-l+o alice` — `l` does not consume when removing, so `o` lands
+	// on `alice` from arg[0].
+	state.SetMemberPrefix("#chan", "alice", "")
+	applyPrefixModesToState(state, "#chan", "-l+o", []string{"alice"})
+	info = state.Get("#chan")
+	assert.Equal(t, "@", info.Members["alice"])
+}
+
+func TestApplyPrefixModesToStateGuards(t *testing.T) {
+	// nil state must be a no-op (defensive).
+	assert.NotPanics(t, func() {
+		applyPrefixModesToState(nil, "#chan", "+o", []string{"alice"})
+	})
+
+	// Unknown channel — no-op.
+	state := NewChannelState()
+	assert.NotPanics(t, func() {
+		applyPrefixModesToState(state, "#missing", "+o", []string{"alice"})
+	})
+
+	// Unknown nick on a known channel — must not invent a phantom
+	// member (matches SetMemberPrefix's own guard).
+	state.OnSelfJoin("#chan")
+	applyPrefixModesToState(state, "#chan", "+o", []string{"ghost"})
+	info := state.Get("#chan")
+	require.NotNil(t, info)
+	_, present := info.Members["ghost"]
+	assert.False(t, present, "MODE for a non-member mustn't materialise the nick")
+}

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -79,6 +79,29 @@ func TestParseUnixSeconds(t *testing.T) {
 	assert.Equal(t, int64(0), parseUnixSeconds("123abc"))
 }
 
+func TestServerNoticeTextPrefersTrailing(t *testing.T) {
+	// Standard shape: most server numerics carry their human-readable
+	// body in the trailing parameter.
+	got := serverNoticeText(Message{Params: []string{"alice"}, Trailing: "Welcome to the network"})
+	assert.Equal(t, "Welcome to the network", got)
+}
+
+func TestServerNoticeTextFallsBackToParamsWhenNoTrailing(t *testing.T) {
+	// RFC-loose servers occasionally stuff the body into space-separated
+	// params instead. Skip the first param (recipient nick) and join
+	// the rest so the server tab still renders something useful.
+	got := serverNoticeText(Message{Params: []string{"alice", "ergo.test", "ergo-2.18.0"}})
+	assert.Equal(t, "ergo.test ergo-2.18.0", got)
+}
+
+func TestIsServerPrefix(t *testing.T) {
+	assert.True(t, isServerPrefix(""), "empty prefix counts as server-originated")
+	assert.True(t, isServerPrefix("irc.libera.chat"), "bare hostname is a server")
+	assert.True(t, isServerPrefix("ergo.test"), "bare hostname is a server")
+	assert.False(t, isServerPrefix("alice!~user@host"), "nick!user@host is a user")
+	assert.False(t, isServerPrefix("bot!~b@cloak/bot"), "user with cloak is still a user")
+}
+
 func TestCTCPHelpers(t *testing.T) {
 	assert.True(t, isCTCP("\x01VERSION\x01"))
 	assert.False(t, isCTCP("plain"))

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -162,6 +162,170 @@ func TestPeerIPOnNilConn(t *testing.T) {
 	assert.Equal(t, "", peerIP(&BouncerClient{}))
 }
 
+// ─── Whois / List / Who numeric handlers ──────────────────────────────
+
+// connectorWithBus spins up a minimal Connector wired to a fresh
+// EventBus, plus an unbuffered subscriber channel keyed on the event
+// type. Lets numeric-handler tests assert "given input X, exactly one
+// event Y was published with these fields" without standing up the
+// runtime / dial loop.
+func connectorWithBus(t *testing.T, eventType agent.EventType) (*Connector, <-chan *agent.Event) {
+	t.Helper()
+	bus := agent.NewEventBus(nil)
+	c := New(&Settings{Nick: "me"}, nil, bus)
+	out := make(chan *agent.Event, 16)
+	bus.Subscribe(eventType, func(_ context.Context, ev *agent.Event) {
+		out <- ev
+	})
+	return c, out
+}
+
+func TestHandleWhoisNumericAccumulatesAndFlushesOnEnd(t *testing.T) {
+	c, ch := connectorWithBus(t, agent.EventWhoisResult)
+	ctx := context.Background()
+
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisUser, Params: []string{"me", "alice", "~uid", "host.tld", "*"}, Trailing: "Alice Wonderland"})
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisServer, Params: []string{"me", "alice", "ergo.test"}, Trailing: "Test Server"})
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisOperator, Params: []string{"me", "alice"}, Trailing: "is an IRC operator"})
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisIdle, Params: []string{"me", "alice", "42", "1700000000"}, Trailing: "seconds idle"})
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisChannels, Params: []string{"me", "alice"}, Trailing: "@#test +#voice #plain"})
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisAccount, Params: []string{"me", "alice", "alice-account"}, Trailing: "is logged in as"})
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisSecure, Params: []string{"me", "alice"}, Trailing: "is using a secure connection"})
+
+	// Nothing published yet — no 318 received.
+	select {
+	case ev := <-ch:
+		t.Fatalf("EventWhoisResult fired before RplEndOfWhois: %+v", ev)
+	default:
+	}
+
+	c.handleWhoisNumeric(ctx, Message{Command: RplEndOfWhois, Params: []string{"me", "alice"}, Trailing: "End of /WHOIS list"})
+
+	ev := <-ch
+	require.NotNil(t, ev)
+	assert.Equal(t, "alice", ev.Fields["nick"])
+	assert.Equal(t, "~uid", ev.Fields["user"])
+	assert.Equal(t, "host.tld", ev.Fields["host"])
+	assert.Equal(t, "Alice Wonderland", ev.Fields["realName"])
+	assert.Equal(t, "alice-account", ev.Fields["account"])
+	assert.Equal(t, "ergo.test", ev.Fields["server"])
+	assert.Equal(t, "Test Server", ev.Fields["serverInfo"])
+	assert.Equal(t, int64(42), ev.Fields["idleSeconds"])
+	assert.Equal(t, int64(1700000000), ev.Fields["signonAt"])
+	assert.Equal(t, true, ev.Fields["secure"])
+	assert.Equal(t, true, ev.Fields["isOperator"])
+	assert.Equal(t, []string{"#test", "#voice", "#plain"}, ev.Fields["channels"],
+		"channel-list prefix glyphs (@, +) must be stripped")
+
+	// Builder cleared.
+	c.whoisMu.Lock()
+	_, stillThere := c.whoisInFlight["alice"]
+	c.whoisMu.Unlock()
+	assert.False(t, stillThere, "whois builder must be cleared after the 318 flush")
+}
+
+func TestHandleWhoisNoSuchNick(t *testing.T) {
+	c, ch := connectorWithBus(t, agent.EventWhoisResult)
+	ctx := context.Background()
+
+	// Open a whois that the server will fail. The handler buffers
+	// nothing until at least one numeric arrives; simulate a 401
+	// straight away — common when the user types /whois on a nick
+	// the server has never seen.
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisUser, Params: []string{"me", "phantom", "~u", "h", "*"}, Trailing: "P"})
+	c.handleWhoisNoSuchNick(ctx, "phantom", "No such nick/channel")
+
+	ev := <-ch
+	assert.Equal(t, "phantom", ev.Fields["nick"])
+	assert.Equal(t, "No such nick/channel", ev.Fields["error"])
+	// Optional fields must NOT be set on an error result — the modal
+	// renders the error path when ev.error is present.
+	assert.NotContains(t, ev.Fields, "realName")
+
+	// And a 401 with no in-flight builder is a silent no-op.
+	c.handleWhoisNoSuchNick(ctx, "nobody-i-care-about", "No such nick")
+	select {
+	case ev := <-ch:
+		t.Fatalf("401 with no in-flight whois must not publish: %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestHandleListNumericAggregatesAcrossBatch(t *testing.T) {
+	c, ch := connectorWithBus(t, agent.EventListResult)
+	ctx := context.Background()
+
+	c.handleListNumeric(ctx, Message{Command: RplListStart, Params: []string{"me"}, Trailing: "Channel :Users  Name"})
+	c.handleListNumeric(ctx, Message{Command: RplList, Params: []string{"me", "#test", "5"}, Trailing: "the test channel"})
+	c.handleListNumeric(ctx, Message{Command: RplList, Params: []string{"me", "#empty", "0"}, Trailing: ""})
+	c.handleListNumeric(ctx, Message{Command: RplList, Params: []string{"me", "#bare", "12"}})
+	c.handleListNumeric(ctx, Message{Command: RplListEnd, Params: []string{"me"}, Trailing: "End of /LIST"})
+
+	ev := <-ch
+	channels := ev.Fields["channels"].([]map[string]any)
+	require.Len(t, channels, 3)
+	assert.Equal(t, "#test", channels[0]["name"])
+	assert.Equal(t, 5, channels[0]["users"])
+	assert.Equal(t, "the test channel", channels[0]["topic"])
+	// Empty topic and zero users are omitted from the row map to keep
+	// the SPA's row.users / row.topic = undefined distinction intact.
+	assert.NotContains(t, channels[1], "topic")
+	assert.NotContains(t, channels[1], "users")
+	assert.Equal(t, "#bare", channels[2]["name"])
+	assert.Equal(t, 12, channels[2]["users"])
+}
+
+func TestHandleWhoNumericAggregatesPerTarget(t *testing.T) {
+	c, ch := connectorWithBus(t, agent.EventWhoResult)
+	ctx := context.Background()
+
+	// /who #test
+	c.handleWhoNumeric(ctx, Message{
+		Command:  RplWhoReply,
+		Params:   []string{"me", "#test", "~alice", "alice.tld", "ergo", "alice", "H@"},
+		Trailing: "0 Alice W",
+	})
+	c.handleWhoNumeric(ctx, Message{
+		Command:  RplWhoReply,
+		Params:   []string{"me", "#test", "~bob", "bob.tld", "ergo", "bob", "H+"},
+		Trailing: "1 Bob",
+	})
+	c.handleWhoNumeric(ctx, Message{Command: RplEndOfWho, Params: []string{"me", "#test"}, Trailing: "End of /WHO list"})
+
+	ev := <-ch
+	assert.Equal(t, "#test", ev.Fields["target"])
+	users := ev.Fields["users"].([]map[string]any)
+	require.Len(t, users, 2)
+	assert.Equal(t, "alice", users[0]["nick"])
+	assert.Equal(t, "~alice", users[0]["user"])
+	assert.Equal(t, "alice.tld", users[0]["host"])
+	assert.Equal(t, "H@", users[0]["flags"])
+	assert.Equal(t, "Alice W", users[0]["realName"], "hopcount prefix must be stripped from realname")
+	assert.Equal(t, "bob", users[1]["nick"])
+	assert.Equal(t, "Bob", users[1]["realName"])
+}
+
+func TestHandleWhoNumericTwoTargetsInFlight(t *testing.T) {
+	// Two /who targets running interleaved must not smear their
+	// member lists into each other.
+	c, ch := connectorWithBus(t, agent.EventWhoResult)
+	ctx := context.Background()
+
+	c.handleWhoNumeric(ctx, Message{Command: RplWhoReply, Params: []string{"me", "#a", "~a", "h", "s", "alice", "H"}, Trailing: "0 A"})
+	c.handleWhoNumeric(ctx, Message{Command: RplWhoReply, Params: []string{"me", "#b", "~b", "h", "s", "bob", "H"}, Trailing: "0 B"})
+	c.handleWhoNumeric(ctx, Message{Command: RplEndOfWho, Params: []string{"me", "#a"}})
+	c.handleWhoNumeric(ctx, Message{Command: RplEndOfWho, Params: []string{"me", "#b"}})
+
+	first := <-ch
+	second := <-ch
+	// Order on the bus matches the order of EndOfWho processing.
+	assert.Equal(t, "#a", first.Fields["target"])
+	assert.Len(t, first.Fields["users"].([]map[string]any), 1)
+	assert.Equal(t, "alice", first.Fields["users"].([]map[string]any)[0]["nick"])
+	assert.Equal(t, "#b", second.Fields["target"])
+	assert.Equal(t, "bob", second.Fields["users"].([]map[string]any)[0]["nick"])
+}
+
 func TestPeerIPNonTCPFallback(t *testing.T) {
 	// Our recordingConn returns a fakeAddr that is NOT *net.TCPAddr,
 	// so peerIP must fall through to RemoteAddr().String() — covers

--- a/internal/connector/irc/state.go
+++ b/internal/connector/irc/state.go
@@ -146,6 +146,15 @@ func (s *ChannelState) SetTopicMeta(channel, setBy string, setAt int64) {
 // OnNamesReply appends one RPL_NAMREPLY chunk to a channel's member list.
 // Multiple chunks may arrive before RPL_ENDOFNAMES; callers don't need to
 // coordinate.
+//
+// A 353 line that arrives AFTER a previous NAMES cycle has already
+// completed (NamesComplete=true) marks the start of a fresh burst —
+// typically because the bot rejoined the channel after a netsplit or
+// the user issued /NAMES. The previous member set is stale at that
+// point: ergo's NAMES reply is a complete snapshot of the channel
+// right now, so we drop the old set and let this burst rebuild from
+// scratch. Without this reset, members who QUIT during the bot's
+// upstream outage stay ghosted in the member list forever.
 func (s *ChannelState) OnNamesReply(channel string, members []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -155,6 +164,9 @@ func (s *ChannelState) OnNamesReply(channel string, members []string) {
 		info = &ChannelInfo{Name: channel, Members: map[string]string{}}
 		s.channels[key] = info
 		s.order = append(s.order, key)
+	} else if info.NamesComplete {
+		info.Members = map[string]string{}
+		info.NamesComplete = false
 	}
 	for _, entry := range members {
 		prefix, nick := splitMemberPrefix(entry)

--- a/internal/connector/irc/state.go
+++ b/internal/connector/irc/state.go
@@ -209,6 +209,32 @@ func (s *ChannelState) OnMemberKick(channel, nick string) {
 	s.OnMemberPart(channel, nick)
 }
 
+// SetMemberPrefix overwrites the displayed prefix for a nick on a
+// channel. Callers (the MODE dispatcher) compute the new displayed
+// prefix by walking the mode string against the known prefix
+// hierarchy (~ > & > @ > % > +); we just store the result here so
+// the next sendState reflects what the SPA / bouncer-attached client
+// would see live.
+//
+// No-op when the channel or nick is unknown — services or oper-issued
+// modes on someone not in our view shouldn't materialise a phantom
+// member.
+func (s *ChannelState) SetMemberPrefix(channel, nick, prefix string) {
+	if nick == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	info, ok := s.channels[strings.ToLower(channel)]
+	if !ok {
+		return
+	}
+	if _, present := info.Members[nick]; !present {
+		return
+	}
+	info.Members[nick] = prefix
+}
+
 // OnMemberQuit removes a nick from every channel — IRC QUIT applies
 // network-wide, not per-channel.
 func (s *ChannelState) OnMemberQuit(nick string) {

--- a/internal/connector/irc/state.go
+++ b/internal/connector/irc/state.go
@@ -219,6 +219,25 @@ func (s *ChannelState) OnMemberQuit(nick string) {
 	}
 }
 
+// ChannelsContaining returns the channel names (original casing) the
+// given nick is currently a member of. Read-only; callers can take
+// the snapshot before invoking a mutator like OnMemberQuit so they
+// can fan out per-channel "leave" notifications to subscribers.
+func (s *ChannelState) ChannelsContaining(nick string) []string {
+	if nick == "" {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []string
+	for _, info := range s.channels {
+		if _, ok := info.Members[nick]; ok {
+			out = append(out, info.Name)
+		}
+	}
+	return out
+}
+
 // OnNickChange propagates a NICK change across every channel that knew
 // the old nick.
 func (s *ChannelState) OnNickChange(oldNick, newNick string) {

--- a/internal/connector/irc/state_test.go
+++ b/internal/connector/irc/state_test.go
@@ -130,6 +130,37 @@ func TestChannelStateNamesReplyReplacesAfterCycleComplete(t *testing.T) {
 	assert.NotContains(t, info.Members, "bob", "bob must be evicted; NAMES is a full snapshot")
 }
 
+// ChannelsContaining is used by the connector's QUIT handler to fan
+// out a per-channel EventUserLeave before OnMemberQuit wipes the
+// nick everywhere. Without it the gateway emits op:part events with
+// a nil channel and the SPA's per-channel state can't apply them,
+// leaving QUIT'd members ghosted in every channel they were in.
+func TestChannelStateChannelsContaining(t *testing.T) {
+	s := irc.NewChannelState()
+	s.OnSelfJoin("#one")
+	s.OnSelfJoin("#two")
+	s.OnSelfJoin("#three")
+	s.OnNamesReply("#one", []string{"alice", "bob"})
+	s.OnNamesEnd("#one")
+	s.OnNamesReply("#two", []string{"alice"})
+	s.OnNamesEnd("#two")
+	s.OnNamesReply("#three", []string{"bob"})
+	s.OnNamesEnd("#three")
+
+	got := s.ChannelsContaining("alice")
+	require.Len(t, got, 2)
+	assert.ElementsMatch(t, []string{"#one", "#two"}, got)
+
+	got = s.ChannelsContaining("bob")
+	assert.ElementsMatch(t, []string{"#one", "#three"}, got)
+
+	got = s.ChannelsContaining("carol")
+	assert.Empty(t, got)
+
+	got = s.ChannelsContaining("")
+	assert.Empty(t, got, "empty nick is a no-op")
+}
+
 func TestChannelStateNamesAutoJoinIfMissing(t *testing.T) {
 	s := irc.NewChannelState()
 	s.OnNamesReply("#auto", []string{"alice"})

--- a/internal/connector/irc/state_test.go
+++ b/internal/connector/irc/state_test.go
@@ -161,6 +161,37 @@ func TestChannelStateChannelsContaining(t *testing.T) {
 	assert.Empty(t, got, "empty nick is a no-op")
 }
 
+func TestChannelStateSetMemberPrefix(t *testing.T) {
+	// Mirrors the bot-side ApplyPrefixModes path: when a live MODE
+	// line changes a member's displayed prefix, we need to keep the
+	// in-memory ChannelState aligned so the next sendState (fresh WS
+	// attach) reflects reality without waiting for NAMES.
+	s := irc.NewChannelState()
+	s.OnSelfJoin("#ch")
+	s.OnNamesReply("#ch", []string{"alice", "bob"})
+	s.OnNamesEnd("#ch")
+
+	// Promote bob to op.
+	s.SetMemberPrefix("#ch", "bob", "@")
+	assert.Equal(t, "@", s.Get("#ch").Members["bob"])
+
+	// Demote bob.
+	s.SetMemberPrefix("#ch", "bob", "")
+	assert.Equal(t, "", s.Get("#ch").Members["bob"])
+
+	// Unknown nick is a no-op (no phantom members invented).
+	s.SetMemberPrefix("#ch", "phantom", "@")
+	assert.NotContains(t, s.Get("#ch").Members, "phantom")
+
+	// Unknown channel is a no-op.
+	s.SetMemberPrefix("#nope", "alice", "@")
+	assert.Nil(t, s.Get("#nope"))
+
+	// Empty nick is a no-op (defensive against malformed MODE args).
+	s.SetMemberPrefix("#ch", "", "@")
+	assert.Equal(t, 2, len(s.Get("#ch").Members))
+}
+
 func TestChannelStateNamesAutoJoinIfMissing(t *testing.T) {
 	s := irc.NewChannelState()
 	s.OnNamesReply("#auto", []string{"alice"})

--- a/internal/connector/irc/state_test.go
+++ b/internal/connector/irc/state_test.go
@@ -102,6 +102,34 @@ func TestChannelStateNamesReply(t *testing.T) {
 	assert.Equal(t, "~", info.Members["fred"])
 }
 
+// Reproduces the post-netsplit ghost-member bug: a NAMES burst that
+// arrives AFTER a previous cycle has already completed must REPLACE
+// the member set, not merge into it. Pre-fix, members who QUIT
+// during the bot's upstream outage stayed ghosted forever because
+// OnNamesReply appended to the stale set.
+func TestChannelStateNamesReplyReplacesAfterCycleComplete(t *testing.T) {
+	s := irc.NewChannelState()
+	s.OnSelfJoin("#ch")
+
+	// First NAMES cycle: alice, bob, carol present.
+	s.OnNamesReply("#ch", []string{"@alice", "bob", "carol"})
+	s.OnNamesEnd("#ch")
+	require.True(t, s.Get("#ch").NamesComplete)
+
+	// Simulate the bot losing/rejoining upstream — bob has quit while
+	// the bot was disconnected. The new NAMES burst only contains
+	// alice + carol.
+	s.OnNamesReply("#ch", []string{"@alice", "carol"})
+	s.OnNamesEnd("#ch")
+
+	info := s.Get("#ch")
+	require.NotNil(t, info)
+	assert.True(t, info.NamesComplete)
+	assert.Contains(t, info.Members, "alice")
+	assert.Contains(t, info.Members, "carol")
+	assert.NotContains(t, info.Members, "bob", "bob must be evicted; NAMES is a full snapshot")
+}
+
 func TestChannelStateNamesAutoJoinIfMissing(t *testing.T) {
 	s := irc.NewChannelState()
 	s.OnNamesReply("#auto", []string{"alice"})

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -364,8 +364,32 @@ func (g *Gateway) handleWS(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	g.sendState(ctx, c)
+	g.sendInitialConnectorState(ctx, c)
 	g.replayBuffers(ctx, c)
 	g.readLoop(ctx, c)
+}
+
+// sendInitialConnectorState publishes a one-shot connector.state_changed
+// to the newly-attached client carrying the upstream state machine's
+// CURRENT value. onUpstreamStateChange only fires on transitions, so a
+// client that connects mid-outage (or after registration completed
+// before the WS handshake finished) would otherwise never learn the
+// upstream isn't registered, the SPA's pill would stay green, and
+// users would have to wait for the next transition to find out.
+func (g *Gateway) sendInitialConnectorState(ctx context.Context, c *client) {
+	machine := g.bridge.UpstreamState()
+	if machine == nil {
+		return
+	}
+	state := machine.State()
+	g.sendTo(ctx, c, map[string]any{
+		"op":            "connector.state_changed",
+		"state":         string(state),
+		"prior_state":   "",
+		"message":       irc.DescribeUpstreamState(state, "", machine.ServerReason()),
+		"severity":      irc.SeverityForUpstreamState(state),
+		"server_reason": machine.ServerReason(),
+	})
 }
 
 func (g *Gateway) handleHealth(w http.ResponseWriter, _ *http.Request) {

--- a/internal/web/gateway_state_test.go
+++ b/internal/web/gateway_state_test.go
@@ -51,7 +51,7 @@ func TestGatewayBroadcastsConnectorStateChanged(t *testing.T) {
 
 	// Drain the initial state + replay frames so the next read sees
 	// only fresh state-change events.
-	_ = readJSON(t, ws)
+	drainInitialFrames(t, ws)
 
 	// Drive a transition through the bridge's state machine.
 	bridge.UpstreamState().Transition(irc.UpstreamStateDisconnectedTransient,
@@ -92,7 +92,7 @@ func TestGatewayStateChangedSeverityForTerminalStates(t *testing.T) {
 
 			ws := dialWS(t, g.Addr(), "p")
 			defer ws.Close(0, "")
-			_ = readJSON(t, ws)
+			drainInitialFrames(t, ws)
 
 			bridge.UpstreamState().Transition(tc.state)
 			got := drainUntilOp(t, ws, "connector.state_changed", time.Second)
@@ -115,7 +115,7 @@ func TestGatewaySayRejectedWhenStateNotRegistered(t *testing.T) {
 
 	ws := dialWS(t, g.Addr(), "p")
 	defer ws.Close(0, "")
-	_ = readJSON(t, ws)
+	drainInitialFrames(t, ws)
 
 	// Drop upstream out from under any subsequent say op.
 	bridge.UpstreamState().Transition(irc.UpstreamStateDisconnectedTransient,
@@ -148,7 +148,7 @@ func TestGatewaySayWriteErrorPathRejects(t *testing.T) {
 
 	ws := dialWS(t, g.Addr(), "p")
 	defer ws.Close(0, "")
-	_ = readJSON(t, ws)
+	drainInitialFrames(t, ws)
 
 	require.NoError(t, ws.Write(context.Background(), websocket.MessageText,
 		[]byte(`{"op":"say","channel":"#a","text":"hi"}`)))
@@ -174,7 +174,7 @@ func TestGatewaySayDuringRegisteredFlowsThrough(t *testing.T) {
 
 	ws := dialWS(t, g.Addr(), "p")
 	defer ws.Close(0, "")
-	_ = readJSON(t, ws)
+	drainInitialFrames(t, ws)
 
 	require.NoError(t, ws.Write(context.Background(), websocket.MessageText,
 		[]byte(`{"op":"say","channel":"#a","text":"hi"}`)))

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -132,6 +132,17 @@ func readJSON(t *testing.T, conn *websocket.Conn) map[string]any {
 	return out
 }
 
+// drainInitialFrames consumes the gateway's standard attach burst —
+// currently `state` followed by `connector.state_changed` — so tests
+// can land on the first event their assertions actually care about.
+// Centralised here so adding/removing initial frames is a one-line
+// change instead of touching every test that opens a WS.
+func drainInitialFrames(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	_ = readJSON(t, conn) // state
+	_ = readJSON(t, conn) // connector.state_changed (sendInitialConnectorState)
+}
+
 func newOptions(t *testing.T, password string) web.Options {
 	v, err := web.NewStaticPasswordVerifier(password)
 	require.NoError(t, err)
@@ -365,7 +376,7 @@ func TestEveryEventBusHandlerBroadcastsAnOp(t *testing.T) {
 
 			conn := dialWS(t, g.Addr(), "p")
 			defer conn.Close(websocket.StatusNormalClosure, "")
-			_ = readJSON(t, conn) // state
+			drainInitialFrames(t, conn)
 
 			a.Events.Publish(context.Background(), &tc.event)
 			got := readJSON(t, conn)
@@ -386,7 +397,7 @@ func TestEventBroadcastReachesClients(t *testing.T) {
 
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state op
+	drainInitialFrames(t, conn)
 
 	a.Events.Publish(context.Background(), &agent.Event{
 		Type:   agent.EventUserJoin,
@@ -405,7 +416,7 @@ func TestMessageEventCarriesText(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn)
+	drainInitialFrames(t, conn)
 
 	a.Events.Publish(context.Background(), &agent.Event{
 		Type: agent.EventMessage,
@@ -429,7 +440,7 @@ func TestInboundSayCallsSender(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	payload, _ := json.Marshal(map[string]any{
 		"op": "say", "channel": "#test", "text": "hello via ws",
@@ -450,7 +461,7 @@ func TestInboundSayPublishesMessageSentBackToSender(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	body, _ := json.Marshal(map[string]any{
 		"op": "say", "channel": "#test", "text": "echo to self",
@@ -477,7 +488,7 @@ func TestMessageSentFromAgentDispatchRendersCorrectly(t *testing.T) {
 
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	out := &agent.OutboundEnvelope{
 		Connector: "irc",
@@ -502,7 +513,7 @@ func TestInboundSayUsesCurrentNickAfterChange(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state shows "orig"
+	drainInitialFrames(t, conn)
 
 	// Bot renames itself. In production, irc.Connector.setCurrentNick
 	// fires from the 001 welcome or an observed self-NICK; here we
@@ -586,7 +597,7 @@ func TestServerNoticesReplayedOnConnect(t *testing.T) {
 
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	got := readJSON(t, conn)
 	assert.Equal(t, "server", got["op"])
@@ -784,7 +795,7 @@ func TestRateLimiterResetsOnSuccessfulAuth(t *testing.T) {
 		_ = resp.Body.Close()
 	}
 	conn := dialWS(t, g.Addr(), "right")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 	_ = conn.Close(websocket.StatusNormalClosure, "")
 
 	// A single bad attempt after the reset must NOT 429 — it must 401.
@@ -820,7 +831,7 @@ func TestChannelMessagesReplayedInTSOrder(t *testing.T) {
 
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	got := []string{}
 	deadline := time.Now().Add(3 * time.Second)
@@ -851,7 +862,7 @@ func TestBroadcastDropsClientOnClosedConn(t *testing.T) {
 	defer td()
 
 	conn := dialWS(t, g.Addr(), "p")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	// Close from the client side without notice; the gateway's next
 	// broadcast.sendTo write will fail and remove the client.
@@ -886,7 +897,7 @@ func TestInboundDispatchSkipsEmptyOrInvalidPayloads(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	// Every one of these is a syntactic no-op: required fields missing,
 	// empty strings, etc. None should fan to bridge or sender.
@@ -959,7 +970,7 @@ func TestOnMessageReadsEnvelopeFieldsWhenPresent(t *testing.T) {
 
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	// Publish an EventMessage with an envelope (not channel/sender/
 	// text fields). The gateway must read from env.* — covers the
@@ -1002,7 +1013,7 @@ func TestRecordChannelTrimsBufferAtCap(t *testing.T) {
 
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	replayed := 0
 	deadline := time.Now().Add(2 * time.Second)
@@ -1035,7 +1046,7 @@ func TestServerNoticeBufferTrimsAtCap(t *testing.T) {
 
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	replayed := 0
 	deadline := time.Now().Add(2 * time.Second)
@@ -1064,7 +1075,7 @@ func TestInboundNickDeniedWhenLocked(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	body, _ := json.Marshal(map[string]any{"op": "nick", "nick": "newnick"})
 	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
@@ -1092,7 +1103,7 @@ func TestInboundJoinDeniedAtChannelCap(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	body, _ := json.Marshal(map[string]any{"op": "join", "channel": "#c"})
 	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
@@ -1118,7 +1129,7 @@ func TestInboundJoinAllowedBelowChannelCap(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	body, _ := json.Marshal(map[string]any{"op": "join", "channel": "#b"})
 	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
@@ -1139,7 +1150,7 @@ func TestInboundSayRateLimitedEmitsRateLimitedEvent(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	// First 2 sends pass the throttle and produce the MESSAGE_SENT echo.
 	for i := 0; i < 2; i++ {
@@ -1172,7 +1183,7 @@ func TestInboundSayPerTargetThrottleScopesIndependently(t *testing.T) {
 	defer td()
 	conn := dialWS(t, g.Addr(), "p")
 	defer conn.Close(websocket.StatusNormalClosure, "")
-	_ = readJSON(t, conn) // state
+	drainInitialFrames(t, conn)
 
 	// #a uses its bucket.
 	bodyA, _ := json.Marshal(map[string]any{"op": "say", "channel": "#a", "text": "hi"})


### PR DESCRIPTION
## Summary

Four commits that came out of running the IRC product through a real netsplit drill end-to-end. Three are user-visible bug fixes; the fourth is a small dev tool that made the drill ergonomic.

### Bug fixes

- **`fix(connector/irc): gate backoff reset on stable-session window`** (`7fd43ae`)
  The supervisor called `backoff.Reset()` the instant `bringUp` returned success — but a successful handshake doesn't prove the session is sticky. Networks that accept the handshake and immediately tear the connection down (drone-BL post-register KILL, forwarded K-line) put the loop in a 1s hot-loop forever. Now requires ≥30s of sticky session before crediting a reset; the schedule walks 1→2→4→8→16→30→60s as designed otherwise.

- **`feat(web/gateway): push current upstream state on WS client attach`** (`4382a91`)
  `onUpstreamStateChange` only fires on transitions. A client connecting mid-outage never learned the upstream wasn't registered. Send a one-shot `connector.state_changed` per attaching client carrying the machine's current state.

- **`fix(connector/irc): drop stale members on a new NAMES cycle`** (`b75ccc2`)
  `OnNamesReply` appended to existing `Members` without ever clearing. Post-netsplit, members who QUIT during the bot's upstream outage stayed ghosted in the channel forever — the upstream's fresh NAMES burst only contained still-present nicks, our merge-only handler kept the QUIT'd ones alongside. Uses the existing `NamesComplete` flag to detect a new burst and reset.

### Dev tool

- **`feat(cmd/devirc): minimal IRC stub for local netsplit drills`** (`e7685b8`)
  Standalone IRC daemon with an HTTP control plane (`/kill`, `/pause`, `/resume`, `/status`) for driving the agent through reconnect scenarios without standing up ergo / ngircd. ~270 LOC, stdlib only.

## Test plan

- [x] All existing `internal/connector/irc/...` tests pass (`9.8s`, 0 fails)
- [x] New `TestChannelStateNamesReplyReplacesAfterCycleComplete` covers the ghost-member regression
- [x] Manually verified end-to-end against ergo:
  - oper `/KILL` the bot → reconnects in ~1s, NAMES list rebuilds cleanly, no ghosts (was: stale member lingered)
  - `docker stop` the upstream → bot walks 1→2→4→8→16→30→60s backoff (was: pinned at 1s)
  - Client refresh mid-outage → upstream-state indicator reflects reality immediately (was: stayed stale until next transition)
- [x] `cmd/devirc/...` builds clean, golangci-lint passes

## Notes

`devirc` binary is gitignored (`/devirc` anchored to repo root so it doesn't shadow `cmd/devirc/`).