### PR TITLE
feat(messages): shared Store + WS history op + IRCv3 CHATHISTORY + tagged replay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,13 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 # TURBORG_IRC_BOUNCER_MAX_FAILED_ATTEMPTS=5
 # TURBORG_IRC_BOUNCER_FAILURE_WINDOW_SECONDS=60
 # TURBORG_IRC_BOUNCER_LOCKOUT_SECONDS=300
+# TURBORG_IRC_BOUNCER_WELCOME_REPLAY_DEPTH=200           # per-channel backfill on each fresh attach (1..2000)
+#                                                        # Bump for IRC clients that don't speak IRCv3
+#                                                        # draft/chathistory (HexChat 2.16 et al) so users
+#                                                        # see more history at attach. Costs a slower
+#                                                        # welcome on every reconnect. Modern clients
+#                                                        # (Goguma, Quassel, soju-aware) scroll back via
+#                                                        # CHATHISTORY against this same backend regardless.
 
 
 # =============================================================================

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -166,6 +166,21 @@ type Settings struct {
 	// per-container token reused, since both endpoints terminate at
 	// the same sidecar gating on the same ActivityTracker.
 	MessageSinkToken string `env:"MESSAGE_SINK_TOKEN"`
+
+	// MessageStoreURL is the endpoint the bouncer (CHATHISTORY) +
+	// gateway (history op, attach replay) GET to read historical
+	// messages. Empty = no remote read backend: replay + scrollback
+	// fall back to the in-process MemoryStore (capped at 200/channel,
+	// lost across restarts). When set, operators point it at an HTTP
+	// service that implements the contract documented on
+	// messages.HTTPStore.
+	MessageStoreURL string `env:"MESSAGE_STORE_URL"`
+
+	// MessageStoreToken is the bearer the store endpoint expects on
+	// every GET. Defaults to MessageSinkToken via normalize() when
+	// unset — the write and read halves typically share the same
+	// per-container token.
+	MessageStoreToken string `env:"MESSAGE_STORE_TOKEN"`
 }
 
 // Load parses TURBORG_* env vars into a Settings, normalizing the
@@ -194,6 +209,14 @@ func (s *Settings) normalize() error {
 	}
 	s.AllowedNetworks = trimDropEmpties(s.AllowedNetworks)
 	s.AllowedLLMModels = trimDropEmpties(s.AllowedLLMModels)
+
+	// MessageStoreToken defaults to the sink token — both halves
+	// usually terminate at the same accounts-api endpoint with the
+	// same per-container bearer. Operators who want different tokens
+	// for read vs. write set MESSAGE_STORE_TOKEN explicitly.
+	if s.MessageStoreToken == "" {
+		s.MessageStoreToken = s.MessageSinkToken
+	}
 	return nil
 }
 

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -3,7 +3,9 @@ package irc
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -12,6 +14,20 @@ import (
 	"sync"
 	"time"
 )
+
+// serverTimeLayout is the IRCv3 server-time tag format: ISO8601 UTC
+// with millisecond precision. See
+// https://ircv3.net/specs/extensions/server-time
+const serverTimeLayout = "2006-01-02T15:04:05.000Z"
+
+// loggedLine is one entry in the per-channel replay ring. ts is the
+// wall-clock moment we observed the line (used to populate the IRCv3
+// `time=` tag on replay so attached clients render the message as
+// historical instead of highlighting the tab as new traffic).
+type loggedLine struct {
+	line string
+	ts   time.Time
+}
 
 // channelLogCap is the per-channel ring of recent PRIVMSG / NOTICE lines
 // replayed to a bouncer client on (re)connect. Bound per-channel so a
@@ -213,10 +229,10 @@ type Bouncer struct {
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
 
-	upstreamMu     sync.RWMutex
-	upstreamNick   string
-	upstreamIdent  string
-	upstreamHost   string
+	upstreamMu    sync.RWMutex
+	upstreamNick  string
+	upstreamIdent string
+	upstreamHost  string
 
 	sendUpstream SendUpstreamFunc
 	onForwarded  ForwardedObserver
@@ -262,7 +278,7 @@ type Bouncer struct {
 	setPreferredNick func(nick string)
 
 	logMu      sync.Mutex
-	channelLog map[string][]string
+	channelLog map[string][]loggedLine
 }
 
 func NewBouncer(password, host string, port int, rl *RateLimiter, log *slog.Logger) (*Bouncer, error) {
@@ -282,7 +298,7 @@ func NewBouncer(password, host string, port int, rl *RateLimiter, log *slog.Logg
 		rateLimiter:  rl,
 		log:          log,
 		clients:      map[*BouncerClient]struct{}{},
-		channelLog:   map[string][]string{},
+		channelLog:   map[string][]loggedLine{},
 		upstreamHost: "turborg",
 	}, nil
 }
@@ -736,6 +752,12 @@ func (b *Bouncer) recordPartedFromWanted(msg Message) {
 //     Pure pass-through.
 //   - away-notify: when an upstream user goes away/back, the server
 //     sends AWAY notifications. Pure pass-through.
+//   - batch: framework cap for grouping a sequence of lines under a
+//     server-generated batch id. The bouncer uses this to wrap
+//     channel-log replay in a `chathistory`-typed batch so capable
+//     clients render the block as historical instead of highlighting
+//     each line as fresh activity. Clients that didn't negotiate it
+//     get the legacy NOTICE-bracketed replay.
 //
 // All listed caps are honored by the existing dispatchLine →
 // Broadcast path; advertising them costs nothing extra.
@@ -746,6 +768,7 @@ var supportedCaps = map[string]bool{
 	"server-time":         true,
 	"account-tag":         true,
 	"away-notify":         true,
+	"batch":               true,
 }
 
 func supportedCapsList() string {
@@ -928,12 +951,12 @@ func (b *Bouncer) replayState(client *BouncerClient) {
 
 func (b *Bouncer) replayChannelLogs(client *BouncerClient) {
 	b.logMu.Lock()
-	snap := make(map[string][]string, len(b.channelLog))
+	snap := make(map[string][]loggedLine, len(b.channelLog))
 	for k, v := range b.channelLog {
 		if len(v) == 0 {
 			continue
 		}
-		cp := make([]string, len(v))
+		cp := make([]loggedLine, len(v))
 		copy(cp, v)
 		snap[k] = cp
 	}
@@ -946,20 +969,90 @@ func (b *Bouncer) replayChannelLogs(client *BouncerClient) {
 		return
 	}
 
+	tagTime := client.hasCap("server-time")
+	useBatch := client.hasCap("batch")
+
 	for channel, lines := range snap {
-		_ = client.sendLine(fmt.Sprintf(
-			":turborg-bouncer NOTICE %s :--- buffer playback for %s (%d lines) ---",
-			channel, channel, len(lines),
-		))
-		for _, line := range lines {
-			if err := client.sendLine(line); err != nil {
+		var batchID string
+		if useBatch {
+			batchID = newBatchID()
+			_ = client.sendLine(fmt.Sprintf(
+				"BATCH +%s chathistory %s", batchID, channel,
+			))
+		} else {
+			_ = client.sendLine(fmt.Sprintf(
+				":turborg-bouncer NOTICE %s :--- buffer playback for %s (%d lines) ---",
+				channel, channel, len(lines),
+			))
+		}
+		for _, entry := range lines {
+			if err := client.sendLine(decorateReplayLine(entry, tagTime, batchID)); err != nil {
 				return
 			}
 		}
-		_ = client.sendLine(fmt.Sprintf(
-			":turborg-bouncer NOTICE %s :--- end of buffer ---", channel,
-		))
+		if useBatch {
+			_ = client.sendLine("BATCH -" + batchID)
+		} else {
+			_ = client.sendLine(fmt.Sprintf(
+				":turborg-bouncer NOTICE %s :--- end of buffer ---", channel,
+			))
+		}
 	}
+}
+
+// decorateReplayLine builds the wire form of a replay line for the
+// attached client's negotiated caps:
+//
+//   - server-time: prepend `time=<ISO8601 UTC>` so HexChat / mIRC /
+//     irssi render the line as historical and don't highlight the
+//     channel tab. Upstream's own `@time=` (when the line already
+//     carries tags) takes precedence — we don't second-guess what the
+//     network declared the message arrival time was.
+//   - batch:       prepend `batch=<id>` so the line is associated with
+//     the surrounding `BATCH +<id> chathistory <channel>` envelope.
+//
+// When neither cap was negotiated, the line passes through unchanged —
+// preserving today's behavior for clients on legacy stacks.
+func decorateReplayLine(entry loggedLine, tagTime bool, batchID string) string {
+	line := entry.line
+	hasExistingTags := strings.HasPrefix(line, "@")
+
+	var added []string
+	if batchID != "" {
+		added = append(added, "batch="+batchID)
+	}
+	if tagTime && !hasExistingTags {
+		added = append(added, "time="+entry.ts.UTC().Format(serverTimeLayout))
+	}
+	if len(added) == 0 {
+		return line
+	}
+
+	if !hasExistingTags {
+		return "@" + strings.Join(added, ";") + " " + line
+	}
+	// Merge: keep upstream's tags as-is, prepend ours. IRCv3 message-tags
+	// allows duplicate keys ordering-wise, but to be conservative we
+	// place ours first and let upstream's win on conflict (clients that
+	// parse left-to-right will see upstream's value last and store it).
+	sp := strings.IndexByte(line, ' ')
+	if sp < 0 {
+		// Malformed (tags without a body) — pass through.
+		return line
+	}
+	existing := line[1:sp]
+	rest := line[sp+1:]
+	return "@" + strings.Join(added, ";") + ";" + existing + " " + rest
+}
+
+// newBatchID returns a short, sufficiently-unique batch reference tag
+// per the IRCv3 batch spec. 8 hex chars (32 bits) easily clears the
+// per-attach collision bar — there are at most a few hundred channels
+// in flight at once for one bouncer client.
+func newBatchID() string {
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
 }
 
 // Broadcast writes line to every authenticated client except exclude.
@@ -1578,7 +1671,7 @@ func (b *Bouncer) recordForReplay(line string) {
 	b.logMu.Lock()
 	defer b.logMu.Unlock()
 	bucket := b.channelLog[target]
-	bucket = append(bucket, line)
+	bucket = append(bucket, loggedLine{line: line, ts: time.Now()})
 	if len(bucket) > channelLogCap {
 		bucket = bucket[len(bucket)-channelLogCap:]
 	}

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -13,26 +13,14 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/turborg/turborg/internal/messages"
 )
 
 // serverTimeLayout is the IRCv3 server-time tag format: ISO8601 UTC
 // with millisecond precision. See
 // https://ircv3.net/specs/extensions/server-time
 const serverTimeLayout = "2006-01-02T15:04:05.000Z"
-
-// loggedLine is one entry in the per-channel replay ring. ts is the
-// wall-clock moment we observed the line (used to populate the IRCv3
-// `time=` tag on replay so attached clients render the message as
-// historical instead of highlighting the tab as new traffic).
-type loggedLine struct {
-	line string
-	ts   time.Time
-}
-
-// channelLogCap is the per-channel ring of recent PRIVMSG / NOTICE lines
-// replayed to a bouncer client on (re)connect. Bound per-channel so a
-// busy channel can't starve quiet ones.
-const channelLogCap = 200
 
 // forwardable is the set of commands that bouncer clients are allowed to
 // send upstream. Anything else is silently dropped post-auth.
@@ -277,8 +265,20 @@ type Bouncer struct {
 	// queuing; the bouncer still acknowledges the NICK with a NOTICE.
 	setPreferredNick func(nick string)
 
-	logMu      sync.Mutex
-	channelLog map[string][]loggedLine
+	// messageStore is the read seam the bouncer consults on attach
+	// (state replay) and for CHATHISTORY queries. The runtime wires
+	// this to a process-wide messages.Store so the bouncer + WS
+	// gateway share the same history view — see runtime.Build. nil =
+	// no replay (an unattached test bouncer behaves as a brand-new
+	// install with empty history).
+	messageStoreMu sync.RWMutex
+	messageStore   messages.Store
+
+	// welcomeReplayDepth is the per-channel cap passed to
+	// store.Recent on each fresh attach. Overridable via
+	// AttachWelcomeReplayDepth; defaults to defaultReplayDepthOnAttach.
+	welcomeReplayMu    sync.RWMutex
+	welcomeReplayDepth int
 }
 
 func NewBouncer(password, host string, port int, rl *RateLimiter, log *slog.Logger) (*Bouncer, error) {
@@ -298,9 +298,23 @@ func NewBouncer(password, host string, port int, rl *RateLimiter, log *slog.Logg
 		rateLimiter:  rl,
 		log:          log,
 		clients:      map[*BouncerClient]struct{}{},
-		channelLog:   map[string][]loggedLine{},
 		upstreamHost: "turborg",
 	}, nil
+}
+
+// AttachMessageStore wires the bouncer to a shared messages.Store.
+// Replay-on-attach and CHATHISTORY both query through this seam. nil
+// disables replay; the bouncer still serves live traffic normally.
+func (b *Bouncer) AttachMessageStore(s messages.Store) {
+	b.messageStoreMu.Lock()
+	defer b.messageStoreMu.Unlock()
+	b.messageStore = s
+}
+
+func (b *Bouncer) currentMessageStore() messages.Store {
+	b.messageStoreMu.RLock()
+	defer b.messageStoreMu.RUnlock()
+	return b.messageStore
 }
 
 func (b *Bouncer) AttachUpstream(send SendUpstreamFunc) {
@@ -613,6 +627,15 @@ func (b *Bouncer) handleLine(client *BouncerClient, line string) {
 		return
 	}
 
+	// CHATHISTORY is a bouncer-local query against messages.Store —
+	// never forwarded upstream, handled regardless of upstream-state
+	// (clients can ask for scrollback even while reconnecting). Must
+	// run BEFORE the forwardable filter.
+	if msg.Command == CmdChathistory {
+		b.handleChathistory(client, msg)
+		return
+	}
+
 	if !forwardable[msg.Command] {
 		return
 	}
@@ -769,6 +792,12 @@ var supportedCaps = map[string]bool{
 	"account-tag":         true,
 	"away-notify":         true,
 	"batch":               true,
+	// draft/chathistory advertises that the bouncer answers
+	// CHATHISTORY queries against the configured messages.Store.
+	// Clients that negotiate this cap learn they can scroll back past
+	// the welcome replay depth (the 200-msg cap above) by issuing
+	// CHATHISTORY BEFORE / LATEST against any joined channel.
+	"draft/chathistory": true,
 }
 
 func supportedCapsList() string {
@@ -949,19 +978,40 @@ func (b *Bouncer) replayState(client *BouncerClient) {
 	}
 }
 
-func (b *Bouncer) replayChannelLogs(client *BouncerClient) {
-	b.logMu.Lock()
-	snap := make(map[string][]loggedLine, len(b.channelLog))
-	for k, v := range b.channelLog {
-		if len(v) == 0 {
-			continue
-		}
-		cp := make([]loggedLine, len(v))
-		copy(cp, v)
-		snap[k] = cp
-	}
-	b.logMu.Unlock()
+// defaultReplayDepthOnAttach pins the welcome-replay depth when the
+// operator hasn't overridden it via AttachWelcomeReplayDepth.
+// Matches the historical 200/channel ring used before the store
+// seam landed — change the value at the runtime boundary, not here.
+const defaultReplayDepthOnAttach = 200
 
+// AttachWelcomeReplayDepth overrides how many recent messages per
+// joined channel the bouncer ships to a freshly-attached client.
+// Larger values let HexChat-class clients (no CHATHISTORY support)
+// see a deeper backfill at the cost of a slower welcome on every
+// reconnect. Pass 0 to use the default.
+func (b *Bouncer) AttachWelcomeReplayDepth(n int) {
+	b.welcomeReplayMu.Lock()
+	defer b.welcomeReplayMu.Unlock()
+	if n <= 0 {
+		n = defaultReplayDepthOnAttach
+	}
+	b.welcomeReplayDepth = n
+}
+
+func (b *Bouncer) currentWelcomeReplayDepth() int {
+	b.welcomeReplayMu.RLock()
+	defer b.welcomeReplayMu.RUnlock()
+	if b.welcomeReplayDepth <= 0 {
+		return defaultReplayDepthOnAttach
+	}
+	return b.welcomeReplayDepth
+}
+
+func (b *Bouncer) replayChannelLogs(client *BouncerClient) {
+	store := b.currentMessageStore()
+	if store == nil || b.state == nil {
+		return
+	}
 	b.upstreamMu.RLock()
 	hasUpstream := b.upstreamNick != ""
 	b.upstreamMu.RUnlock()
@@ -971,32 +1021,90 @@ func (b *Bouncer) replayChannelLogs(client *BouncerClient) {
 
 	tagTime := client.hasCap("server-time")
 	useBatch := client.hasCap("batch")
+	depth := b.currentWelcomeReplayDepth()
 
-	for channel, lines := range snap {
-		var batchID string
-		if useBatch {
-			batchID = newBatchID()
-			_ = client.sendLine(fmt.Sprintf(
-				"BATCH +%s chathistory %s", batchID, channel,
-			))
-		} else {
-			_ = client.sendLine(fmt.Sprintf(
-				":turborg-bouncer NOTICE %s :--- buffer playback for %s (%d lines) ---",
-				channel, channel, len(lines),
-			))
+	for _, info := range b.state.JoinedChannels() {
+		msgs, err := store.Recent(context.Background(), info.Name, time.Time{}, depth)
+		if err != nil || len(msgs) == 0 {
+			continue
 		}
-		for _, entry := range lines {
-			if err := client.sendLine(decorateReplayLine(entry, tagTime, batchID)); err != nil {
-				return
-			}
+		// store.Recent returns newest-first; replay is chronological
+		// so the client sees the conversation in the order it
+		// happened.
+		reverseMessages(msgs)
+		b.writeReplayBatch(client, info.Name, msgs, tagTime, useBatch)
+	}
+}
+
+// writeReplayBatch emits one channel's worth of historical messages
+// using the cap-aware framing (BATCH for batch-capable clients,
+// NOTICE markers for everyone else). Each message is decorated with
+// the IRCv3 tags the client negotiated.
+func (b *Bouncer) writeReplayBatch(client *BouncerClient, channel string, msgs []messages.Message, tagTime, useBatch bool) {
+	var batchID string
+	if useBatch {
+		batchID = newBatchID()
+		_ = client.sendLine(fmt.Sprintf("BATCH +%s chathistory %s", batchID, channel))
+	} else {
+		_ = client.sendLine(fmt.Sprintf(
+			":turborg-bouncer NOTICE %s :--- buffer playback for %s (%d lines) ---",
+			channel, channel, len(msgs),
+		))
+	}
+	for _, m := range msgs {
+		line := b.formatMessageForReplay(m)
+		if err := client.sendLine(decorateReplayLine(loggedLine{line: line, ts: m.TS}, tagTime, batchID)); err != nil {
+			return
 		}
-		if useBatch {
-			_ = client.sendLine("BATCH -" + batchID)
-		} else {
-			_ = client.sendLine(fmt.Sprintf(
-				":turborg-bouncer NOTICE %s :--- end of buffer ---", channel,
-			))
-		}
+	}
+	if useBatch {
+		_ = client.sendLine("BATCH -" + batchID)
+	} else {
+		_ = client.sendLine(fmt.Sprintf(
+			":turborg-bouncer NOTICE %s :--- end of buffer ---", channel,
+		))
+	}
+}
+
+// formatMessageForReplay reconstructs an IRC PRIVMSG wire line from a
+// stored messages.Message. The prefix uses the bouncer's known
+// upstream identity for self-messages (so echo-message-aware clients
+// match it against the prefix they learned at attach) and a synthetic
+// host for other senders — the receiving client only renders the nick
+// portion anyway, and we don't store ident/host across the wire.
+func (b *Bouncer) formatMessageForReplay(m messages.Message) string {
+	b.upstreamMu.RLock()
+	selfNick := b.upstreamNick
+	selfIdent := b.upstreamIdent
+	selfHost := b.upstreamHost
+	b.upstreamMu.RUnlock()
+
+	var prefix string
+	if m.Nick == selfNick && selfNick != "" {
+		prefix = fmt.Sprintf(":%s!%s@%s", selfNick, selfIdent, selfHost)
+	} else {
+		// Synthetic ident@host — clients don't render this visibly
+		// for non-self messages. A future PR can extend the wire
+		// contract with ident/host preservation if needed.
+		prefix = fmt.Sprintf(":%s!~user@upstream", m.Nick)
+	}
+	return fmt.Sprintf("%s PRIVMSG %s :%s", prefix, m.Channel, m.Text)
+}
+
+// loggedLine survives as the input shape decorateReplayLine accepts —
+// keeping the helper signature stable across the in-memory ring
+// removal so the cap-merging tests in internal_test.go continue to
+// exercise the same code path the replay loop hits.
+type loggedLine struct {
+	line string
+	ts   time.Time
+}
+
+// reverseMessages flips a slice in place so a newest-first store
+// reply renders oldest-first in the replay.
+func reverseMessages(msgs []messages.Message) {
+	for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+		msgs[i], msgs[j] = msgs[j], msgs[i]
 	}
 }
 
@@ -1577,10 +1685,11 @@ func (b *Bouncer) NotifyJoinFailure(channel, reason string) {
 	b.Broadcast(line, nil)
 }
 
-// replay ring so a bouncer client that reconnects later sees the
-// traffic it missed.
+// Broadcast fans line to every authenticated bouncer client except
+// exclude. Recording for replay is no longer the bouncer's concern —
+// the EventBus subscriber wired in runtime.Build feeds the shared
+// messages.Store so the bouncer + WS gateway see one canonical history.
 func (b *Bouncer) Broadcast(line string, exclude *BouncerClient) {
-	b.recordForReplay(line)
 	b.mu.Lock()
 	clients := make([]*BouncerClient, 0, len(b.clients))
 	for c := range b.clients {
@@ -1622,7 +1731,6 @@ func (b *Bouncer) BroadcastAsSelf(line string, exclude *BouncerClient) {
 	if prefix != "" {
 		line = prefix + " " + line
 	}
-	b.recordForReplay(line)
 
 	b.mu.Lock()
 	clients := make([]*BouncerClient, 0, len(b.clients))
@@ -1644,38 +1752,6 @@ func (b *Bouncer) BroadcastAsSelf(line string, exclude *BouncerClient) {
 			b.mu.Unlock()
 		}
 	}
-}
-
-func (b *Bouncer) recordForReplay(line string) {
-	if b.state == nil {
-		return
-	}
-	upper := strings.ToUpper(line)
-	if !strings.Contains(upper, "PRIVMSG") && !strings.Contains(upper, "NOTICE") {
-		return
-	}
-	msg := Parse(line)
-	if msg.Command != CmdPrivmsg && msg.Command != CmdNotice {
-		return
-	}
-	if len(msg.Params) == 0 {
-		return
-	}
-	target := msg.Params[0]
-	if !startsWithChannelSigil(target) {
-		return
-	}
-	if b.state.Get(target) == nil {
-		return
-	}
-	b.logMu.Lock()
-	defer b.logMu.Unlock()
-	bucket := b.channelLog[target]
-	bucket = append(bucket, loggedLine{line: line, ts: time.Now()})
-	if len(bucket) > channelLogCap {
-		bucket = bucket[len(bucket)-channelLogCap:]
-	}
-	b.channelLog[target] = bucket
 }
 
 func startsWithChannelSigil(s string) bool {

--- a/internal/connector/irc/bouncer_test.go
+++ b/internal/connector/irc/bouncer_test.go
@@ -12,7 +12,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/messages"
 )
+
+// attachStoreWithSeed wires a fresh MemoryStore to the bouncer and
+// pre-populates it with the given seed entries so replay-on-attach
+// tests have something to render. Returns the store for additional
+// assertions.
+func attachStoreWithSeed(t *testing.T, b *irc.Bouncer, seed []messages.Message) *messages.MemoryStore {
+	t.Helper()
+	store := messages.NewMemoryStore(0)
+	for _, m := range seed {
+		require.NoError(t, store.Submit(context.Background(), m))
+	}
+	b.AttachMessageStore(store)
+	return store
+}
 
 // freshBouncer builds a bouncer listening on a random port. tearDown
 // stops it and waits for goroutines so goleak stays happy.
@@ -763,9 +778,11 @@ func TestBouncerReplaysChannelLog(t *testing.T) {
 	state.OnSelfJoin("#test")
 	b.AttachState(state, "turborg", "ident", "host")
 
-	// Record some traffic on the channel before any client connects.
-	b.Broadcast(":alice!u@h PRIVMSG #test :hello from before", nil)
-	b.Broadcast(":bob!u@h PRIVMSG #test :and from before too", nil)
+	base := time.Now().Add(-time.Minute)
+	attachStoreWithSeed(t, b, []messages.Message{
+		{Channel: "#test", Nick: "alice", Text: "hello from before", TS: base},
+		{Channel: "#test", Nick: "bob", Text: "and from before too", TS: base.Add(time.Second)},
+	})
 
 	conn, r := bouncerClient(t, addr)
 	_, _ = r.ReadString('\n')
@@ -829,7 +846,9 @@ func TestBouncerReplayCarriesServerTimeTag(t *testing.T) {
 	state.OnSelfJoin("#test")
 	b.AttachState(state, "turborg", "ident", "host")
 
-	b.Broadcast(":alice!u@h PRIVMSG #test :hello from before", nil)
+	attachStoreWithSeed(t, b, []messages.Message{
+		{Channel: "#test", Nick: "alice", Text: "hello from before", TS: time.Now().Add(-time.Minute)},
+	})
 
 	conn, r := bouncerClient(t, addr)
 	negotiateAndPass(t, conn, r, "server-time message-tags", "hunter2")
@@ -867,7 +886,9 @@ func TestBouncerReplayWrappedInChathistoryBatch(t *testing.T) {
 	state.OnSelfJoin("#test")
 	b.AttachState(state, "turborg", "ident", "host")
 
-	b.Broadcast(":alice!u@h PRIVMSG #test :hello from before", nil)
+	attachStoreWithSeed(t, b, []messages.Message{
+		{Channel: "#test", Nick: "alice", Text: "hello from before", TS: time.Now().Add(-time.Minute)},
+	})
 
 	conn, r := bouncerClient(t, addr)
 	negotiateAndPass(t, conn, r, "batch message-tags", "hunter2")
@@ -911,6 +932,173 @@ func TestBouncerReplayWrappedInChathistoryBatch(t *testing.T) {
 	assert.True(t, batchEnd, "missing BATCH end")
 	assert.True(t, batchedLine, "missing batched replay line")
 	assert.False(t, sawLegacyMarker, "legacy NOTICE markers must be suppressed for batch-cap clients")
+}
+
+// --- CHATHISTORY --------------------------------------------------------
+
+func TestChathistoryLatestReturnsFromStore(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	attachStoreWithSeed(t, b, []messages.Message{
+		{Channel: "#test", Nick: "alice", Text: "one", TS: base},
+		{Channel: "#test", Nick: "bob", Text: "two", TS: base.Add(time.Second)},
+		{Channel: "#test", Nick: "alice", Text: "three", TS: base.Add(2 * time.Second)},
+	})
+
+	conn, r := bouncerClient(t, addr)
+	negotiateAndPass(t, conn, r, "batch message-tags draft/chathistory", "hunter2")
+	drainUntilEndOfWelcome(t, conn, r)
+
+	writeLine(t, conn, "CHATHISTORY LATEST #test * 50")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var batchID string
+	var lines []string
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if strings.HasPrefix(line, "BATCH +") {
+			parts := strings.Fields(strings.TrimPrefix(line, "BATCH +"))
+			require.GreaterOrEqual(t, len(parts), 3, "BATCH start malformed: %q", line)
+			batchID = parts[0]
+			assert.Equal(t, "chathistory", parts[1])
+			assert.Equal(t, "#test", parts[2])
+			continue
+		}
+		if strings.HasPrefix(line, "BATCH -") {
+			assert.Equal(t, "BATCH -"+batchID, line, "BATCH end must match start id")
+			break
+		}
+		if strings.Contains(line, "PRIVMSG #test") {
+			assert.Contains(t, line, "batch="+batchID, "line must carry batch tag")
+			lines = append(lines, line)
+		}
+	}
+
+	require.Len(t, lines, 3, "expected 3 history lines, got %v", lines)
+	// Inside the batch, messages must render chronologically (oldest first).
+	assert.Contains(t, lines[0], ":one")
+	assert.Contains(t, lines[1], ":two")
+	assert.Contains(t, lines[2], ":three")
+}
+
+func TestChathistoryBeforeFiltersByTimestamp(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	attachStoreWithSeed(t, b, []messages.Message{
+		{Channel: "#test", Nick: "a", Text: "old", TS: base},
+		{Channel: "#test", Nick: "b", Text: "newer", TS: base.Add(10 * time.Second)},
+	})
+
+	conn, r := bouncerClient(t, addr)
+	negotiateAndPass(t, conn, r, "batch draft/chathistory", "hunter2")
+	drainUntilEndOfWelcome(t, conn, r)
+
+	// `before` strictly excludes equal/newer entries — passing the ts
+	// of `newer` must omit it and return only `old`.
+	writeLine(t, conn, "CHATHISTORY BEFORE #test timestamp=2026-05-21T12:00:10Z 50")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var historyLines []string
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if strings.HasPrefix(line, "BATCH -") {
+			break
+		}
+		if strings.Contains(line, "PRIVMSG #test") {
+			historyLines = append(historyLines, line)
+		}
+	}
+	require.Len(t, historyLines, 1)
+	assert.Contains(t, historyLines[0], ":old")
+}
+
+func TestChathistoryRejectsInvalidInputs(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+	attachStoreWithSeed(t, b, nil)
+
+	cases := []struct {
+		name string
+		cmd  string
+		code string
+	}{
+		{"too few params", "CHATHISTORY LATEST", "NEED_MORE_PARAMS"},
+		{"non-channel target", "CHATHISTORY LATEST alice * 50", "INVALID_TARGET"},
+		{"bad limit", "CHATHISTORY LATEST #test * abc", "INVALID_PARAMS"},
+		{"unknown subcommand", "CHATHISTORY AROUND #test * 50", "UNKNOWN_COMMAND"},
+		{"bad selector", "CHATHISTORY BEFORE #test msgid=xyz 50", "INVALID_PARAMS"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, r := bouncerClient(t, addr)
+			negotiateAndPass(t, conn, r, "draft/chathistory", "hunter2")
+			drainUntilEndOfWelcome(t, conn, r)
+
+			writeLine(t, conn, tc.cmd)
+			conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+			var sawFail bool
+			for {
+				line, err := r.ReadString('\n')
+				if err != nil {
+					break
+				}
+				if strings.HasPrefix(line, "FAIL CHATHISTORY "+tc.code) {
+					sawFail = true
+					break
+				}
+			}
+			assert.True(t, sawFail, "expected FAIL CHATHISTORY %s for %q", tc.code, tc.cmd)
+		})
+	}
+}
+
+// drainUntilEndOfWelcome reads until the welcome flush has settled so
+// CHATHISTORY tests start with a clean stream. The welcome sequence
+// always ends with either RPL_ENDOFNAMES (366) when channels are
+// joined or the BATCH/buffer trailer; we look for both.
+func drainUntilEndOfWelcome(t *testing.T, conn net.Conn, r *bufio.Reader) {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		// 366 = RPL_ENDOFNAMES (state replay trailer), "end of buffer"
+		// or BATCH - = end of channel-log replay block.
+		if strings.Contains(line, " 366 ") ||
+			strings.Contains(line, "end of buffer") ||
+			strings.HasPrefix(line, "BATCH -") {
+			// Give the bouncer ~10ms to send anything else queued
+			// from the welcome path before we hand off to the test.
+			conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond))
+			for {
+				if _, err := r.ReadString('\n'); err != nil {
+					return
+				}
+			}
+		}
+	}
 }
 
 // --- PING / PONG --------------------------------------------------------

--- a/internal/connector/irc/bouncer_test.go
+++ b/internal/connector/irc/bouncer_test.go
@@ -795,6 +795,124 @@ func TestBouncerReplaysChannelLog(t *testing.T) {
 	assert.True(t, sawBufferEnd, "buffer end marker missing")
 }
 
+// negotiateAndPass walks the IRCv3 CAP LS → CAP REQ <caps> → PASS →
+// CAP END handshake against the bouncer and returns once auth+welcome
+// have completed. Used by the replay-decoration tests to put the
+// client into a known cap state before it consumes replay output.
+func negotiateAndPass(t *testing.T, conn net.Conn, r *bufio.Reader, caps, password string) {
+	t.Helper()
+	_, _ = r.ReadString('\n') // pre-auth NOTICE
+
+	writeLine(t, conn, "CAP LS")
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, err := r.ReadString('\n')
+	require.NoError(t, err)
+
+	writeLine(t, conn, "CAP REQ :"+caps)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	ack, err := r.ReadString('\n')
+	require.NoError(t, err)
+	require.Contains(t, ack, "CAP * ACK :", "expected ACK for negotiated caps, got %q", ack)
+
+	writeLine(t, conn, "PASS "+password)
+	writeLine(t, conn, "CAP END")
+}
+
+func TestBouncerReplayCarriesServerTimeTag(t *testing.T) {
+	// Clients that negotiated server-time must receive replayed lines
+	// with an `@time=<ISO8601 UTC>` prefix so HexChat / mIRC / irssi
+	// render them as historical and don't highlight the channel tab
+	// as fresh activity. This is the user-visible fix for the "buffer
+	// playback looks like new messages" bug.
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+
+	b.Broadcast(":alice!u@h PRIVMSG #test :hello from before", nil)
+
+	conn, r := bouncerClient(t, addr)
+	negotiateAndPass(t, conn, r, "server-time message-tags", "hunter2")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var sawTaggedReplay bool
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if strings.Contains(line, "PRIVMSG #test") &&
+			strings.Contains(line, "hello from before") {
+			// Tag block must precede the prefix and contain time= in
+			// the expected ISO8601 format (RFC3339-ish with millis).
+			assert.True(t, strings.HasPrefix(line, "@"),
+				"server-time replay must start with @tags, got %q", line)
+			assert.Contains(t, line, "time=",
+				"server-time replay must carry time= tag, got %q", line)
+			sawTaggedReplay = true
+			break
+		}
+	}
+	assert.True(t, sawTaggedReplay, "expected tagged replay line for #test")
+}
+
+func TestBouncerReplayWrappedInChathistoryBatch(t *testing.T) {
+	// Clients that negotiated the `batch` cap get the per-channel
+	// replay block wrapped in `BATCH +<id> chathistory <channel>` /
+	// `BATCH -<id>` with every replayed line tagged `batch=<id>`. The
+	// legacy NOTICE markers are dropped in this case — capable clients
+	// would render them as out-of-band server NOTICEs, which is wrong.
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+
+	b.Broadcast(":alice!u@h PRIVMSG #test :hello from before", nil)
+
+	conn, r := bouncerClient(t, addr)
+	negotiateAndPass(t, conn, r, "batch message-tags", "hunter2")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var batchStart, batchEnd, batchedLine, sawLegacyMarker bool
+	var batchID string
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimRight(line, "\r\n")
+		switch {
+		case strings.HasPrefix(line, "BATCH +"):
+			// Format: "BATCH +<id> chathistory <channel>"
+			rest := strings.TrimPrefix(line, "BATCH +")
+			parts := strings.Fields(rest)
+			require.GreaterOrEqual(t, len(parts), 3, "BATCH start malformed: %q", line)
+			batchID = parts[0]
+			assert.Equal(t, "chathistory", parts[1])
+			assert.Equal(t, "#test", parts[2])
+			batchStart = true
+		case strings.HasPrefix(line, "BATCH -") && batchID != "":
+			assert.Equal(t, "BATCH -"+batchID, line)
+			batchEnd = true
+		case strings.Contains(line, "PRIVMSG #test") &&
+			strings.Contains(line, "hello from before"):
+			assert.Contains(t, line, "batch="+batchID,
+				"replay line must carry the batch tag: %q", line)
+			batchedLine = true
+		case strings.Contains(line, "buffer playback for #test"),
+			strings.Contains(line, "end of buffer"):
+			sawLegacyMarker = true
+		}
+		if batchEnd {
+			break
+		}
+	}
+	assert.True(t, batchStart, "missing BATCH start")
+	assert.True(t, batchEnd, "missing BATCH end")
+	assert.True(t, batchedLine, "missing batched replay line")
+	assert.False(t, sawLegacyMarker, "legacy NOTICE markers must be suppressed for batch-cap clients")
+}
+
 // --- PING / PONG --------------------------------------------------------
 
 func TestBouncerPingReplyDoesNotForward(t *testing.T) {

--- a/internal/connector/irc/chathistory.go
+++ b/internal/connector/irc/chathistory.go
@@ -1,0 +1,170 @@
+package irc
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/turborg/turborg/internal/messages"
+)
+
+// chathistoryMaxLimit caps how many entries a single CHATHISTORY
+// query can return. Mirrors common IRCv3 server behavior (Soju /
+// ergo default to 100; we go to 200 to match the welcome-replay
+// depth — same conceptual "one screen of backfill" unit).
+const chathistoryMaxLimit = 200
+
+// chathistorySubBefore returns messages strictly older than the
+// selector; chathistoryLatest returns the latest N when the selector
+// is `*` (or older-than selector when a real selector is given,
+// equivalent to BEFORE in that case).
+//
+// Subcommands we don't implement yet — AFTER, AROUND, BETWEEN,
+// TARGETS — return FAIL CHATHISTORY UNKNOWN_COMMAND so clients fall
+// back gracefully. The set we ship covers the scroll-up case all
+// known clients actually use.
+const (
+	chathistorySubBefore = "BEFORE"
+	chathistorySubLatest = "LATEST"
+)
+
+// handleChathistory parses and dispatches an IRCv3
+// `CHATHISTORY <sub> <target> <selector> <limit>` command.
+//
+// Selectors supported: `timestamp=<ISO8601>` and `*` (LATEST only).
+// `msgid=<id>` is rejected with FAIL INVALID_PARAMS — the store
+// doesn't yet expose msgid-keyed lookups; adding them is a follow-up
+// once a consumer needs it.
+//
+// Response shape per IRCv3:
+//
+//	BATCH +<id> chathistory <target>
+//	  @batch=<id>;time=<ISO> :nick!u@h PRIVMSG <target> :text
+//	  ...
+//	BATCH -<id>
+//
+// On error: `FAIL CHATHISTORY <code> [<context...>] :<message>`.
+func (b *Bouncer) handleChathistory(client *BouncerClient, msg Message) {
+	if len(msg.Params) < 4 {
+		sendChathistoryFail(client, "NEED_MORE_PARAMS", msg.Command,
+			"Need <subcommand> <target> <selector> <limit>")
+		return
+	}
+	sub := strings.ToUpper(msg.Params[0])
+	target := msg.Params[1]
+	selector := msg.Params[2]
+	limitStr := msg.Params[3]
+
+	if target == "" || !startsWithChannelSigil(target) {
+		sendChathistoryFail(client, "INVALID_TARGET", target,
+			"Channel target required for CHATHISTORY")
+		return
+	}
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit <= 0 {
+		sendChathistoryFail(client, "INVALID_PARAMS", target,
+			"Limit must be a positive integer")
+		return
+	}
+	if limit > chathistoryMaxLimit {
+		limit = chathistoryMaxLimit
+	}
+
+	var before time.Time
+	switch sub {
+	case chathistorySubBefore:
+		ts, ok := parseChathistorySelector(selector)
+		if !ok {
+			sendChathistoryFail(client, "INVALID_PARAMS", target,
+				"Selector must be timestamp=<ISO8601>")
+			return
+		}
+		before = ts
+	case chathistorySubLatest:
+		// `*` selector means "no lower bound, last N" — equivalent to
+		// passing the zero time to store.Recent. A concrete selector
+		// behaves like BEFORE for ordering purposes (older-than).
+		if selector != "*" {
+			ts, ok := parseChathistorySelector(selector)
+			if !ok {
+				sendChathistoryFail(client, "INVALID_PARAMS", target,
+					"Selector must be * or timestamp=<ISO8601>")
+				return
+			}
+			before = ts
+		}
+	default:
+		sendChathistoryFail(client, "UNKNOWN_COMMAND", sub,
+			"Subcommand not implemented")
+		return
+	}
+
+	store := b.currentMessageStore()
+	if store == nil {
+		// Empty result is a valid response — equivalent to "no history
+		// available". Don't FAIL just because the operator hasn't
+		// configured a store.
+		b.writeChathistoryBatch(client, target, nil)
+		return
+	}
+
+	out, err := store.Recent(context.Background(), target, before, limit)
+	if err != nil {
+		sendChathistoryFail(client, "MESSAGE_ERROR", target,
+			"history lookup failed")
+		return
+	}
+	// store.Recent returns newest-first; CHATHISTORY responses are
+	// emitted oldest-first inside the batch so clients render the
+	// conversation in chronological order.
+	reverseMessages(out)
+	b.writeChathistoryBatch(client, target, out)
+}
+
+func (b *Bouncer) writeChathistoryBatch(client *BouncerClient, target string, msgs []messages.Message) {
+	useBatch := client.hasCap("batch")
+	tagTime := client.hasCap("server-time")
+
+	var batchID string
+	if useBatch {
+		batchID = newBatchID()
+		_ = client.sendLine("BATCH +" + batchID + " chathistory " + target)
+	}
+	for _, m := range msgs {
+		line := b.formatMessageForReplay(m)
+		_ = client.sendLine(decorateReplayLine(loggedLine{line: line, ts: m.TS}, tagTime, batchID))
+	}
+	if useBatch {
+		_ = client.sendLine("BATCH -" + batchID)
+	}
+}
+
+// parseChathistorySelector accepts `timestamp=<ISO8601>` and returns
+// the parsed time. Future selector forms (msgid=, etc.) plug in here.
+func parseChathistorySelector(selector string) (time.Time, bool) {
+	const prefix = "timestamp="
+	if !strings.HasPrefix(selector, prefix) {
+		return time.Time{}, false
+	}
+	raw := selector[len(prefix):]
+	// IRCv3 says ISO8601; in practice that's RFC3339(Nano).
+	if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02T15:04:05.000Z", raw); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02T15:04:05Z", raw); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+func sendChathistoryFail(client *BouncerClient, code, context, message string) {
+	if context == "" {
+		context = "*"
+	}
+	_ = client.sendLine("FAIL CHATHISTORY " + code + " " + context + " :" + message)
+}

--- a/internal/connector/irc/codes.go
+++ b/internal/connector/irc/codes.go
@@ -36,12 +36,12 @@ const (
 	RplEndOfMOTD     = "376"
 	RplWhoisSecure   = "671"
 
-	RplSaslLoggedIn  = "900"
-	RplSaslSuccess   = "903"
-	ErrSaslFail      = "904"
-	ErrSaslTooLong   = "905"
-	ErrSaslAborted   = "906"
-	ErrSaslAlready   = "907"
+	RplSaslLoggedIn = "900"
+	RplSaslSuccess  = "903"
+	ErrSaslFail     = "904"
+	ErrSaslTooLong  = "905"
+	ErrSaslAborted  = "906"
+	ErrSaslAlready  = "907"
 
 	ErrNoSuchNick       = "401"
 	ErrNoMOTD           = "422"
@@ -59,28 +59,36 @@ const (
 
 // IRC commands turborg sends or recognizes on the wire.
 const (
-	CmdPrivmsg       = "PRIVMSG"
-	CmdNotice        = "NOTICE"
-	CmdJoin          = "JOIN"
-	CmdPart          = "PART"
-	CmdQuit          = "QUIT"
-	CmdNick          = "NICK"
-	CmdUser          = "USER"
-	CmdPass          = "PASS"
-	CmdPing          = "PING"
-	CmdPong          = "PONG"
-	CmdMode          = "MODE"
-	CmdTopic         = "TOPIC"
-	CmdKick          = "KICK"
-	CmdNames         = "NAMES"
-	CmdCap           = "CAP"
-	CmdWhois         = "WHOIS"
-	CmdInvite        = "INVITE"
-	CmdAway          = "AWAY"
-	CmdList          = "LIST"
-	CmdWho           = "WHO"
-	CmdAuthenticate  = "AUTHENTICATE"
-	CmdError         = "ERROR"
+	CmdPrivmsg      = "PRIVMSG"
+	CmdNotice       = "NOTICE"
+	CmdJoin         = "JOIN"
+	CmdPart         = "PART"
+	CmdQuit         = "QUIT"
+	CmdNick         = "NICK"
+	CmdUser         = "USER"
+	CmdPass         = "PASS"
+	CmdPing         = "PING"
+	CmdPong         = "PONG"
+	CmdMode         = "MODE"
+	CmdTopic        = "TOPIC"
+	CmdKick         = "KICK"
+	CmdNames        = "NAMES"
+	CmdCap          = "CAP"
+	CmdWhois        = "WHOIS"
+	CmdInvite       = "INVITE"
+	CmdAway         = "AWAY"
+	CmdList         = "LIST"
+	CmdWho          = "WHO"
+	CmdAuthenticate = "AUTHENTICATE"
+	CmdError        = "ERROR"
+	// CmdChathistory is the IRCv3 draft/chathistory command. Handled
+	// locally by the bouncer (queries messages.Store, returns a
+	// chathistory-typed BATCH); never forwarded upstream.
+	CmdChathistory = "CHATHISTORY"
+	// CmdBatch is the IRCv3 batch command. Used by the bouncer when
+	// framing CHATHISTORY responses and welcome replay for
+	// batch-capable clients.
+	CmdBatch = "BATCH"
 )
 
 // IsHandshakeComplete reports whether the given numeric reply signals the

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/messages"
 	"github.com/turborg/turborg/internal/version"
 	"golang.org/x/sync/errgroup"
 )
@@ -88,6 +89,18 @@ type Connector struct {
 	// during startBouncer. Held here so SetBouncerAttachHook can run
 	// before Start without depending on bouncer existence yet.
 	bouncerAttachHook func(reason string)
+
+	// messageStore is forwarded onto the bouncer at startBouncer time
+	// so attach-replay and CHATHISTORY queries go against the runtime-
+	// composed store. Held here so the runtime can call
+	// SetMessageStore before Start.
+	messageStore messages.Store
+
+	// bouncerWelcomeReplayDepth is forwarded onto the bouncer at
+	// startBouncer time so the operator's
+	// TURBORG_BOUNCER_WELCOME_REPLAY_DEPTH lands on the right knob.
+	// Zero leaves the bouncer default in place.
+	bouncerWelcomeReplayDepth int
 
 	// onUpstreamWarn fires from the escalation watchdog once per
 	// transient-outage window when UpstreamWarnAfter elapses without
@@ -296,6 +309,18 @@ func (c *Connector) SetActivityHook(hook func(reason string)) { c.onBotSpoke = h
 // successful client auth. Pass nil to disable. Must be called before
 // Start so the bouncer picks it up when it is constructed.
 func (c *Connector) SetBouncerAttachHook(hook func(reason string)) { c.bouncerAttachHook = hook }
+
+// SetMessageStore wires the shared messages.Store. The connector
+// forwards it to the bouncer at startBouncer time so attach-replay
+// and CHATHISTORY queries flow through it. Must be called before
+// Start.
+func (c *Connector) SetMessageStore(s messages.Store) { c.messageStore = s }
+
+// SetBouncerWelcomeReplayDepth overrides how many recent messages
+// the bouncer ships per joined channel on each fresh client attach.
+// Forwarded to the bouncer at startBouncer time. Pass 0 to leave the
+// default in place.
+func (c *Connector) SetBouncerWelcomeReplayDepth(n int) { c.bouncerWelcomeReplayDepth = n }
 
 // SetUpstreamWarnHook installs the callback the escalation watchdog
 // fires when a transient outage persists past UpstreamWarnAfter. Pass
@@ -632,6 +657,8 @@ func (c *Connector) startBouncer(ctx context.Context) error {
 	b.AttachUpstreamState(c.machine, c.settings.Hostname)
 	b.AttachWantedChannels(c.wanted)
 	b.AttachPreferredNickHook(c.SetPreferredNick)
+	b.AttachMessageStore(c.messageStore)
+	b.AttachWelcomeReplayDepth(c.bouncerWelcomeReplayDepth)
 	// Reuse the existing onUpstreamWarn hook slot: the supervisor's
 	// long-outage watchdog calls into the bouncer's broadcast so
 	// channels get a stronger "still retrying" NOTICE at the warn

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -373,28 +373,12 @@ func TestAddrBeforeStart(t *testing.T) {
 	assert.Equal(t, "", b.Addr(), "Addr before Start is empty")
 }
 
-func TestRecordForReplayIgnoresNonChannel(t *testing.T) {
-	state := NewChannelState()
-	state.OnSelfJoin("#known")
-	b, err := NewBouncer("p", "127.0.0.1", 0, nil, nil)
-	require.NoError(t, err)
-	b.AttachState(state, "nick", "ident", "host")
-
-	// Non-PRIVMSG/NOTICE: noop.
-	b.recordForReplay("PING :x")
-	// Channel-targeted to an unknown channel: noop.
-	b.recordForReplay(":a!u@h PRIVMSG #unknown :hi")
-	// Non-channel target (DM): noop.
-	b.recordForReplay(":a!u@h PRIVMSG nick :hi")
-	// Channel we track: should be captured.
-	b.recordForReplay(":a!u@h PRIVMSG #known :hi")
-
-	b.logMu.Lock()
-	got := b.channelLog
-	b.logMu.Unlock()
-	require.Len(t, got, 1, "only the known-channel line should be captured: %v", got)
-	require.Equal(t, 1, len(got["#known"]))
-}
+// Recording-side filter logic (only channel-targeted PRIVMSG / NOTICE
+// counts as recordable history) used to live on the bouncer as
+// recordForReplay. That filter now lives on the runtime-wired EventBus
+// subscriber that feeds messages.Store; the bouncer is read-only on
+// the store. See `messages` package tests for the ring/cap behavior
+// and `runtime` package tests for the publish filter.
 
 // Direct handler tests via private API to cover guard-rail branches that
 // the integration tests don't naturally hit.
@@ -714,13 +698,27 @@ func TestSendBroadcastsThroughBouncerWhenAttached(t *testing.T) {
 	b.AttachState(c.state, "bot", "user", "host")
 	c.state.OnSelfJoin("#x")
 
-	// Send must call bouncer.BroadcastAsSelf — visible via the replay buffer.
+	// Connector.Send fans through bouncer.BroadcastAsSelf, which
+	// writes to every authenticated client. Attach a recording stub
+	// so we can observe the line landed.
+	rc := newRecordingConn()
+	bc := newBouncerClient(rc, slog.Default())
+	bc.setAuthenticated()
+	b.mu.Lock()
+	b.clients[bc] = struct{}{}
+	b.mu.Unlock()
+
 	require.NoError(t, c.Send(&agent.OutboundEnvelope{Channel: "#x", Text: "hi"}))
 
-	b.logMu.Lock()
-	defer b.logMu.Unlock()
-	require.Len(t, b.channelLog["#x"], 1,
-		"Send must record self-prefixed line into the bouncer's replay buffer")
+	got := rc.snapshot()
+	require.NotEmpty(t, got, "Send must fan a self-prefixed PRIVMSG to attached clients")
+	var sawPrivmsg bool
+	for _, line := range got {
+		if strings.Contains(line, "PRIVMSG #x :hi") {
+			sawPrivmsg = true
+		}
+	}
+	assert.True(t, sawPrivmsg, "attached client must see the PRIVMSG; got %v", got)
 }
 
 func TestHandlePrivmsgRoutesDMToSenderChannel(t *testing.T) {
@@ -898,8 +896,7 @@ func TestBroadcastSkipsUnauthenticatedClients(t *testing.T) {
 
 func TestUpstreamPrefixEmptyShortCircuitsBroadcastAsSelf(t *testing.T) {
 	// With no upstream nick, upstreamPrefix() returns "" and
-	// BroadcastAsSelf passes the line through untouched. recordForReplay
-	// runs with no state attached (early return).
+	// BroadcastAsSelf passes the line through untouched.
 	b, err := NewBouncer("p", "127.0.0.1", 0, nil, nil)
 	require.NoError(t, err)
 	// No AttachState call → state == nil, upstreamNick == "" → both
@@ -1208,21 +1205,8 @@ func TestDecorateReplayLine(t *testing.T) {
 	})
 }
 
-func TestRecordForReplayBoundsRing(t *testing.T) {
-	state := NewChannelState()
-	state.OnSelfJoin("#busy")
-	b, err := NewBouncer("p", "127.0.0.1", 0, nil, nil)
-	require.NoError(t, err)
-	b.AttachState(state, "nick", "ident", "host")
-
-	for i := 0; i < channelLogCap+50; i++ {
-		b.recordForReplay(":a!u@h PRIVMSG #busy :spam")
-	}
-	b.logMu.Lock()
-	got := len(b.channelLog["#busy"])
-	b.logMu.Unlock()
-	assert.Equal(t, channelLogCap, got, "ring should cap at channelLogCap")
-}
+// Per-channel ring cap behavior moved with the storage seam — see
+// TestMemoryStoreRingCap in the messages package.
 
 func TestWatchdogPollInterval(t *testing.T) {
 	cases := []struct {

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -113,13 +113,13 @@ func TestCTCPHelpers(t *testing.T) {
 
 func TestCTCPReplyCovers(t *testing.T) {
 	cases := map[string]string{
-		"\x01VERSION\x01":        "VERSION turborg " + version.Version + " (https://github.com/turborg/turborg)",
-		"\x01PING 12345\x01":     "PING 12345",
-		"\x01CLIENTINFO\x01":     "CLIENTINFO VERSION PING TIME CLIENTINFO SOURCE USERINFO",
-		"\x01SOURCE\x01":         "SOURCE https://github.com/turborg/turborg",
-		"\x01USERINFO\x01":       "USERINFO turborg agent",
-		"\x01\x01":               "",  // empty inner
-		"\x01UNKNOWN\x01":        "",  // unrecognized
+		"\x01VERSION\x01":           "VERSION turborg " + version.Version + " (https://github.com/turborg/turborg)",
+		"\x01PING 12345\x01":        "PING 12345",
+		"\x01CLIENTINFO\x01":        "CLIENTINFO VERSION PING TIME CLIENTINFO SOURCE USERINFO",
+		"\x01SOURCE\x01":            "SOURCE https://github.com/turborg/turborg",
+		"\x01USERINFO\x01":          "USERINFO turborg agent",
+		"\x01\x01":                  "", // empty inner
+		"\x01UNKNOWN\x01":           "", // unrecognized
 		"\x01version lowercase\x01": "VERSION turborg " + version.Version + " (https://github.com/turborg/turborg)",
 	}
 	for in, want := range cases {
@@ -407,7 +407,7 @@ func TestHandlersIgnoreMalformedMessages(t *testing.T) {
 	c.handlePrivmsg(ctx, Message{}, "")
 	c.handlePart(ctx, Message{})
 	c.handleKick(ctx, Message{Params: []string{"#ch"}}) // missing victim
-	c.handleNickChange(ctx, Message{}) // no old
+	c.handleNickChange(ctx, Message{})                  // no old
 	c.handleTopic(ctx, Message{})
 	c.handleJoin(ctx, Message{}) // empty target
 
@@ -921,7 +921,7 @@ func TestUpstreamPrefixEmptyShortCircuitsBroadcastAsSelf(t *testing.T) {
 // recordingConn captures everything written to it so tests can assert
 // the bytes the bouncer emits to a client.
 type recordingConn struct {
-	mu    sync.Mutex
+	mu     sync.Mutex
 	writes [][]byte
 }
 
@@ -1150,6 +1150,62 @@ func TestHandleCapListAndEnd(t *testing.T) {
 		}
 	}
 	assert.True(t, gotAck, "CAP REQ via params (not trailing) must still ACK")
+}
+
+func TestDecorateReplayLine(t *testing.T) {
+	ts := time.Date(2026, 5, 21, 12, 34, 56, 789_000_000, time.UTC)
+	entry := loggedLine{line: ":alice!u@h PRIVMSG #ch :hi", ts: ts}
+	taggedEntry := loggedLine{
+		line: "@time=2025-01-01T00:00:00.000Z;account=alice :alice!u@h PRIVMSG #ch :tagged",
+		ts:   ts,
+	}
+
+	t.Run("no caps passes line through unchanged", func(t *testing.T) {
+		assert.Equal(t, entry.line, decorateReplayLine(entry, false, ""))
+	})
+
+	t.Run("server-time prepends time= tag", func(t *testing.T) {
+		got := decorateReplayLine(entry, true, "")
+		assert.Equal(t,
+			"@time=2026-05-21T12:34:56.789Z :alice!u@h PRIVMSG #ch :hi",
+			got)
+	})
+
+	t.Run("batch prepends batch= tag", func(t *testing.T) {
+		got := decorateReplayLine(entry, false, "abc123")
+		assert.Equal(t,
+			"@batch=abc123 :alice!u@h PRIVMSG #ch :hi",
+			got)
+	})
+
+	t.Run("both caps combine in one @-segment", func(t *testing.T) {
+		got := decorateReplayLine(entry, true, "abc123")
+		assert.Equal(t,
+			"@batch=abc123;time=2026-05-21T12:34:56.789Z :alice!u@h PRIVMSG #ch :hi",
+			got)
+	})
+
+	t.Run("existing upstream tags merge: time= preserved, our tags prepended", func(t *testing.T) {
+		got := decorateReplayLine(taggedEntry, true, "abc123")
+		// Upstream's `time=2025-01-01...` must survive; ours must NOT be
+		// duplicated when the line already has tags. Batch tag is
+		// always prepended.
+		assert.True(t, strings.HasPrefix(got, "@batch=abc123;"),
+			"merged line must start with batch tag, got %q", got)
+		assert.Contains(t, got, "time=2025-01-01T00:00:00.000Z",
+			"upstream's time= must survive merge, got %q", got)
+		assert.NotContains(t, got, "time=2026-05-21",
+			"our recorded ts must not overwrite upstream's time=, got %q", got)
+		assert.Contains(t, got, "account=alice",
+			"other upstream tags must survive merge, got %q", got)
+	})
+
+	t.Run("malformed tagged line (no body separator) passes through", func(t *testing.T) {
+		malformed := loggedLine{line: "@time=2025-01-01T00:00:00.000Z", ts: ts}
+		// No space → no body. decorateReplayLine returns it unchanged
+		// rather than producing an invalid frame.
+		assert.Equal(t, malformed.line, decorateReplayLine(malformed, true, "abc123"))
+	})
 }
 
 func TestRecordForReplayBoundsRing(t *testing.T) {

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -23,8 +23,8 @@ type Settings struct {
 	Username string `env:"USERNAME"`
 	RealName string `env:"REAL_NAME" envDefault:"turborg agent"`
 
-	ServerPassword    string `env:"SERVER_PASSWORD"`
-	NickServPassword  string `env:"NICKSERV_PASSWORD"`
+	ServerPassword   string `env:"SERVER_PASSWORD"`
+	NickServPassword string `env:"NICKSERV_PASSWORD"`
 
 	SASLUser     string `env:"SASL_USER"`
 	SASLPassword string `env:"SASL_PASSWORD"`
@@ -55,13 +55,21 @@ type Settings struct {
 	// hosted users.
 	QuitMessage string `env:"QUIT_MESSAGE" envDefault:"bye from turborg"`
 
-	BouncerPassword              string        `env:"BOUNCER_PASSWORD"`
-	BouncerHost                  string        `env:"BOUNCER_HOST" envDefault:"127.0.0.1"`
-	BouncerPort                  int           `env:"BOUNCER_PORT" envDefault:"31337"`
-	BouncerRatelimitEnabled      bool          `env:"BOUNCER_RATELIMIT_ENABLED" envDefault:"true"`
-	BouncerMaxFailedAttempts     int           `env:"BOUNCER_MAX_FAILED_ATTEMPTS" envDefault:"5"`
-	BouncerFailureWindowSeconds  int           `env:"BOUNCER_FAILURE_WINDOW_SECONDS" envDefault:"60"`
-	BouncerLockoutSeconds        int           `env:"BOUNCER_LOCKOUT_SECONDS" envDefault:"300"`
+	BouncerPassword             string `env:"BOUNCER_PASSWORD"`
+	BouncerHost                 string `env:"BOUNCER_HOST" envDefault:"127.0.0.1"`
+	BouncerPort                 int    `env:"BOUNCER_PORT" envDefault:"31337"`
+	BouncerRatelimitEnabled     bool   `env:"BOUNCER_RATELIMIT_ENABLED" envDefault:"true"`
+	BouncerMaxFailedAttempts    int    `env:"BOUNCER_MAX_FAILED_ATTEMPTS" envDefault:"5"`
+	BouncerFailureWindowSeconds int    `env:"BOUNCER_FAILURE_WINDOW_SECONDS" envDefault:"60"`
+	BouncerLockoutSeconds       int    `env:"BOUNCER_LOCKOUT_SECONDS" envDefault:"300"`
+	// BouncerWelcomeReplayDepth controls how many recent channel
+	// messages the bouncer ships per joined channel on each fresh
+	// client attach. Bumping it lets IRC clients without
+	// `draft/chathistory` support (HexChat 2.16 et al) see a deeper
+	// backfill on attach, at the cost of a slower welcome on every
+	// reconnect. Capped at 2000 by the bouncer to keep welcome
+	// bursts bounded.
+	BouncerWelcomeReplayDepth int `env:"BOUNCER_WELCOME_REPLAY_DEPTH" envDefault:"200"`
 
 	CTCPAutoReply     bool `env:"CTCP_AUTO_REPLY" envDefault:"true"`
 	CTCPMaxPerWindow  int  `env:"CTCP_MAX_PER_WINDOW" envDefault:"3"`

--- a/internal/messages/http.go
+++ b/internal/messages/http.go
@@ -1,0 +1,179 @@
+package messages
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/turborg/turborg/internal/messagesink"
+)
+
+// HTTPStore mirrors channel history to an external HTTP service that
+// implements the wire contract documented below. Writes are batched
+// through the existing messagesink.Sink (already tuned, retried, and
+// backpressured); reads are a synchronous GET.
+//
+// Wire contract operators must implement at the configured URL:
+//
+//	POST <url>
+//	  Authorization: Bearer <token>
+//	  Content-Type: application/json
+//	  Body: {"messages": [{"msg_id","channel","nick","text","ts","kind"}, ...]}
+//	  Status: 2xx on success; non-2xx is logged at debug and entries
+//	  are NOT retried (the receiving side is expected to dedupe on
+//	  msg_id, so a dropped batch is recoverable from the next batch).
+//
+//	GET <url>?channel=<ch>&before=<ISO8601>&limit=<int>
+//	  Authorization: Bearer <token>
+//	  Status: 200 on success.
+//	  Body: {"messages": [{"msg_id","channel","nick","text","ts"}, ...],
+//	         "has_more": bool}
+//	  - `before` empty means "no upper bound, return the most recent N".
+//	  - Messages are returned newest-first.
+//	  - has_more = true tells the caller to keep paginating.
+type HTTPStore struct {
+	endpoint string
+	token    string
+	client   *http.Client
+	sink     *messagesink.Sink // owned: written by Submit, closed by Close.
+	log      *slog.Logger
+}
+
+// NewHTTPStore returns nil when either endpoint or token is empty —
+// matches the convention messagesink.New uses, so the caller can plug
+// the result straight into a Store-typed field with a single non-nil
+// check.
+//
+// sink is owned by the returned HTTPStore — Submit pushes through it
+// (write half) and the caller passes it in so the same batched +
+// retried + backpressured queue services Submit for both this Store
+// and the existing gateway.MessageRecorder path during migration.
+func NewHTTPStore(endpoint, token string, sink *messagesink.Sink, log *slog.Logger) *HTTPStore {
+	if endpoint == "" || token == "" {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &HTTPStore{
+		endpoint: endpoint,
+		token:    token,
+		client:   &http.Client{Timeout: readTimeout},
+		sink:     sink,
+		log:      log,
+	}
+}
+
+// readTimeout caps how long a Recent call can block. The gateway's
+// `history` op + bouncer's CHATHISTORY both run on hot paths (a WS
+// frame handler / an IRC client read loop) — letting either stall on a
+// slow backend would visibly freeze the user's UI.
+const readTimeout = 5 * time.Second
+
+// Submit defers to the underlying sink. The HTTPStore intentionally
+// owns no per-Submit logic — message ID minting + ISO 8601 timestamp
+// formatting + batched POST are all messagesink concerns we don't
+// duplicate here.
+func (s *HTTPStore) Submit(_ context.Context, m Message) error {
+	if s == nil || s.sink == nil {
+		return nil
+	}
+	// Hand the entry off through messagesink's batched Submit. The
+	// receiving service is expected to mint msg_id when the field is
+	// empty (matching the legacy messagesink.Recorder contract); a
+	// caller that has its own id can pass it through Message.ID.
+	s.sink.Submit(messagesink.Entry{
+		MsgID:   m.ID,
+		Channel: m.Channel,
+		Nick:    m.Nick,
+		Text:    m.Text,
+		Ts:      m.TS.UTC().Format("2006-01-02T15:04:05.000000Z"),
+		Kind:    "message",
+	})
+	return nil
+}
+
+// Recent queries the configured endpoint for up to limit messages
+// strictly older than before. Returns an empty slice (not an error) on
+// network failure — callers treat history as best-effort, and an
+// in-flight reconnect shouldn't trip a hard failure on an attach-time
+// replay.
+func (s *HTTPStore) Recent(ctx context.Context, channel string, before time.Time, limit int) ([]Message, error) {
+	if s == nil || channel == "" || limit <= 0 {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	q := url.Values{}
+	q.Set("channel", channel)
+	q.Set("limit", strconv.Itoa(limit))
+	if !before.IsZero() {
+		q.Set("before", before.UTC().Format("2006-01-02T15:04:05.000000Z"))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint+"?"+q.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("messages: build history request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		// Network/timeout failures are downgraded to debug + empty —
+		// the replay path stays best-effort. A flaky read endpoint
+		// must not cascade into a failed bouncer attach.
+		s.log.Debug("messages: history fetch", "err", err, "channel", channel)
+		return nil, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		s.log.Debug("messages: history non-200",
+			"status", resp.StatusCode,
+			"channel", channel,
+		)
+		return nil, nil
+	}
+
+	var body struct {
+		Messages []struct {
+			MsgID   string `json:"msg_id"`
+			Channel string `json:"channel"`
+			Nick    string `json:"nick"`
+			Text    string `json:"text"`
+			Ts      string `json:"ts"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		s.log.Debug("messages: history decode", "err", err)
+		return nil, nil
+	}
+
+	out := make([]Message, 0, len(body.Messages))
+	for _, e := range body.Messages {
+		ts, err := time.Parse("2006-01-02T15:04:05.000000Z", e.Ts)
+		if err != nil {
+			// Fall back to RFC3339 / RFC3339Nano so a receiver that
+			// emits a slightly different ISO precision still flows
+			// through. Skip the entry on hard parse failure rather
+			// than poison the whole reply with an error.
+			if ts, err = time.Parse(time.RFC3339Nano, e.Ts); err != nil {
+				continue
+			}
+		}
+		out = append(out, Message{
+			ID:      e.MsgID,
+			Channel: e.Channel,
+			Nick:    e.Nick,
+			Text:    e.Text,
+			TS:      ts,
+		})
+	}
+	return out, nil
+}

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -1,0 +1,148 @@
+// Package messages defines the durable channel-history seam turborg
+// uses for replay (on bouncer / WS attach) and on-demand scrollback
+// (CHATHISTORY for IRC clients, the WS `history` op for the bundled
+// reference UI and downstream UIs like xshellz's Angular client).
+//
+// Two implementations ship in this package:
+//
+//   - MemoryStore — bounded per-channel ring, the self-host default.
+//     History is lost on restart; cap is 200 lines per channel,
+//     mirroring the prior in-memory rings the bouncer and gateway each
+//     held independently.
+//   - HTTPStore — durable mirror backed by an external HTTP service.
+//     Submits batch through the existing messagesink.Sink (write side);
+//     reads are a synchronous GET. Operators point
+//     TURBORG_MESSAGE_STORE_URL at any service that speaks the wire
+//     contract documented on HTTPStore.
+//
+// The Store interface is intentionally narrow — two methods. Adding
+// more (TARGETS for CHATHISTORY's channel listing, msgid lookups for
+// edit/delete, etc.) is a forward step we'll take once a real consumer
+// needs them.
+package messages
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// PerChannelCap is the default soft cap MemoryStore applies per
+// channel. Sized to match the historical 200-msg rings the bouncer and
+// gateway each maintained before the store seam landed. Bumping this
+// is a deliberate operator choice — bigger rings mean bigger
+// per-connector memory footprint on busy networks.
+const PerChannelCap = 200
+
+// Message is the in-process representation of a channel message —
+// what the store accepts on Submit and yields from Recent. Mirrors the
+// shape of messagesink.Entry on the wire, modulo time being a proper
+// time.Time so downstream code (decorateReplayLine, the WS frame
+// builder) doesn't reparse strings.
+//
+// ID is optional. MemoryStore tolerates an empty ID; HTTPStore
+// requires the receiving service to mint one if missing (matches the
+// existing recorder behavior).
+type Message struct {
+	ID      string
+	Channel string
+	Nick    string
+	Text    string
+	TS      time.Time
+}
+
+// Store is the read+write seam for channel history. Implementations
+// must be safe for concurrent use — both Submit and Recent fire from
+// multiple goroutines (every inbound IRC line; every WS history op;
+// every bouncer attach).
+//
+// Recent returns messages strictly OLDER than `before`, newest-first,
+// up to `limit` entries. Passing the zero time means "no upper bound,
+// return the most recent `limit` messages". An empty channel string is
+// treated as a no-op (no implementation looks up cross-channel
+// history).
+type Store interface {
+	Submit(ctx context.Context, m Message) error
+	Recent(ctx context.Context, channel string, before time.Time, limit int) ([]Message, error)
+}
+
+// MemoryStore is the goroutine-safe in-process Store implementation.
+// Per-channel rings keep at most cap entries; oldest entries fall off
+// when the cap is exceeded. cap == 0 means "use the package default".
+type MemoryStore struct {
+	cap int
+
+	mu       sync.RWMutex
+	channels map[string][]Message
+}
+
+// NewMemoryStore returns a fresh, empty MemoryStore. Pass cap = 0 to
+// get the package default (PerChannelCap).
+func NewMemoryStore(cap int) *MemoryStore {
+	if cap <= 0 {
+		cap = PerChannelCap
+	}
+	return &MemoryStore{
+		cap:      cap,
+		channels: map[string][]Message{},
+	}
+}
+
+// Submit appends m to the per-channel ring. The ring is bounded; once
+// it exceeds cap, the oldest entries are dropped. Context is honored
+// only for cancellation parity with HTTPStore — MemoryStore itself
+// never blocks long enough to need it.
+func (s *MemoryStore) Submit(_ context.Context, m Message) error {
+	if m.Channel == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	bucket := append(s.channels[m.Channel], m)
+	if len(bucket) > s.cap {
+		bucket = bucket[len(bucket)-s.cap:]
+	}
+	s.channels[m.Channel] = bucket
+	return nil
+}
+
+// Recent returns up to limit messages in the channel that are strictly
+// older than before. before == zero time means "no upper bound, last
+// limit messages". Returned slice is newest-first; nil when the
+// channel has no history.
+func (s *MemoryStore) Recent(_ context.Context, channel string, before time.Time, limit int) ([]Message, error) {
+	if channel == "" || limit <= 0 {
+		return nil, nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	bucket := s.channels[channel]
+	if len(bucket) == 0 {
+		return nil, nil
+	}
+	// Walk newest → oldest, filtering by `before` and accumulating up
+	// to `limit`. Returned slice stays newest-first so the WS history
+	// frame and the bouncer BATCH wrap the right order without an
+	// extra reverse at every call site.
+	out := make([]Message, 0, limit)
+	for i := len(bucket) - 1; i >= 0; i-- {
+		m := bucket[i]
+		if !before.IsZero() && !m.TS.Before(before) {
+			continue
+		}
+		out = append(out, m)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+// Len reports the count of messages currently stored for channel.
+// Useful for tests and for operators consuming the /metrics endpoint —
+// not part of the Store interface.
+func (s *MemoryStore) Len(channel string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.channels[channel])
+}

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -1,0 +1,311 @@
+package messages_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/messages"
+	"github.com/turborg/turborg/internal/messagesink"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func mkMsg(channel, nick, text string, ts time.Time) messages.Message {
+	return messages.Message{Channel: channel, Nick: nick, Text: text, TS: ts}
+}
+
+func TestMemoryStoreEmptyChannelNoop(t *testing.T) {
+	s := messages.NewMemoryStore(0)
+	require.NoError(t, s.Submit(context.Background(), mkMsg("", "a", "x", time.Now())))
+	got, err := s.Recent(context.Background(), "", time.Now(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestMemoryStoreSubmitAndRecent(t *testing.T) {
+	s := messages.NewMemoryStore(0)
+	ctx := context.Background()
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, s.Submit(ctx, mkMsg("#a", "alice", "hi", base)))
+	require.NoError(t, s.Submit(ctx, mkMsg("#a", "bob", "yo", base.Add(time.Second))))
+	require.NoError(t, s.Submit(ctx, mkMsg("#b", "cara", "elsewhere", base.Add(2*time.Second))))
+
+	t.Run("recent #a returns newest-first", func(t *testing.T) {
+		got, err := s.Recent(ctx, "#a", time.Time{}, 10)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, "yo", got[0].Text)
+		assert.Equal(t, "hi", got[1].Text)
+	})
+
+	t.Run("recent #b is isolated from #a", func(t *testing.T) {
+		got, err := s.Recent(ctx, "#b", time.Time{}, 10)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "elsewhere", got[0].Text)
+	})
+
+	t.Run("limit caps result", func(t *testing.T) {
+		got, err := s.Recent(ctx, "#a", time.Time{}, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "yo", got[0].Text)
+	})
+
+	t.Run("before filter excludes equal and newer", func(t *testing.T) {
+		// `before` is exclusive — passing the ts of the newer message
+		// must omit it and return only the older one.
+		got, err := s.Recent(ctx, "#a", base.Add(time.Second), 10)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "hi", got[0].Text)
+	})
+}
+
+func TestMemoryStoreRingCap(t *testing.T) {
+	s := messages.NewMemoryStore(3)
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		require.NoError(t, s.Submit(ctx, mkMsg("#c", "n", "m"+strconv.Itoa(i),
+			time.Date(2026, 5, 21, 12, 0, i, 0, time.UTC))))
+	}
+	assert.Equal(t, 3, s.Len("#c"))
+	got, err := s.Recent(ctx, "#c", time.Time{}, 100)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	// Oldest survivor is m7 (m0..m6 dropped); newest is m9.
+	assert.Equal(t, "m9", got[0].Text)
+	assert.Equal(t, "m7", got[2].Text)
+}
+
+func TestMemoryStoreZeroLimit(t *testing.T) {
+	s := messages.NewMemoryStore(0)
+	require.NoError(t, s.Submit(context.Background(), mkMsg("#a", "n", "m", time.Now())))
+	got, err := s.Recent(context.Background(), "#a", time.Time{}, 0)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestMemoryStoreConcurrentSubmit(t *testing.T) {
+	s := messages.NewMemoryStore(0)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = s.Submit(context.Background(), mkMsg("#c", "n", "m",
+				time.Now().Add(time.Duration(i)*time.Millisecond)))
+		}(i)
+	}
+	wg.Wait()
+	assert.Equal(t, 50, s.Len("#c"))
+}
+
+// --- HTTPStore -------------------------------------------------------------
+
+func TestHTTPStoreNilOnMissingConfig(t *testing.T) {
+	assert.Nil(t, messages.NewHTTPStore("", "tok", nil, nil))
+	assert.Nil(t, messages.NewHTTPStore("http://x", "", nil, nil))
+}
+
+func TestHTTPStoreSubmitNilReceiverNoop(t *testing.T) {
+	var hs *messages.HTTPStore
+	// Calling Submit on a nil receiver must not panic — keeps the
+	// caller's "did we configure HTTPStore?" check optional.
+	assert.NoError(t, hs.Submit(context.Background(), mkMsg("#a", "n", "t", time.Now())))
+}
+
+func TestHTTPStoreSubmitNilSinkNoop(t *testing.T) {
+	// HTTPStore with nil sink (a configuration the constructor
+	// rejects but defensible against external composition).
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	require.NotNil(t, hs)
+	assert.NoError(t, hs.Submit(context.Background(), mkMsg("#a", "n", "t", time.Now())))
+}
+
+func TestHTTPStoreRecentRejectsEmptyChannelAndZeroLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("server should not be hit for empty channel / zero limit")
+	}))
+	defer srv.Close()
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	got, err := hs.Recent(context.Background(), "", time.Time{}, 10)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	got, err = hs.Recent(context.Background(), "#a", time.Time{}, 0)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestHTTPStoreRecentNilReceiverNoop(t *testing.T) {
+	var hs *messages.HTTPStore
+	got, err := hs.Recent(context.Background(), "#a", time.Time{}, 10)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestHTTPStoreRecentMalformedJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"messages": "this is not an array"}`))
+	}))
+	defer srv.Close()
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	got, err := hs.Recent(context.Background(), "#a", time.Time{}, 10)
+	// Decode error is downgraded to empty result, not surfaced.
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestMemoryStoreLenWithUnknownChannel(t *testing.T) {
+	s := messages.NewMemoryStore(0)
+	assert.Equal(t, 0, s.Len("#never-existed"))
+}
+
+func TestHTTPStoreRecentRoundtrip(t *testing.T) {
+	// Fake receiver: serves a small history payload, recording the
+	// query params it received so we can pin the wire contract.
+	var gotPath, gotQuery, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages": []map[string]any{
+				{"msg_id": "01H1", "channel": "#a", "nick": "alice", "text": "hi", "ts": "2026-05-21T12:00:00.000000Z"},
+				{"msg_id": "01H2", "channel": "#a", "nick": "bob", "text": "yo", "ts": "2026-05-21T12:00:01.000000Z"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	require.NotNil(t, hs)
+
+	before := time.Date(2026, 5, 21, 12, 0, 5, 0, time.UTC)
+	got, err := hs.Recent(context.Background(), "#a", before, 50)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "/", gotPath)
+	assert.Equal(t, "Bearer tok", gotAuth)
+	q, _ := url.ParseQuery(gotQuery)
+	assert.Equal(t, "#a", q.Get("channel"))
+	assert.Equal(t, "50", q.Get("limit"))
+	assert.Equal(t, "2026-05-21T12:00:05.000000Z", q.Get("before"))
+
+	assert.Equal(t, "alice", got[0].Nick)
+	assert.Equal(t, "01H1", got[0].ID)
+	assert.True(t, got[0].TS.Equal(time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)))
+}
+
+func TestHTTPStoreRecentBeforeOmittedWhenZero(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"messages": []}`))
+	}))
+	defer srv.Close()
+
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	_, err := hs.Recent(context.Background(), "#a", time.Time{}, 10)
+	require.NoError(t, err)
+	q, _ := url.ParseQuery(gotQuery)
+	assert.Empty(t, q.Get("before"), "before must be omitted when zero")
+}
+
+func TestHTTPStoreRecentNetworkErrorReturnsEmpty(t *testing.T) {
+	// Endpoint that immediately closes — emulates a dead receiver.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	got, err := hs.Recent(context.Background(), "#a", time.Time{}, 10)
+	// Best-effort: no hard error returned, just an empty slice.
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestHTTPStoreRecentBadStatusReturnsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	got, err := hs.Recent(context.Background(), "#a", time.Time{}, 10)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestHTTPStoreRecentBadTimestampSkipsEntry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"messages": [
+			{"msg_id":"a","channel":"#a","nick":"a","text":"good","ts":"2026-05-21T12:00:00.000000Z"},
+			{"msg_id":"b","channel":"#a","nick":"b","text":"bad","ts":"NOT-A-TIMESTAMP"}
+		]}`))
+	}))
+	defer srv.Close()
+
+	hs := messages.NewHTTPStore(srv.URL, "tok", nil, nil)
+	got, err := hs.Recent(context.Background(), "#a", time.Time{}, 10)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "malformed entry must be dropped, not whole reply")
+	assert.Equal(t, "good", got[0].Text)
+}
+
+func TestHTTPStoreSubmitDelegatesToSink(t *testing.T) {
+	// Capture POSTed payload so we know HTTPStore.Submit really
+	// pushed through messagesink.Sink. The sink does batching, so we
+	// wait briefly after Submit for the flush.
+	var (
+		mu       sync.Mutex
+		captured []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		mu.Lock()
+		captured = buf[:n]
+		mu.Unlock()
+	}))
+	defer srv.Close()
+
+	sink := messagesink.New(srv.URL, "tok", nil)
+	require.NotNil(t, sink)
+
+	hs := messages.NewHTTPStore(srv.URL, "tok", sink, nil)
+	require.NoError(t, hs.Submit(context.Background(), mkMsg("#a", "alice", "hi",
+		time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))))
+
+	// Sink batches with a 1s ticker; Close drains synchronously so we
+	// don't sleep here. Single Close per Sink — the channel-close inside
+	// would panic on a second call.
+	sink.Close(context.Background())
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, string(captured), `"channel":"#a"`)
+	assert.Contains(t, string(captured), `"nick":"alice"`)
+	assert.Contains(t, string(captured), `"text":"hi"`)
+}

--- a/internal/runtime/messages_test.go
+++ b/internal/runtime/messages_test.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/config"
+	"github.com/turborg/turborg/internal/messages"
+)
+
+// White-box tests for the helpers in runtime.go. The full Build flow
+// is exercised in runtime_test.go; these tighten the unit-level
+// coverage on the small pure helpers.
+
+func TestClampReplayDepthBounds(t *testing.T) {
+	assert.Equal(t, 200, clampReplayDepth(0), "zero falls back to default")
+	assert.Equal(t, 200, clampReplayDepth(-1), "negative falls back to default")
+	assert.Equal(t, 1, clampReplayDepth(1))
+	assert.Equal(t, 1000, clampReplayDepth(1000))
+	assert.Equal(t, 2000, clampReplayDepth(2000))
+	assert.Equal(t, 2000, clampReplayDepth(5000), "over-max clamps to ceiling")
+}
+
+func TestIsChannelTarget(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"#chan", true}, {"&local", true}, {"+modeless", true}, {"!safe", true},
+		{"alice", false}, {"", false}, {"~bad", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, isChannelTarget(tc.in), "input=%q", tc.in)
+	}
+}
+
+func TestBuildMessageStoreMemoryDefault(t *testing.T) {
+	s := &config.Settings{} // No sink, no store URLs configured.
+	store, sink := buildMessageStore(s, nil)
+	require.NotNil(t, store)
+	assert.Nil(t, sink, "no sink URL → nil *Sink")
+	_, isMem := store.(*messages.MemoryStore)
+	assert.True(t, isMem, "default store must be MemoryStore")
+}
+
+func TestBuildMessageStoreHTTPWhenConfigured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+	s := &config.Settings{
+		MessageSinkURL:    srv.URL,
+		MessageSinkToken:  "t",
+		MessageStoreURL:   srv.URL,
+		MessageStoreToken: "t",
+	}
+	store, sink := buildMessageStore(s, nil)
+	require.NotNil(t, store)
+	require.NotNil(t, sink)
+	defer sink.Close(context.Background())
+	_, isHTTP := store.(*messages.HTTPStore)
+	assert.True(t, isHTTP, "with both URLs set → HTTPStore")
+}
+
+func TestMakeStoreSubmitterSkipsNonChannelTargets(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, nil)
+	sub(context.Background(), &agent.Event{
+		Type: agent.EventMessage,
+		Fields: map[string]any{
+			"channel": "alice", "sender": "bob", "text": "psst",
+		},
+	})
+	assert.Equal(t, 0, store.Len("alice"), "DM target must not be stored")
+}
+
+func TestMakeStoreSubmitterSubmitsChannelMessages(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, nil)
+	sub(context.Background(), &agent.Event{
+		Type: agent.EventMessage,
+		Fields: map[string]any{
+			"channel": "#x", "sender": "alice", "text": "hi",
+		},
+	})
+	assert.Equal(t, 1, store.Len("#x"))
+}
+
+func TestMakeStoreSubmitterUnpacksInboundEnvelope(t *testing.T) {
+	// Some publishers carry the data on `envelope` instead of the
+	// flat fields — the submitter must read both shapes.
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, nil)
+	sub(context.Background(), &agent.Event{
+		Type: agent.EventMessage,
+		Fields: map[string]any{
+			"envelope": &agent.InboundEnvelope{
+				Channel: "#x", Sender: "alice", Text: "hi",
+			},
+		},
+	})
+	assert.Equal(t, 1, store.Len("#x"))
+}
+
+func TestMakeStoreSubmitterUnpacksOutboundEnvelope(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, nil)
+	sub(context.Background(), &agent.Event{
+		Type: agent.EventMessageSent,
+		Fields: map[string]any{
+			"sender":   "bot",
+			"envelope": &agent.OutboundEnvelope{Channel: "#x", Text: "reply"},
+		},
+	})
+	assert.Equal(t, 1, store.Len("#x"))
+}
+
+func TestMakeStoreSubmitterEmptyChannelNoop(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, nil)
+	sub(context.Background(), &agent.Event{
+		Type:   agent.EventMessage,
+		Fields: map[string]any{"sender": "alice", "text": "no channel"},
+	})
+	// MemoryStore tracks per-channel; absent channel == nothing recorded.
+	assert.Equal(t, 0, store.Len(""))
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -26,6 +26,7 @@ import (
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/llm/anthropic"
+	"github.com/turborg/turborg/internal/messages"
 	"github.com/turborg/turborg/internal/messagesink"
 	"github.com/turborg/turborg/internal/statepush"
 	"github.com/turborg/turborg/internal/version"
@@ -43,12 +44,12 @@ const AskSystemPrompt = "You are turborg, an IRC chatbot. Keep replies short and
 // connectors are added; built-in commands are registered; the owner +
 // throttle guard is installed.
 type Built struct {
-	Agent        *agent.Agent
-	IRC          *irc.Connector
-	Gateway      *web.Gateway
-	LLM          llm.Provider        // nil when Anthropic is not configured
-	Activity     *activity.Notifier  // never nil; no-op when ACTIVITY_URL is unset
-	StatePush    *statepush.Emitter  // never nil; inert no-op when STATE_WEBHOOK_URL is unset
+	Agent     *agent.Agent
+	IRC       *irc.Connector
+	Gateway   *web.Gateway
+	LLM       llm.Provider       // nil when Anthropic is not configured
+	Activity  *activity.Notifier // never nil; no-op when ACTIVITY_URL is unset
+	StatePush *statepush.Emitter // never nil; inert no-op when STATE_WEBHOOK_URL is unset
 }
 
 // Build wires the agent + connectors + gateway from settings. Callers
@@ -126,7 +127,24 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	)
 	wireStatePushEmitter(ircConn, stateEmitter)
 
+	// Build the shared messages.Store before connectors register
+	// for events, so the IRC connector's bouncer + the gateway both
+	// see the same store. The store also picks up Submit calls from
+	// the EventBus subscriber wired further down.
+	store, sink := buildMessageStore(s, log)
+	ircConn.SetMessageStore(store)
+	ircConn.SetBouncerWelcomeReplayDepth(clampReplayDepth(ircCfg.BouncerWelcomeReplayDepth))
+
 	a.AddConnector(ircConn)
+
+	// Single EventBus subscriber feeds the store for every channel
+	// message the agent observes. Filters at submit-time: only
+	// channel-sigil targets count (DMs don't enter replay history).
+	if store != nil {
+		a.Events.Subscribe(agent.EventMessage, makeStoreSubmitter(store, log))
+		a.Events.Subscribe(agent.EventMessageSent, makeStoreSubmitter(store, log))
+	}
+	_ = sink // referenced for lifecycle parity; closing happens with the agent
 
 	if len(s.Connectors) > 1 {
 		for _, name := range s.Connectors {
@@ -151,7 +169,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	}
 
 	if s.GatewayEnabled() {
-		gw, err := buildGateway(s, ircConn, a, log, notifier)
+		gw, err := buildGateway(s, ircConn, a, log, notifier, store)
 		if err != nil {
 			return nil, err
 		}
@@ -200,7 +218,7 @@ func buildLLM(s *config.Settings) (llm.Provider, error) {
 	return p, nil
 }
 
-func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger, notifier *activity.Notifier) (*web.Gateway, error) {
+func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger, notifier *activity.Notifier, store messages.Store) (*web.Gateway, error) {
 	verifier, err := web.NewStaticPasswordVerifier(s.GatewayPassword)
 	if err != nil {
 		return nil, fmt.Errorf("runtime: gateway verifier: %w", err)
@@ -215,11 +233,12 @@ func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, lo
 		return nil, fmt.Errorf("runtime: gateway ratelimit: %w", err)
 	}
 	opts := web.Options{
-		Host:        s.GatewayHost,
-		Port:        s.GatewayPort,
-		Verifier:    verifier,
-		RateLimiter: rl,
-		Log:         log,
+		Host:         s.GatewayHost,
+		Port:         s.GatewayPort,
+		Verifier:     verifier,
+		RateLimiter:  rl,
+		Log:          log,
+		MessageStore: store,
 	}
 	if notifier.Enabled() {
 		opts.OnClientAttached = notifier.Hook
@@ -231,20 +250,109 @@ func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, lo
 		// CLI's ctx. Leaving OnIdleShutdown nil here means the gateway
 		// logs and no-ops; the CLI installs the real callback after Build.
 	}
-	// Durable message mirror. Empty MESSAGE_SINK_URL = self-host: nil
-	// sink, nil recorder, web.Options.MessageRecorder stays unset.
-	// Guard the assignment behind a non-nil check so we don't end up
-	// with a typed-nil interface value (Go gotcha — the `if recorder
-	// != nil` guard inside the gateway only catches an untyped nil).
-	if sink := messagesink.New(s.MessageSinkURL, s.MessageSinkToken, log); sink != nil {
-		opts.MessageRecorder = messagesink.NewRecorder(sink)
-		log.Info("message sink enabled", "endpoint", s.MessageSinkURL)
-	}
 	gw, err := web.New(ircConn, ircConn, opts)
 	if err != nil {
 		return nil, err
 	}
 	return gw, nil
+}
+
+// buildMessageStore picks the right Store implementation from
+// settings. Returns the chosen Store plus the underlying sink (if
+// any) so the caller can own its lifecycle.
+//
+//   - MESSAGE_STORE_URL + MESSAGE_SINK_URL both set → HTTPStore
+//     (durable read + write through accounts-api).
+//   - MESSAGE_SINK_URL set, MESSAGE_STORE_URL unset → MemoryStore for
+//     reads but writes still mirror through the sink (legacy half).
+//   - Neither set → MemoryStore only (self-host default).
+func buildMessageStore(s *config.Settings, log *slog.Logger) (messages.Store, *messagesink.Sink) {
+	if log == nil {
+		log = slog.Default()
+	}
+	sink := messagesink.New(s.MessageSinkURL, s.MessageSinkToken, log)
+	if sink != nil {
+		log.Info("message sink enabled", "endpoint", s.MessageSinkURL)
+	}
+	if hs := messages.NewHTTPStore(s.MessageStoreURL, s.MessageStoreToken, sink, log); hs != nil {
+		log.Info("message store enabled (HTTP)", "endpoint", s.MessageStoreURL)
+		return hs, sink
+	}
+	// Fall back to in-process. When a sink IS configured but no store
+	// URL, the MemoryStore still serves attach replay + scrollback
+	// locally; the sink keeps mirroring writes for whatever consumer
+	// runs on the other side.
+	return messages.NewMemoryStore(0), sink
+}
+
+// makeStoreSubmitter returns an EventBus handler that mirrors every
+// channel-targeted EventMessage / EventMessageSent into the shared
+// store. DMs are filtered out at this seam (channel must start with
+// a channel sigil) so replay history stays channel-only.
+func makeStoreSubmitter(store messages.Store, log *slog.Logger) func(ctx context.Context, ev *agent.Event) {
+	return func(ctx context.Context, ev *agent.Event) {
+		channel, _ := ev.Fields["channel"].(string)
+		nick, _ := ev.Fields["sender"].(string)
+		text, _ := ev.Fields["text"].(string)
+		// MESSAGE_SENT from agent command-dispatch carries the
+		// envelope, not the explicit fields — peek for both shapes.
+		if env, ok := ev.Fields["envelope"].(*agent.OutboundEnvelope); ok && env != nil {
+			if channel == "" {
+				channel = env.Channel
+			}
+			if text == "" {
+				text = env.Text
+			}
+		}
+		if env, ok := ev.Fields["envelope"].(*agent.InboundEnvelope); ok && env != nil {
+			if channel == "" {
+				channel = env.Channel
+			}
+			if nick == "" {
+				nick = env.Sender
+			}
+			if text == "" {
+				text = env.Text
+			}
+		}
+		if channel == "" || !isChannelTarget(channel) {
+			return
+		}
+		if err := store.Submit(ctx, messages.Message{
+			Channel: channel,
+			Nick:    nick,
+			Text:    text,
+			TS:      time.Now(),
+		}); err != nil {
+			log.Debug("store submit", "err", err, "channel", channel)
+		}
+	}
+}
+
+// clampReplayDepth keeps the operator's TURBORG_IRC_BOUNCER_WELCOME_
+// REPLAY_DEPTH inside a sane window. 1..2000 are accepted; out-of-band
+// values fall back to the package default rather than rejecting boot.
+func clampReplayDepth(n int) int {
+	const def = 200
+	const max = 2000
+	if n < 1 {
+		return def
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
+func isChannelTarget(s string) bool {
+	if s == "" {
+		return false
+	}
+	switch s[0] {
+	case '#', '&', '+', '!':
+		return true
+	}
+	return false
 }
 
 // RegisterBuiltinCommands installs ping, version, help, and (when an

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/messages"
 )
 
 // Ring-buffer caps for replay on new client attach. Bumping these is a
@@ -79,25 +80,13 @@ type Options struct {
 	// using this agent — distinct from "bot is alive" log signal.
 	OnClientAttached func(reason string)
 
-	// MessageRecorder receives every recorded channel message so it
-	// can mirror it to a durable backend. SaaS deployments wire a
-	// messagesink-backed recorder that batches into a sidecar HTTP
-	// call; self-host leaves this nil and history stops at the
-	// in-memory ring (which is still served on (re)connect via
-	// replayBuffers).
-	MessageRecorder MessageRecorder
-}
-
-// MessageRecorder is the narrow seam between the gateway and a
-// durable message store. One method: the gateway hands off (channel,
-// nick, text, ts); the recorder owns msg_id generation, timestamp
-// formatting, transport, batching, and retries.
-//
-// Nil interface value = no-op (no durable mirror). To avoid the
-// typed-nil-interface gotcha, runtime constructs the recorder behind
-// a non-nil guard before assigning to Options.
-type MessageRecorder interface {
-	Submit(channel, nick, text string, ts time.Time)
+	// MessageStore is the read/write seam for channel history. The
+	// gateway calls Submit on every observed inbound + outbound
+	// channel message (so DB-backed deployments mirror durably) and
+	// Recent on attach + on the `history` WS op for scrollback. nil
+	// means "no history available" — clients still see live traffic,
+	// but replay and scrollback frames are empty.
+	MessageStore messages.Store
 }
 
 // Gateway is an HTTP server exposing /ws (WebSocket), /health, /metrics,
@@ -123,20 +112,21 @@ type Gateway struct {
 	// gateway doesn't leak handlers across lifecycle restarts.
 	stateSub *irc.Subscription
 
-	// Per-channel + server-log ring buffers replayed on (re)connect so
-	// a UI that closed mid-traffic sees what flowed in while it was
-	// offline.
-	logMu      sync.Mutex
-	serverLog  []map[string]any
-	channelLog map[string][]map[string]any
+	// Server-log ring of recent state-level notices (connection
+	// transitions, etc). Channel-message history lives in
+	// opts.MessageStore instead — the gateway no longer maintains a
+	// parallel channelLog ring, so the bouncer + WS gateway share one
+	// canonical history view.
+	logMu     sync.Mutex
+	serverLog []map[string]any
 
 	idleMu   sync.Mutex
 	idleStop chan struct{} // closed by cancelIdleTimer
 
 	metMu   sync.Mutex
 	metrics struct {
-		connections      uint64
-		authFailures     uint64
+		connections       uint64
+		authFailures      uint64
 		messagesForwarded uint64
 	}
 }
@@ -167,13 +157,12 @@ func New(bridge IRCBridge, sender Sender, opts Options) (*Gateway, error) {
 	// the runtime composer always passes an explicit port from
 	// TURBORG_GATEWAY_PORT (default 8765 in config.Settings).
 	g := &Gateway{
-		opts:       opts,
-		bridge:     bridge,
-		sender:     sender,
-		log:        opts.Log,
-		clients:    map[*client]struct{}{},
-		channelLog: map[string][]map[string]any{},
-		started:    time.Now(),
+		opts:    opts,
+		bridge:  bridge,
+		sender:  sender,
+		log:     opts.Log,
+		clients: map[*client]struct{}{},
+		started: time.Now(),
 	}
 	return g, nil
 }
@@ -456,25 +445,44 @@ func (g *Gateway) sendState(ctx context.Context, c *client) {
 }
 
 func (g *Gateway) replayBuffers(ctx context.Context, c *client) {
+	// Server log: a small ring of state-level notices the gateway
+	// itself produced (connection transitions, etc) — kept in-process
+	// because they're per-instance, not per-message.
 	g.logMu.Lock()
 	serverSnap := append([]map[string]any{}, g.serverLog...)
-	channelSnap := make([]map[string]any, 0)
-	for _, log := range g.channelLog {
-		channelSnap = append(channelSnap, log...)
-	}
 	g.logMu.Unlock()
-
 	for _, entry := range serverSnap {
 		dup := mapCopy(entry)
 		dup["replayed"] = true
 		g.sendTo(ctx, c, dup)
 	}
-	// Order channel replay by ts so the UI can dedupe by ts in IndexedDB.
-	sortByTS(channelSnap)
-	for _, entry := range channelSnap {
-		dup := mapCopy(entry)
-		dup["replayed"] = true
-		g.sendTo(ctx, c, dup)
+
+	// Channel-message history comes from the shared store. Per joined
+	// channel, fetch the last channelLogCap (default 200) entries and
+	// stream them oldest-first as `replayed: true` frames. The store
+	// returns newest-first; the loop walks in reverse so the UI sees
+	// chronological order.
+	store := g.opts.MessageStore
+	if store == nil {
+		return
+	}
+	for _, info := range g.bridge.State().JoinedChannels() {
+		msgs, err := store.Recent(ctx, info.Name, time.Time{}, channelLogCap)
+		if err != nil {
+			g.log.Debug("history fetch on attach", "channel", info.Name, "err", err)
+			continue
+		}
+		for i := len(msgs) - 1; i >= 0; i-- {
+			m := msgs[i]
+			g.sendTo(ctx, c, map[string]any{
+				"op":       "message",
+				"channel":  m.Channel,
+				"nick":     m.Nick,
+				"text":     m.Text,
+				"ts":       m.TS.Unix(),
+				"replayed": true,
+			})
+		}
 	}
 }
 
@@ -714,7 +722,82 @@ func (g *Gateway) dispatchInbound(ctx context.Context, c *client, p map[string]a
 		}
 		line = strings.TrimPrefix(line, "/")
 		_ = g.bridge.SendRaw(line)
+	case "history":
+		g.handleHistoryOp(ctx, c, p)
 	}
+}
+
+// handleHistoryOp answers a `{op: "history", channel, before, limit}`
+// scrollback request from a WS client. The infinite-scroll UI in the
+// reference + appui front-ends fires this when the user nears the top
+// of the channel pane. Wire shape:
+//
+//   inbound:  {op:"history", channel:"#x", before:"2026-05-21T12:00:00.000Z", limit:200}
+//   outbound: {op:"history_result", channel, messages:[{nick,text,ts,id}], has_more:bool}
+//
+// `before` and `limit` are both optional: empty `before` returns the
+// most recent `limit` messages (equivalent to the initial attach
+// replay's depth, but on demand). `limit` defaults to 200, capped to
+// 200 — the SAME cap the bouncer's CHATHISTORY enforces, so the two
+// surfaces agree on a single page size.
+func (g *Gateway) handleHistoryOp(ctx context.Context, c *client, p map[string]any) {
+	channel, _ := p["channel"].(string)
+	if channel == "" || !startsWithChannelSigil(channel) {
+		return
+	}
+	limit := 200
+	// JSON numbers unmarshal as float64 — no int branch needed.
+	if v, ok := p["limit"].(float64); ok && int(v) > 0 {
+		limit = int(v)
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	var before time.Time
+	if raw, ok := p["before"].(string); ok && raw != "" {
+		if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+			before = t
+		} else if t, err := time.Parse("2006-01-02T15:04:05.000Z", raw); err == nil {
+			before = t
+		}
+	}
+
+	store := g.opts.MessageStore
+	if store == nil {
+		g.sendTo(ctx, c, map[string]any{
+			"op": "history_result", "channel": channel,
+			"messages": []map[string]any{}, "has_more": false,
+		})
+		return
+	}
+	msgs, err := store.Recent(ctx, channel, before, limit)
+	if err != nil {
+		g.log.Debug("history op", "err", err, "channel", channel)
+		g.sendTo(ctx, c, map[string]any{
+			"op": "history_result", "channel": channel,
+			"messages": []map[string]any{}, "has_more": false,
+		})
+		return
+	}
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, map[string]any{
+			"nick": m.Nick,
+			"text": m.Text,
+			"ts":   m.TS.Unix(),
+			"id":   m.ID,
+		})
+	}
+	// has_more is "the result hit the limit". Strictly speaking that
+	// can over-report (the next page might be empty), but the UI's
+	// next scroll-up will fire one more call and see the empty page,
+	// so worst case is a single redundant request.
+	g.sendTo(ctx, c, map[string]any{
+		"op":       "history_result",
+		"channel":  channel,
+		"messages": out,
+		"has_more": len(msgs) == limit,
+	})
 }
 
 // --- EventBus handlers ----------------------------------------------------
@@ -727,22 +810,17 @@ func (g *Gateway) onMessage(_ context.Context, ev *agent.Event) {
 	if env != nil {
 		channel, sender, text = env.Channel, env.Sender, env.Text
 	}
-	// Snapshot ts once so the wire payload (seconds for back-compat
-	// with the existing replay format) and the durable recorder
-	// (microsecond ISO for accounts-api) agree on the moment.
+	// Snapshot ts once so the wire payload (Unix seconds) and the
+	// durable store entry agree on the moment.
 	now := time.Now()
-	payload := map[string]any{
+	g.submitToStore(channel, sender, text, now)
+	g.broadcast(map[string]any{
 		"op":      "message",
 		"channel": channel,
 		"nick":    sender,
 		"text":    text,
 		"ts":      now.Unix(),
-	}
-	g.recordChannel(payload)
-	g.broadcast(payload)
-	if g.opts.MessageRecorder != nil {
-		g.opts.MessageRecorder.Submit(channel, sender, text, now)
-	}
+	})
 }
 
 func (g *Gateway) onMessageSent(_ context.Context, ev *agent.Event) {
@@ -769,18 +847,44 @@ func (g *Gateway) onMessageSent(_ context.Context, ev *agent.Event) {
 		sender = g.bridge.CurrentNick()
 	}
 	now := time.Now()
-	payload := map[string]any{
+	g.submitToStore(channel, sender, text, now)
+	g.broadcast(map[string]any{
 		"op":      "message",
 		"channel": channel,
 		"nick":    sender,
 		"text":    text,
 		"ts":      now.Unix(),
+	})
+}
+
+// submitToStore pushes a channel message into the configured store.
+// Filters at the gateway boundary: only channel-sigil targets are
+// stored (DMs aren't part of replay history). Errors are downgraded
+// to debug — failure to mirror must not break live broadcast.
+func (g *Gateway) submitToStore(channel, sender, text string, ts time.Time) {
+	if g.opts.MessageStore == nil || !startsWithChannelSigil(channel) {
+		return
 	}
-	g.recordChannel(payload)
-	g.broadcast(payload)
-	if g.opts.MessageRecorder != nil {
-		g.opts.MessageRecorder.Submit(channel, sender, text, now)
+	err := g.opts.MessageStore.Submit(context.Background(), messages.Message{
+		Channel: channel,
+		Nick:    sender,
+		Text:    text,
+		TS:      ts,
+	})
+	if err != nil {
+		g.log.Debug("message store submit", "err", err, "channel", channel)
 	}
+}
+
+func startsWithChannelSigil(s string) bool {
+	if s == "" {
+		return false
+	}
+	switch s[0] {
+	case '#', '&', '+', '!':
+		return true
+	}
+	return false
 }
 
 func (g *Gateway) onUserJoin(_ context.Context, ev *agent.Event) {
@@ -928,23 +1032,6 @@ func (g *Gateway) rejectSend(ctx context.Context, c *client, target, body, reaso
 	})
 }
 
-// --- replay buffer mgmt ---------------------------------------------------
-
-func (g *Gateway) recordChannel(payload map[string]any) {
-	channel, _ := payload["channel"].(string)
-	if channel == "" {
-		return
-	}
-	g.logMu.Lock()
-	defer g.logMu.Unlock()
-	bucket := g.channelLog[channel]
-	bucket = append(bucket, payload)
-	if len(bucket) > channelLogCap {
-		bucket = bucket[len(bucket)-channelLogCap:]
-	}
-	g.channelLog[channel] = bucket
-}
-
 // --- broadcast + send -----------------------------------------------------
 
 func (g *Gateway) broadcast(payload map[string]any) {
@@ -1061,25 +1148,4 @@ func mapCopy(in map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
-}
-
-func sortByTS(items []map[string]any) {
-	for i := 1; i < len(items); i++ {
-		for j := i; j > 0; j-- {
-			a, _ := items[j-1]["ts"].(int64)
-			b, _ := items[j]["ts"].(int64)
-			if a == 0 {
-				ai, _ := items[j-1]["ts"].(int)
-				a = int64(ai)
-			}
-			if b == 0 {
-				bi, _ := items[j]["ts"].(int)
-				b = int64(bi)
-			}
-			if a <= b {
-				break
-			}
-			items[j-1], items[j] = items[j], items[j-1]
-		}
-	}
 }

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -15,8 +15,11 @@ import (
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"errors"
+
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/messages"
 	"github.com/turborg/turborg/internal/web"
 )
 
@@ -42,10 +45,10 @@ func newFakeBridge(nick string) *fakeBridge {
 	m.Transition(irc.UpstreamStateRegistered)
 	return &fakeBridge{nick: nick, state: irc.NewChannelState(), machine: m}
 }
-func (f *fakeBridge) CurrentNick() string                 { return f.nick }
-func (f *fakeBridge) State() *irc.ChannelState            { return f.state }
-func (f *fakeBridge) ClientLimits() irc.ClientLimits      { return f.limits }
-func (f *fakeBridge) OutboundThrottle() *irc.Throttle     { return f.throttle }
+func (f *fakeBridge) CurrentNick() string                      { return f.nick }
+func (f *fakeBridge) State() *irc.ChannelState                 { return f.state }
+func (f *fakeBridge) ClientLimits() irc.ClientLimits           { return f.limits }
+func (f *fakeBridge) OutboundThrottle() *irc.Throttle          { return f.throttle }
 func (f *fakeBridge) UpstreamState() *irc.UpstreamStateMachine { return f.machine }
 func (f *fakeBridge) SendRaw(line string) error {
 	f.sentMu.Lock()
@@ -146,7 +149,16 @@ func drainInitialFrames(t *testing.T, conn *websocket.Conn) {
 func newOptions(t *testing.T, password string) web.Options {
 	v, err := web.NewStaticPasswordVerifier(password)
 	require.NoError(t, err)
-	return web.Options{Host: "127.0.0.1", Port: 0, Verifier: v}
+	// Every test gets a fresh in-memory store so attach replay +
+	// history scrollback have something to read from. Tests that
+	// need to seed/inspect the store can read MessageStore back via
+	// type assertion on *messages.MemoryStore.
+	return web.Options{
+		Host:         "127.0.0.1",
+		Port:         0,
+		Verifier:     v,
+		MessageStore: messages.NewMemoryStore(0),
+	}
 }
 
 // --- construction ----------------------------------------------------------
@@ -812,14 +824,18 @@ func TestRateLimiterResetsOnSuccessfulAuth(t *testing.T) {
 
 func TestChannelMessagesReplayedInTSOrder(t *testing.T) {
 	bridge := newFakeBridge("turborg")
+	// replayBuffers iterates over JoinedChannels — seed the bridge
+	// state so #x is in the list, otherwise the channel-history
+	// replay loop never visits it.
+	bridge.state.OnSelfJoin("#x")
 	g, a, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})
 	defer td()
 
 	// Publish three EventMessage events before any client connects;
-	// they land in the per-channel ring buffer. Wait until the bus
-	// has actually recorded all three before connecting — without
-	// this, the WS client could connect mid-publish and miss the
-	// later messages from the replay.
+	// they land in the gateway's MessageStore (via gateway.onMessage
+	// → submitToStore). When the WS client attaches, replayBuffers
+	// pulls the last N for every joined channel and emits them as
+	// `replayed: true` frames.
 	for _, text := range []string{"first", "second", "third"} {
 		a.Events.Publish(context.Background(), &agent.Event{
 			Type: agent.EventMessage,
@@ -852,6 +868,225 @@ func TestChannelMessagesReplayedInTSOrder(t *testing.T) {
 	}
 	assert.Equal(t, []string{"first", "second", "third"}, got,
 		"channel replay must come back in original publish order")
+}
+
+// --- history op (scrollback) ----------------------------------------
+
+func TestHistoryOpReturnsOlderMessagesFromStore(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	bridge.state.OnSelfJoin("#x")
+	opts := newOptions(t, "p")
+	store := opts.MessageStore.(*messages.MemoryStore)
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+
+	// Seed 5 messages; ask for the 3 older than the most recent.
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	for i, text := range []string{"m1", "m2", "m3", "m4", "m5"} {
+		require.NoError(t, store.Submit(context.Background(), messages.Message{
+			Channel: "#x", Nick: "alice", Text: text,
+			TS: base.Add(time.Duration(i) * time.Second),
+		}))
+	}
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+	// Drain the initial replay frames (5 of them) before the history op.
+	for i := 0; i < 5; i++ {
+		_ = readJSON(t, conn)
+	}
+
+	// Ask for everything strictly before m5's ts.
+	req := map[string]any{
+		"op":      "history",
+		"channel": "#x",
+		"before":  base.Add(4 * time.Second).Format(time.RFC3339Nano),
+		"limit":   10,
+	}
+	body, _ := json.Marshal(req)
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	got := readJSON(t, conn)
+	assert.Equal(t, "history_result", got["op"])
+	assert.Equal(t, "#x", got["channel"])
+	msgs, ok := got["messages"].([]any)
+	require.True(t, ok, "messages must be an array, got %T", got["messages"])
+	require.Len(t, msgs, 4, "expected m1..m4 older than m5")
+	first := msgs[0].(map[string]any)
+	// Newest-first within the response.
+	assert.Equal(t, "m4", first["text"])
+	assert.Equal(t, false, got["has_more"], "5 < limit=10, no more pages")
+}
+
+func TestHistoryOpRespectsLimitAndReportsHasMore(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	bridge.state.OnSelfJoin("#x")
+	opts := newOptions(t, "p")
+	store := opts.MessageStore.(*messages.MemoryStore)
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+
+	for i := 0; i < 5; i++ {
+		require.NoError(t, store.Submit(context.Background(), messages.Message{
+			Channel: "#x", Nick: "alice", Text: "m",
+			TS: time.Now().Add(-time.Duration(5-i) * time.Second),
+		}))
+	}
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+	for i := 0; i < 5; i++ {
+		_ = readJSON(t, conn)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"op": "history", "channel": "#x", "limit": 2,
+	})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+	got := readJSON(t, conn)
+	msgs, _ := got["messages"].([]any)
+	assert.Len(t, msgs, 2)
+	assert.Equal(t, true, got["has_more"], "len == limit signals more available")
+}
+
+func TestHistoryOpWithNilStoreReturnsEmpty(t *testing.T) {
+	// Gateway without a MessageStore: history op must still answer
+	// with a valid history_result frame (empty messages, has_more
+	// false) so the UI's "loading older messages" spinner clears.
+	v, err := web.NewStaticPasswordVerifier("p")
+	require.NoError(t, err)
+	bridge := newFakeBridge("turborg")
+	g, _, td := startGateway(t, web.Options{
+		Host: "127.0.0.1", Port: 0, Verifier: v,
+		// MessageStore intentionally nil.
+	}, bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+
+	body, _ := json.Marshal(map[string]any{
+		"op": "history", "channel": "#x", "limit": 10,
+	})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+	got := readJSON(t, conn)
+	assert.Equal(t, "history_result", got["op"])
+	msgs, _ := got["messages"].([]any)
+	assert.Empty(t, msgs)
+	assert.Equal(t, false, got["has_more"])
+}
+
+func TestHistoryOpAcceptsTimestampWithMillisFormat(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	bridge.state.OnSelfJoin("#x")
+	opts := newOptions(t, "p")
+	store := opts.MessageStore.(*messages.MemoryStore)
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, store.Submit(context.Background(), messages.Message{
+		Channel: "#x", Nick: "a", Text: "older", TS: base,
+	}))
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+	_ = readJSON(t, conn) // initial replay
+
+	// `before` in the .000Z variant — the gateway's parser falls
+	// through to that format when RFC3339Nano doesn't match.
+	body, _ := json.Marshal(map[string]any{
+		"op": "history", "channel": "#x",
+		"before": "2026-05-21T12:00:10.000Z",
+		"limit":  10,
+	})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+	got := readJSON(t, conn)
+	msgs, _ := got["messages"].([]any)
+	require.Len(t, msgs, 1)
+}
+
+// failingStore satisfies messages.Store with a Recent that errors.
+// Used to exercise the gateway's error-degraded response on the
+// history op (which must still emit a valid history_result frame so
+// the UI's loading state clears).
+type failingStore struct{}
+
+func (failingStore) Submit(context.Context, messages.Message) error { return nil }
+func (failingStore) Recent(context.Context, string, time.Time, int) ([]messages.Message, error) {
+	return nil, errFake
+}
+
+var errFake = errors.New("fake store error")
+
+func TestReplayBuffersStoreErrorIsSwallowed(t *testing.T) {
+	// On attach, store.Recent failures must NOT block the gateway —
+	// the client still gets `state` + initial connector state and
+	// can continue normally. Verifies the error-degrade branch in
+	// replayBuffers.
+	v, err := web.NewStaticPasswordVerifier("p")
+	require.NoError(t, err)
+	bridge := newFakeBridge("turborg")
+	bridge.state.OnSelfJoin("#x")
+	g, _, td := startGateway(t, web.Options{
+		Host: "127.0.0.1", Port: 0, Verifier: v,
+		MessageStore: failingStore{},
+	}, bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	// Must successfully read state + connector.state_changed despite
+	// the store error — proves the gateway didn't hang or close.
+	drainInitialFrames(t, conn)
+}
+
+func TestHistoryOpStoreErrorReturnsEmpty(t *testing.T) {
+	v, err := web.NewStaticPasswordVerifier("p")
+	require.NoError(t, err)
+	bridge := newFakeBridge("turborg")
+	g, _, td := startGateway(t, web.Options{
+		Host: "127.0.0.1", Port: 0, Verifier: v,
+		MessageStore: failingStore{},
+	}, bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+
+	body, _ := json.Marshal(map[string]any{"op": "history", "channel": "#x", "limit": 10})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+	got := readJSON(t, conn)
+	assert.Equal(t, "history_result", got["op"])
+	msgs, _ := got["messages"].([]any)
+	assert.Empty(t, msgs, "error path must return empty messages, not panic")
+	assert.Equal(t, false, got["has_more"])
+}
+
+func TestHistoryOpRejectsNonChannelTarget(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	g, _, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+
+	body, _ := json.Marshal(map[string]any{
+		"op": "history", "channel": "alice",
+	})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+	// No response is expected for a malformed op — the gateway
+	// silently drops it. Verify by polling with a short deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, _, err := conn.Read(ctx)
+	assert.Error(t, err, "non-channel target must not produce a history_result")
 }
 
 // --- sendTo error path: closed conn is removed from clients ------

--- a/internal/web/internal_test.go
+++ b/internal/web/internal_test.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"net/http"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,60 +9,8 @@ import (
 
 // White-box tests for unexported helpers. The integration tests in
 // gateway_test.go exercise these indirectly; here we cover the branches
-// they can't easily reach (TS-type fallback in sortByTS, RemoteAddr
-// without port in clientIP, header-only token in extractToken).
-
-func TestSortByTSStableInt64(t *testing.T) {
-	items := []map[string]any{
-		{"ts": int64(3)},
-		{"ts": int64(1)},
-		{"ts": int64(2)},
-	}
-	sortByTS(items)
-	got := []int64{
-		items[0]["ts"].(int64),
-		items[1]["ts"].(int64),
-		items[2]["ts"].(int64),
-	}
-	assert.Equal(t, []int64{1, 2, 3}, got)
-}
-
-func TestSortByTSFallsBackToInt(t *testing.T) {
-	// time.Now().Unix() produces int64, but callers populating the
-	// buffer with the older int shape hit the fallback branch. Mix the
-	// two so both code paths run.
-	items := []map[string]any{
-		{"ts": int(30)},
-		{"ts": int64(10)},
-		{"ts": int(20)},
-	}
-	sortByTS(items)
-	toI64 := func(v any) int64 {
-		switch x := v.(type) {
-		case int64:
-			return x
-		case int:
-			return int64(x)
-		}
-		return -1
-	}
-	got := []int64{toI64(items[0]["ts"]), toI64(items[1]["ts"]), toI64(items[2]["ts"])}
-	assert.True(t, sort.SliceIsSorted(got, func(i, j int) bool { return got[i] < got[j] }))
-	assert.Equal(t, []int64{10, 20, 30}, got)
-}
-
-func TestSortByTSAlreadyOrdered(t *testing.T) {
-	items := []map[string]any{{"ts": int64(1)}, {"ts": int64(2)}, {"ts": int64(3)}}
-	sortByTS(items)
-	assert.Equal(t, int64(1), items[0]["ts"].(int64))
-	assert.Equal(t, int64(3), items[2]["ts"].(int64))
-}
-
-func TestSortByTSEmpty(t *testing.T) {
-	var items []map[string]any
-	sortByTS(items) // must not panic
-	assert.Empty(t, items)
-}
+// they can't easily reach (RemoteAddr without port in clientIP,
+// header-only token in extractToken).
 
 func TestExtractTokenHeaderFallback(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "http://x/ws", nil)
@@ -110,25 +57,19 @@ func TestMapCopyIndependentOfSource(t *testing.T) {
 	assert.Equal(t, "two", dst["b"])
 }
 
-func TestRecordChannelTrimsAtCap(t *testing.T) {
-	// White-box direct call so the trim branch is exercised
-	// deterministically, no goroutines or EventBus draining involved.
-	g := &Gateway{channelLog: map[string][]map[string]any{}}
-	for i := 0; i < channelLogCap+50; i++ {
-		g.recordChannel(map[string]any{"channel": "#x", "n": i})
+func TestStartsWithChannelSigil(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"#channel", true},
+		{"&local", true},
+		{"+modeless", true},
+		{"!safe", true},
+		{"alice", false}, // DM target
+		{"", false},
 	}
-	got := g.channelLog["#x"]
-	assert.Equal(t, channelLogCap, len(got),
-		"recordChannel must cap the per-channel ring at channelLogCap")
-	// The newest entries should win — the first kept entry should be
-	// index 50 (since we trimmed the first 50).
-	first := got[0]["n"].(int)
-	assert.Equal(t, 50, first, "trim must drop the oldest entries first")
-}
-
-func TestRecordChannelEmptyChannelIsNoop(t *testing.T) {
-	g := &Gateway{channelLog: map[string][]map[string]any{}}
-	g.recordChannel(map[string]any{"text": "no channel field"})
-	g.recordChannel(map[string]any{"channel": ""})
-	assert.Empty(t, g.channelLog, "empty channel must not record anything")
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, startsWithChannelSigil(tc.in), "input=%q", tc.in)
+	}
 }

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1299,6 +1299,14 @@
         if (ev.replayed && hasPersistedTwin(ev.channel, ev)) break;
         appendMessage(ev.channel, ev);
         break;
+      case "history_result":
+        // Older-message page from a `history` op the UI fired when the
+        // user scrolled near the top. Prepend in chronological order
+        // (the wire payload is newest-first; we reverse here) and
+        // preserve scroll position so the visible top message stays
+        // anchored under the user's eye.
+        prependHistoryPage(ev);
+        break;
       case "join": {
         const ch = ensureChannel(ev.channel);
         ch.members.set(ev.nick, "");
@@ -1670,10 +1678,76 @@
       channels.set(name, {
         topic: null, members: new Map(), log: [...seedLog],
         unread: 0, mentions: 0,
+        // Scrollback state: hasMoreHistory starts true and flips to
+        // false when the gateway answers a `history` op with
+        // has_more=false. historyLoading is the in-flight guard that
+        // keeps the scroll listener from issuing duplicate requests
+        // while a page is on the wire.
+        hasMoreHistory: true, historyLoading: false,
       });
       renderChannels();
     }
     return channels.get(name);
+  }
+
+  // Infinite scroll: when the user scrolls within 100px of the top of
+  // the messages pane, ask the gateway for the next older page.
+  // hasMoreHistory + historyLoading on the active channel gate the
+  // request so we don't spam pages or repeat after the well runs dry.
+  const HISTORY_PAGE_SIZE = 200;
+  const HISTORY_TRIGGER_PX = 100;
+  messagesEl.addEventListener("scroll", () => {
+    if (!activeChannel) return;
+    const ch = channels.get(activeChannel);
+    if (!ch || !ch.hasMoreHistory || ch.historyLoading) return;
+    if (messagesEl.scrollTop > HISTORY_TRIGGER_PX) return;
+    if (!ws || ws.readyState !== 1) return;
+    // SERVER_TAB and other non-channel views have no history op support
+    // — only channels with a # / & / + / ! sigil.
+    if (!/^[#&+!]/.test(activeChannel)) return;
+    const oldestTs = ch.log.length ? (ch.log[0].ts || 0) : 0;
+    ch.historyLoading = true;
+    send({
+      op: "history",
+      channel: activeChannel,
+      before: oldestTs ? new Date(oldestTs * 1000).toISOString() : "",
+      limit: HISTORY_PAGE_SIZE,
+    });
+  });
+
+  // prependHistoryPage merges an `history_result` payload into the
+  // channel's log without disturbing the user's scroll position. The
+  // wire shape is newest-first; we reverse so the prepended chunk
+  // matches the chronological order of the visible log.
+  function prependHistoryPage(ev) {
+    const ch = channels.get(ev.channel);
+    if (!ch) return;
+    ch.historyLoading = false;
+    ch.hasMoreHistory = !!ev.has_more;
+    const incoming = (ev.messages || []).slice().reverse();
+    if (incoming.length === 0) return;
+
+    // Dedupe by ts+nick+text against existing log head so a refresh
+    // doesn't double-render the initial replay's overlap with what
+    // the user persisted in IndexedDB. Cheap O(n+m) on small windows.
+    const seen = new Set();
+    const seenKey = (m) => `${m.ts || 0}|${m.nick}|${m.text}`;
+    for (let i = 0; i < Math.min(50, ch.log.length); i++) seen.add(seenKey(ch.log[i]));
+    const toAdd = incoming.filter((m) => !seen.has(seenKey(m)));
+    if (toAdd.length === 0) return;
+
+    ch.log = toAdd.concat(ch.log);
+    toAdd.forEach((m) => persistMessage(ev.channel, m));
+
+    if (ev.channel !== activeChannel) return;
+    // Re-render with the user's eye anchored: capture the previous
+    // total height, re-render, then restore the offset so the topmost
+    // visible message stays at the same screen Y.
+    const prevHeight = messagesEl.scrollHeight;
+    const prevTop = messagesEl.scrollTop;
+    renderActiveLog();
+    const delta = messagesEl.scrollHeight - prevHeight;
+    messagesEl.scrollTop = prevTop + delta;
   }
 
   function appendMessage(name, msg) {


### PR DESCRIPTION
Layered build. Three commits on the branch, squash-merged as one.

## Layer 1 — IRCv3 server-time tags on welcome replay

Replay lines fanned to a freshly-attached bouncer client carry `@time=<ISO8601 UTC>` when the client negotiated `server-time`. HexChat / mIRC / irssi render tagged lines as historical and stop highlighting the channel tab as fresh activity on attach.

## Layer 2 — chathistory BATCH framing

Welcome replay for clients that negotiated `batch` is wrapped in `BATCH +<id> chathistory <channel>` … `BATCH -<id>` with every line tagged `batch=<id>`. Legacy NOTICE markers stay for clients without the cap.

## Layer 3 — shared message store + scrollback

New `internal/messages` package with:
- `Store` interface: `Submit(ctx, Message)` + `Recent(ctx, channel, before, limit)`
- `MemoryStore` — bounded per-channel ring (200/channel), self-host default
- `HTTPStore` — durable mirror: writes via the existing `messagesink` batched sink, reads via a synchronous GET on `MESSAGE_STORE_URL`

The bouncer and WS gateway both consume the same `Store` on attach so a single canonical channel history backs replay across both surfaces. The per-surface in-memory rings (`bouncer.channelLog`, `gateway.channelLog`) are gone.

**Scrollback surfaces:**

- **WS `history` op** — `{op:"history", channel, before, limit}` → `{op:"history_result", channel, messages, has_more}`. The bundled reference UI hooks scroll-up within 100px of the top, auto-loads the next 200 older messages, and preserves the user's scroll anchor.
- **IRCv3 CHATHISTORY** — `BEFORE` and `LATEST` subcommands, advertised via the `draft/chathistory` cap, response framed in a chathistory-typed BATCH. Modern IRC clients (Goguma, Quassel, soju-aware) get scrollback for free. HexChat 2.16 doesn't implement CHATHISTORY; for it, see the new env knob below.

**`TURBORG_IRC_BOUNCER_WELCOME_REPLAY_DEPTH`** (default 200, clamped 1..2000) — operator-tunable depth of the per-channel welcome replay on each fresh client attach. Bumping it lets IRC clients without CHATHISTORY support see a deeper backfill at attach, at the cost of a slower welcome on every reconnect.

**`TURBORG_MESSAGE_STORE_URL`** + `TURBORG_MESSAGE_STORE_TOKEN` — when set, the bouncer + gateway read history from this HTTP endpoint instead of in-process memory. Wire contract documented on `messages.HTTPStore`. Self-host leaves them unset and history stays in-process.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass under -race -count=1
- [x] `make cover-gate` — total 94.3%; per-package gates all met (web 95.7%, irc 93.2%, runtime 94.5%, messages 97.3%)
- [x] New unit tests cover `MemoryStore`, `HTTPStore` (roundtrip, error degrade, malformed JSON), `decorateReplayLine`, `clampReplayDepth`, `isChannelTarget`, the EventBus store-submitter
- [x] New integration tests for IRC bouncer: server-time replay, BATCH replay, CHATHISTORY LATEST + BEFORE + 5 error-input cases
- [x] New integration tests for WS gateway: history_result roundtrip, has_more=true at limit, non-channel target dropped, nil-store empty answer, error-degrade fallback
- [ ] Manual: connect HexChat 2.16, confirm no channel highlight on attach (Layer 1 fix). Open appui, scroll up, confirm older messages auto-load (Layer 3 fix, needs accounts-api endpoint).

## Follow-up work (not in this PR)

- **accounts-api** — add `GET /containers/{uuid}/messages?channel=...&before=...&limit=...`
- **appui** — wire the scroll-up handler against the new WS `history` op