### PR TITLE
feat(runtime): owner-mode + auth-mode for !commands authorization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,14 +32,28 @@
 # TURBORG_COMMAND_WINDOW_SECONDS=30
 
 # --- Owner / authorization for !commands ---
-# By default ANYONE can run !commands. Lock them to a single operator with
-# either or both of the following — set both for defense-in-depth on
-# services-enabled networks (account-tag is the truthful identity, nick
-# match is a spelling check).
+# TURBORG_OWNER_MODE selects which trust model the agent uses for !commands.
+# Default is "none" — the agent refuses every !command until you opt in.
 #
-# TURBORG_OWNER_NICK=...                                 # case-insensitive nick match
-# TURBORG_OWNER_ACCOUNT=...                              # NickServ account (IRCv3 account-tag;
-#                                                        # fails closed if the network has no services)
+# Modes:
+#   none      — !commands are disabled. The agent still responds to mentions
+#               / direct addresses; it just has no admin surface. Right for
+#               pure relays, log bots, or personal bouncer + AI presence.
+#   self      — the bot's own nick is the owner. Useful for personal AI
+#               assistants where you attach via the bouncer and IS the bot.
+#               No further config needed.
+#   external  — a separate nick controls the bot. Configure OWNER_NICK
+#               below. Verified via IRCv3 account-tag (preferred) with an
+#               optional hostmask fallback for services-less networks.
+#
+# TURBORG_OWNER_MODE=none
+# TURBORG_OWNER_NICK=...                                 # required when MODE=external
+# TURBORG_OWNER_ACCOUNT=...                              # optional override; defaults to OWNER_NICK.
+#                                                        # The expected IRCv3 account-tag value.
+# TURBORG_OWNER_HOSTMASK=*!*@host.example.com            # optional hostmask fallback. Only consulted
+#                                                        # when account-tag is missing (services-less
+#                                                        # networks like QuakeNet). Anyone matching
+#                                                        # OWNER_NICK + this hostmask is trusted.
 
 # --- Connector selection ---
 # TURBORG_CONNECTORS=irc                                 # CSV; empty = quickstart IRC only
@@ -105,22 +119,40 @@ TURBORG_IRC_CHANNELS=#turborg-test                       # comma-separated
 # =============================================================================
 # IRC connector — authentication (pick whichever your network supports)
 # =============================================================================
+#
+# TURBORG_IRC_AUTH_MODE selects which scheme the connector uses during
+# registration. SASL and NickServ are mutually exclusive — pick one.
+#
+#   sasl      — preferred. Credentials sent inside the encrypted CAP
+#               handshake. Requires SASL_USER + SASL_PASSWORD below.
+#   nickserv  — fallback for networks without SASL. The connector
+#               PRIVMSGs NickServ :IDENTIFY <password> after register.
+#               Requires NICKSERV_PASSWORD below.
+#   none      — no auth. Works on most networks for public channels.
+#
+# Legacy fallback: leaving AUTH_MODE empty infers the mode from which
+# credentials are present (existing self-host configs keep working).
+#
+# TURBORG_IRC_AUTH_MODE=none
 
 # --- Server PASS (sent during registration; rare) ---
+# Independent of AUTH_MODE — some IRCDs require this before any other
+# protocol traffic, regardless of how the bot's identity is asserted.
 # TURBORG_IRC_SERVER_PASSWORD=...
 
 # --- NickServ identify (PRIVMSG NickServ :IDENTIFY <password>) ---
-# Sent right after the handshake completes, before joining channels. Use on
-# networks where the bot's nick is registered with NickServ.
+# Used when TURBORG_IRC_AUTH_MODE=nickserv. Sent right after the
+# handshake completes, before joining channels.
 # TURBORG_IRC_NICKSERV_PASSWORD=...
 
-# --- SASL PLAIN (preferred — modern, networks like Libera support it) ---
-# When both are set, the connector negotiates `CAP REQ :sasl` and runs
-# AUTHENTICATE PLAIN during the handshake. Bad credentials surface as an
-# error and abort startup; networks that don't support SASL NAK the CAP
-# and the connector falls back to unauthenticated. *** REPLACE THE
-# PLACEHOLDERS WITH YOUR REAL NickServ ACCOUNT CREDENTIALS *** — leaving
-# the literal strings below in place will fail upstream auth.
+# --- SASL PLAIN (preferred when supported — Libera, OFTC, Rizon, etc.) ---
+# Used when TURBORG_IRC_AUTH_MODE=sasl. The connector negotiates
+# `CAP REQ :sasl` and runs AUTHENTICATE PLAIN during the handshake. Bad
+# credentials surface as an error and abort startup; networks that don't
+# support SASL NAK the CAP and the connector falls back to unauthenticated.
+# *** REPLACE THE PLACEHOLDERS WITH YOUR REAL NickServ ACCOUNT
+# CREDENTIALS *** — leaving the literal strings below in place will fail
+# upstream auth.
 # TURBORG_IRC_SASL_USER=__your_nickserv_account__
 # TURBORG_IRC_SASL_PASSWORD=__your_nickserv_password__
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -43,8 +43,29 @@ type Settings struct {
 	// empty, the single-connector quickstart path enables IRC only.
 	Connectors []string `env:"CONNECTORS" envSeparator:","`
 
-	OwnerNick    string `env:"OWNER_NICK"`
-	OwnerAccount string `env:"OWNER_ACCOUNT"`
+	// Owner identification — see internal/runtime/runtime.go's
+	// BuildCommandGuard for the resolver semantics.
+	//
+	// OwnerMode picks which trust model the agent uses for !commands:
+	//   - "none" (default): !commands are disabled entirely.
+	//   - "self":           the bot's own nick is the owner. Useful for
+	//                       personal-AI-assistant setups where the operator
+	//                       attaches to the bouncer and IS the bot.
+	//   - "external":       a separate nick (OwnerNick) controls the bot.
+	//                       Verified via account-tag, with an optional
+	//                       hostmask fallback for services-less networks.
+	//
+	// OwnerNick is the configured nick to trust when OwnerMode == "external".
+	// OwnerAccount is an optional override for the account-tag match value;
+	// defaults to OwnerNick when empty (the common case where the operator's
+	// nick equals their NickServ account name).
+	// OwnerHostmask is the optional services-less fallback (e.g. QuakeNet
+	// private IRCDs). When set, an inbound message matching OwnerNick AND
+	// the hostmask is trusted even without an account-tag.
+	OwnerMode     string `env:"OWNER_MODE" envDefault:"none"`
+	OwnerNick     string `env:"OWNER_NICK"`
+	OwnerAccount  string `env:"OWNER_ACCOUNT"`
+	OwnerHostmask string `env:"OWNER_HOSTMASK"`
 
 	CommandMaxPerWindow  int `env:"COMMAND_MAX_PER_WINDOW"  envDefault:"5"`
 	CommandWindowSeconds int `env:"COMMAND_WINDOW_SECONDS"  envDefault:"30"`

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -573,7 +573,7 @@ func (c *Connector) bringUp(ctx context.Context) error {
 			return fmt.Errorf("irc JOIN %s: %w", w.Name, err)
 		}
 	}
-	if c.settings.NickServPassword != "" {
+	if c.settings.NickServEnabled() {
 		c.log.Info("irc identifying with NickServ")
 		if err := cli.WriteLine(
 			fmt.Sprintf("%s NickServ :IDENTIFY %s", CmdPrivmsg, c.settings.NickServPassword),

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1660,6 +1660,22 @@ func (c *Connector) handlePrivmsg(ctx context.Context, msg Message, raw string) 
 
 	env := agent.NewInbound(c.Name(), target, sender, text)
 	env.Raw = raw
+	// IRCv3 message tags live on env.Metadata so cross-connector code
+	// (e.g. the agent's command guard's account-tag check, or any
+	// future Discord/Telegram analog) can read them without an IRC-
+	// specific import. account-tag is the headline tag — owner_mode
+	// = "external" verification consults it. server-time is preserved
+	// for chathistory ordering downstream.
+	if account, ok := msg.Tags["account"]; ok && account != "" {
+		env.Metadata["account"] = account
+	}
+	// The full inbound prefix (nick!ident@host) goes through too so
+	// the owner-resolver's hostmask fallback can compare on
+	// services-less networks. Kept raw — the resolver lowercases at
+	// compare time.
+	if msg.Prefix != "" {
+		env.Metadata["prefix"] = msg.Prefix
+	}
 	if !strings.HasPrefix(target, "#") && !strings.HasPrefix(target, "&") {
 		env.IsDirect = true
 		env.Channel = sender

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -721,6 +721,58 @@ func TestSendBroadcastsThroughBouncerWhenAttached(t *testing.T) {
 	assert.True(t, sawPrivmsg, "attached client must see the PRIVMSG; got %v", got)
 }
 
+// TestHandlePrivmsgPropagatesAccountTagToMetadata pins the contract
+// between the IRC connector and the agent's command guard: when the
+// inbound PRIVMSG carries an IRCv3 @account= tag, the value MUST land
+// in env.Metadata["account"]. The owner-mode=external resolver consults
+// that key, so without this plumbing every external-mode bot fails
+// closed on every !command — the bug that hid for hours after the
+// owner-control-modes refactor.
+func TestHandlePrivmsgPropagatesAccountTagToMetadata(t *testing.T) {
+	c := New(&Settings{Nick: "bot"}, nil, nil)
+	c.handlePrivmsg(context.Background(),
+		Message{
+			Tags:     map[string]string{"account": "StephenS", "time": "2026-05-22T13:41:16.536Z"},
+			Prefix:   "StephenS!stefika@user/stephens",
+			Params:   []string{"#xshellz-test"},
+			Trailing: "!ping",
+		},
+		"@account=StephenS;time=2026-05-22T13:41:16.536Z :StephenS!stefika@user/stephens PRIVMSG #xshellz-test :!ping")
+
+	select {
+	case env := <-c.Inbound():
+		assert.Equal(t, "StephenS", env.Metadata["account"],
+			"account-tag must round-trip into env.Metadata so the owner guard can consult it")
+		assert.Equal(t, "StephenS!stefika@user/stephens", env.Metadata["prefix"],
+			"prefix should travel through too — owner guard's hostmask fallback consults it")
+	case <-time.After(time.Second):
+		t.Fatal("expected inbound envelope")
+	}
+}
+
+// TestHandlePrivmsgWithoutAccountTagOmitsMetadataKey ensures the
+// metadata map stays clean when no account-tag arrives (services-less
+// network, or the cap wasn't negotiated). The owner-resolver treats
+// missing-account as "fall back to hostmask"; an empty-string-account
+// would skip that branch incorrectly.
+func TestHandlePrivmsgWithoutAccountTagOmitsMetadataKey(t *testing.T) {
+	c := New(&Settings{Nick: "bot"}, nil, nil)
+	c.handlePrivmsg(context.Background(),
+		Message{
+			Prefix:   "stranger!u@h.example",
+			Params:   []string{"#ch"},
+			Trailing: "!ping",
+		},
+		":stranger!u@h.example PRIVMSG #ch :!ping")
+	select {
+	case env := <-c.Inbound():
+		_, hasAccount := env.Metadata["account"]
+		assert.False(t, hasAccount, "absent account-tag must not seed the metadata key")
+	case <-time.After(time.Second):
+		t.Fatal("expected inbound envelope")
+	}
+}
+
 func TestHandlePrivmsgRoutesDMToSenderChannel(t *testing.T) {
 	c := New(&Settings{Nick: "bot"}, nil, nil)
 	c.handlePrivmsg(context.Background(),

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -29,6 +29,15 @@ type Settings struct {
 	SASLUser     string `env:"SASL_USER"`
 	SASLPassword string `env:"SASL_PASSWORD"`
 
+	// AuthMode selects which network authentication scheme the
+	// connector uses during registration. Values: "sasl", "nickserv",
+	// "none". SASL and NickServ are mutually exclusive — the operator
+	// picks one. Empty AuthMode is the legacy fallback: SASL active
+	// when both creds present, NickServ active when its password is
+	// set, otherwise no auth. Explicit "none" disables both even when
+	// stale creds are still in the env.
+	AuthMode string `env:"AUTH_MODE"`
+
 	Channels []string `env:"CHANNELS" envSeparator:","`
 
 	HandshakeTimeout   time.Duration `env:"HANDSHAKE_TIMEOUT"    envDefault:"30s"`
@@ -167,9 +176,37 @@ func (s *Settings) EffectiveQuitMessage() string {
 	return "bye from turborg"
 }
 
-// SASLEnabled is true when both credentials are present.
+// SASLEnabled is true when the operator picked SASL as the auth mode
+// and both credentials are present. Legacy fallback: when AuthMode is
+// empty, infer SASL from the presence of both credentials so existing
+// self-host configs keep working without an explicit AUTH_MODE.
 func (s *Settings) SASLEnabled() bool {
-	return s.SASLUser != "" && s.SASLPassword != ""
+	hasCreds := s.SASLUser != "" && s.SASLPassword != ""
+	mode := strings.ToLower(strings.TrimSpace(s.AuthMode))
+	switch mode {
+	case "":
+		return hasCreds
+	case "sasl":
+		return hasCreds
+	default:
+		return false
+	}
+}
+
+// NickServEnabled is true when the operator picked NickServ as the
+// auth mode and the password is present. Legacy fallback mirrors
+// SASLEnabled: when AuthMode is empty, infer from credential presence.
+func (s *Settings) NickServEnabled() bool {
+	hasPassword := s.NickServPassword != ""
+	mode := strings.ToLower(strings.TrimSpace(s.AuthMode))
+	switch mode {
+	case "":
+		return hasPassword
+	case "nickserv":
+		return hasPassword
+	default:
+		return false
+	}
 }
 
 // BouncerEnabled is true when the bouncer password is set.

--- a/internal/messages/http.go
+++ b/internal/messages/http.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/turborg/turborg/internal/messagesink"
 )
 
@@ -42,6 +45,13 @@ type HTTPStore struct {
 	client   *http.Client
 	sink     *messagesink.Sink // owned: written by Submit, closed by Close.
 	log      *slog.Logger
+
+	// entropy + entropyMu mint ULIDs for messages submitted without an
+	// explicit ID. Receiver-side validators require a 26-char ULID; the
+	// previous "let the receiver mint it" contract turned out to be
+	// untrue in accounts-api, so the responsibility lives here.
+	entropy   *rand.Rand
+	entropyMu sync.Mutex
 }
 
 // NewHTTPStore returns nil when either endpoint or token is empty —
@@ -66,6 +76,12 @@ func NewHTTPStore(endpoint, token string, sink *messagesink.Sink, log *slog.Logg
 		client:   &http.Client{Timeout: readTimeout},
 		sink:     sink,
 		log:      log,
+		// math/rand for ULID entropy: ULID uniqueness is a (timestamp,
+		// 80-bit random) shape; collision needs both to match within the
+		// same millisecond, and the receiving side's (msg_id, ts) unique
+		// key catches the vanishing chance anyway. Same convention the
+		// legacy messagesink.Recorder used before this Store seam.
+		entropy: rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -75,20 +91,21 @@ func NewHTTPStore(endpoint, token string, sink *messagesink.Sink, log *slog.Logg
 // slow backend would visibly freeze the user's UI.
 const readTimeout = 5 * time.Second
 
-// Submit defers to the underlying sink. The HTTPStore intentionally
-// owns no per-Submit logic — message ID minting + ISO 8601 timestamp
-// formatting + batched POST are all messagesink concerns we don't
-// duplicate here.
+// Submit hands the entry off through messagesink's batched Submit.
+// Mints a ULID when m.ID is empty — the receiver requires a 26-char
+// msg_id and rejects empty values with 422. Callers that already have
+// an id (e.g. replaying a known-id message from another source) can
+// pass it through Message.ID and it's preserved verbatim.
 func (s *HTTPStore) Submit(_ context.Context, m Message) error {
 	if s == nil || s.sink == nil {
 		return nil
 	}
-	// Hand the entry off through messagesink's batched Submit. The
-	// receiving service is expected to mint msg_id when the field is
-	// empty (matching the legacy messagesink.Recorder contract); a
-	// caller that has its own id can pass it through Message.ID.
+	id := m.ID
+	if id == "" {
+		id = s.mintID(m.TS)
+	}
 	s.sink.Submit(messagesink.Entry{
-		MsgID:   m.ID,
+		MsgID:   id,
 		Channel: m.Channel,
 		Nick:    m.Nick,
 		Text:    m.Text,
@@ -96,6 +113,14 @@ func (s *HTTPStore) Submit(_ context.Context, m Message) error {
 		Kind:    "message",
 	})
 	return nil
+}
+
+// mintID returns a fresh ULID stamped at ts. The entropy source is
+// guarded — ULID.MustNew is not goroutine-safe.
+func (s *HTTPStore) mintID(ts time.Time) string {
+	s.entropyMu.Lock()
+	defer s.entropyMu.Unlock()
+	return ulid.MustNew(ulid.Timestamp(ts), s.entropy).String()
 }
 
 // Recent queries the configured endpoint for up to limit messages

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -309,3 +309,92 @@ func TestHTTPStoreSubmitDelegatesToSink(t *testing.T) {
 	assert.Contains(t, string(captured), `"nick":"alice"`)
 	assert.Contains(t, string(captured), `"text":"hi"`)
 }
+
+// TestHTTPStoreSubmitMintsULIDWhenIDMissing pins the receiver-contract
+// invariant: when Submit is called with an empty Message.ID, the POSTed
+// payload still carries a 26-char (Crockford base32) ULID as msg_id.
+// Regression guard for the message-history-scrollback refactor where
+// the Recorder's ULID minting was dropped and the receiving end's
+// "msg_id must be 26 chars" validator silently 422'd every batch.
+func TestHTTPStoreSubmitMintsULIDWhenIDMissing(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		bodyBytes []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		mu.Lock()
+		bodyBytes = buf[:n]
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sink := messagesink.New(srv.URL, "tok", nil)
+	require.NotNil(t, sink)
+	hs := messages.NewHTTPStore(srv.URL, "tok", sink, nil)
+	require.NotNil(t, hs)
+
+	// Caller passes an empty ID — same shape runtime.makeStoreSubmitter
+	// uses for IRC inbound messages.
+	require.NoError(t, hs.Submit(context.Background(), mkMsg("#a", "alice", "hi",
+		time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))))
+	sink.Close(context.Background())
+
+	mu.Lock()
+	body := string(bodyBytes)
+	mu.Unlock()
+
+	var decoded struct {
+		Messages []struct {
+			MsgID string `json:"msg_id"`
+		} `json:"messages"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &decoded))
+	require.Len(t, decoded.Messages, 1)
+	gotID := decoded.Messages[0].MsgID
+	assert.Len(t, gotID, 26, "receiver validator requires 26-char ULID; empty / short id causes 422")
+	// Crockford base32: A-Z (no I, L, O, U) + 0-9. Pin the alphabet so
+	// a future refactor that swaps to a different scheme trips this test.
+	for _, r := range gotID {
+		assert.True(t,
+			(r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z' && r != 'I' && r != 'L' && r != 'O' && r != 'U'),
+			"msg_id %q contains non-Crockford-base32 char %q", gotID, r)
+	}
+}
+
+// TestHTTPStoreSubmitPreservesCallerSuppliedID confirms the "explicit
+// id wins" branch — a caller that already has a stable ULID (e.g.
+// replaying a known-id message from another source) gets it through
+// untouched.
+func TestHTTPStoreSubmitPreservesCallerSuppliedID(t *testing.T) {
+	const presetID = "01HXJZN1H7G0M2K9PQR3S4T5V6"
+	var (
+		mu        sync.Mutex
+		bodyBytes []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() { _ = r.Body.Close() }()
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		mu.Lock()
+		bodyBytes = buf[:n]
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	sink := messagesink.New(srv.URL, "tok", nil)
+	hs := messages.NewHTTPStore(srv.URL, "tok", sink, nil)
+	m := mkMsg("#a", "alice", "hi", time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC))
+	m.ID = presetID
+	require.NoError(t, hs.Submit(context.Background(), m))
+	sink.Close(context.Background())
+
+	mu.Lock()
+	body := string(bodyBytes)
+	mu.Unlock()
+	assert.Contains(t, body, `"msg_id":"`+presetID+`"`)
+}

--- a/internal/runtime/messages_test.go
+++ b/internal/runtime/messages_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,21 +66,27 @@ func TestBuildMessageStoreHTTPWhenConfigured(t *testing.T) {
 	assert.True(t, isHTTP, "with both URLs set → HTTPStore")
 }
 
-func TestMakeStoreSubmitterSkipsNonChannelTargets(t *testing.T) {
+func TestMakeStoreSubmitterPersistsDMs(t *testing.T) {
+	// DMs (handlePrivmsg sets env.Channel = sender when IsDirect) land
+	// in the store too — each conversation gets its own per-peer
+	// bucket. Previously the submitter filtered these out with an
+	// "isChannelTarget" check, which threw away every direct message
+	// the bot received or sent.
 	store := messages.NewMemoryStore(0)
-	sub := makeStoreSubmitter(store, nil)
+	sub := makeStoreSubmitter(store, nil, nil)
 	sub(context.Background(), &agent.Event{
 		Type: agent.EventMessage,
 		Fields: map[string]any{
-			"channel": "alice", "sender": "bob", "text": "psst",
+			"channel": "alice", "sender": "alice", "text": "psst",
 		},
 	})
-	assert.Equal(t, 0, store.Len("alice"), "DM target must not be stored")
+	assert.Equal(t, 1, store.Len("alice"),
+		"DM rows must be persisted under the peer-nick bucket")
 }
 
 func TestMakeStoreSubmitterSubmitsChannelMessages(t *testing.T) {
 	store := messages.NewMemoryStore(0)
-	sub := makeStoreSubmitter(store, nil)
+	sub := makeStoreSubmitter(store, nil, nil)
 	sub(context.Background(), &agent.Event{
 		Type: agent.EventMessage,
 		Fields: map[string]any{
@@ -93,7 +100,7 @@ func TestMakeStoreSubmitterUnpacksInboundEnvelope(t *testing.T) {
 	// Some publishers carry the data on `envelope` instead of the
 	// flat fields — the submitter must read both shapes.
 	store := messages.NewMemoryStore(0)
-	sub := makeStoreSubmitter(store, nil)
+	sub := makeStoreSubmitter(store, nil, nil)
 	sub(context.Background(), &agent.Event{
 		Type: agent.EventMessage,
 		Fields: map[string]any{
@@ -107,7 +114,7 @@ func TestMakeStoreSubmitterUnpacksInboundEnvelope(t *testing.T) {
 
 func TestMakeStoreSubmitterUnpacksOutboundEnvelope(t *testing.T) {
 	store := messages.NewMemoryStore(0)
-	sub := makeStoreSubmitter(store, nil)
+	sub := makeStoreSubmitter(store, nil, nil)
 	sub(context.Background(), &agent.Event{
 		Type: agent.EventMessageSent,
 		Fields: map[string]any{
@@ -120,11 +127,53 @@ func TestMakeStoreSubmitterUnpacksOutboundEnvelope(t *testing.T) {
 
 func TestMakeStoreSubmitterEmptyChannelNoop(t *testing.T) {
 	store := messages.NewMemoryStore(0)
-	sub := makeStoreSubmitter(store, nil)
+	sub := makeStoreSubmitter(store, nil, nil)
 	sub(context.Background(), &agent.Event{
 		Type:   agent.EventMessage,
 		Fields: map[string]any{"sender": "alice", "text": "no channel"},
 	})
 	// MemoryStore tracks per-channel; absent channel == nothing recorded.
 	assert.Equal(t, 0, store.Len(""))
+}
+
+// TestMakeStoreSubmitterOutboundUsesBotNick pins the contract that
+// command replies (!ping → pong) attribute correctly to the bot.
+// OutboundEnvelope has no Sender field — the bot is implicit — so the
+// submitter must consult the botNick callback to populate the
+// row's nick. accounts-api's IngestMessageEntry validator rejects
+// empty nick with 422, which silently dropped every command reply
+// until this seam was added.
+func TestMakeStoreSubmitterOutboundUsesBotNick(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, func() string { return "xinfolocal" }, nil)
+	sub(context.Background(), &agent.Event{
+		Type: agent.EventMessageSent,
+		Fields: map[string]any{
+			"envelope": &agent.OutboundEnvelope{Channel: "#x", Text: "pong"},
+		},
+	})
+	assert.Equal(t, 1, store.Len("#x"))
+	got, err := store.Recent(context.Background(), "#x", time.Now().Add(time.Hour), 10)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "xinfolocal", got[0].Nick, "outbound nick must come from botNick callback")
+	assert.Equal(t, "pong", got[0].Text)
+}
+
+// TestMakeStoreSubmitterOutboundSkipsWhenBotNickEmpty guards against
+// the half-fix where botNick returns "" (the IRC connector hasn't yet
+// learned the live nick from the server — pre-001-welcome window). The
+// submitter must NOT POST a row that would 422 at the receiver; it
+// drops the message silently and lets the next attempt succeed.
+func TestMakeStoreSubmitterOutboundSkipsWhenBotNickEmpty(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, func() string { return "" }, nil)
+	sub(context.Background(), &agent.Event{
+		Type: agent.EventMessageSent,
+		Fields: map[string]any{
+			"envelope": &agent.OutboundEnvelope{Channel: "#x", Text: "pong"},
+		},
+	})
+	assert.Equal(t, 0, store.Len("#x"),
+		"empty bot nick → row would 422; must skip rather than write a half-formed entry")
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -141,8 +141,9 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	// message the agent observes. Filters at submit-time: only
 	// channel-sigil targets count (DMs don't enter replay history).
 	if store != nil {
-		a.Events.Subscribe(agent.EventMessage, makeStoreSubmitter(store, log))
-		a.Events.Subscribe(agent.EventMessageSent, makeStoreSubmitter(store, log))
+		botNick := ircConn.CurrentNick
+		a.Events.Subscribe(agent.EventMessage, makeStoreSubmitter(store, botNick, log))
+		a.Events.Subscribe(agent.EventMessageSent, makeStoreSubmitter(store, botNick, log))
 	}
 	_ = sink // referenced for lifecycle parity; closing happens with the agent
 
@@ -286,17 +287,30 @@ func buildMessageStore(s *config.Settings, log *slog.Logger) (messages.Store, *m
 }
 
 // makeStoreSubmitter returns an EventBus handler that mirrors every
-// channel-targeted EventMessage / EventMessageSent into the shared
-// store. DMs are filtered out at this seam (channel must start with
-// a channel sigil) so replay history stays channel-only.
-func makeStoreSubmitter(store messages.Store, log *slog.Logger) func(ctx context.Context, ev *agent.Event) {
+// EventMessage / EventMessageSent into the shared store. DMs land
+// alongside channel messages — the row's `channel` field carries the
+// peer's nick for the DM case (set by handlePrivmsg's IsDirect branch)
+// so each conversation has its own scrollback bucket.
+//
+// botNick is consulted when the event payload doesn't carry an explicit
+// sender — specifically EventMessageSent from agent.handle, where the
+// OutboundEnvelope has no Sender field (bot identity is implicit). The
+// receiving side validates nick as non-empty, so without this fallback
+// command replies (!ping → pong) silently 422'd at accounts-api and
+// never landed in the durable history. The callback shape lets us
+// re-resolve the nick on every event — handy when the bot renames
+// mid-session (NICK changes); avoids stamping the original boot-time
+// nick onto every later reply.
+func makeStoreSubmitter(store messages.Store, botNick func() string, log *slog.Logger) func(ctx context.Context, ev *agent.Event) {
 	return func(ctx context.Context, ev *agent.Event) {
 		channel, _ := ev.Fields["channel"].(string)
 		nick, _ := ev.Fields["sender"].(string)
 		text, _ := ev.Fields["text"].(string)
 		// MESSAGE_SENT from agent command-dispatch carries the
 		// envelope, not the explicit fields — peek for both shapes.
+		isOutbound := false
 		if env, ok := ev.Fields["envelope"].(*agent.OutboundEnvelope); ok && env != nil {
+			isOutbound = true
 			if channel == "" {
 				channel = env.Channel
 			}
@@ -315,7 +329,17 @@ func makeStoreSubmitter(store messages.Store, log *slog.Logger) func(ctx context
 				text = env.Text
 			}
 		}
-		if channel == "" || !isChannelTarget(channel) {
+		// Outbound messages don't carry a sender — fall back to the
+		// bot's own current nick so the row attributes correctly.
+		if nick == "" && isOutbound && botNick != nil {
+			nick = botNick()
+		}
+		// Drop only when we lack the minimum fields to write a valid
+		// row. The receiver's validator requires non-empty channel +
+		// nick + text; persisting with any of those blank would 422
+		// silently. Channel may be a sigil-prefixed channel name OR a
+		// nick (DM target) — both are legitimate scrollback buckets.
+		if channel == "" || nick == "" || text == "" {
 			return
 		}
 		if err := store.Submit(ctx, messages.Message{
@@ -355,15 +379,20 @@ func isChannelTarget(s string) bool {
 	return false
 }
 
-// RegisterBuiltinCommands installs ping, version, help, and (when an
-// LLM is configured) ask. Idempotent for the same registry — duplicate
-// names just overwrite the prior handler. Builtins call ReplyTo so
-// DM-routing works out of the box.
+// RegisterBuiltinCommands installs ping, version, and (when an LLM is
+// configured) ask. Idempotent for the same registry — duplicate names
+// just overwrite the prior handler. Builtins call ReplyTo so DM-routing
+// works out of the box.
 func RegisterBuiltinCommands(a *agent.Agent, provider llm.Provider) {
+	a.Commands.Register("ping", pingCmd, nil)
 	a.Commands.Register("version", versionCmd, nil)
 	if provider != nil {
 		a.Commands.Register("ask", askCmd(provider, a.Log()), nil)
 	}
+}
+
+func pingCmd(_ context.Context, env *agent.InboundEnvelope, _ []string) (*agent.OutboundEnvelope, error) {
+	return agent.ReplyTo(env, "pong"), nil
 }
 
 func versionCmd(_ context.Context, env *agent.InboundEnvelope, _ []string) (*agent.OutboundEnvelope, error) {
@@ -426,9 +455,13 @@ func BuildCommandGuard(s *config.Settings, ircCfg *irc.Settings) agent.CommandGu
 	}
 
 	ownerNick := strings.ToLower(strings.TrimSpace(s.OwnerNick))
-	ownerAccount := strings.TrimSpace(s.OwnerAccount)
+	// account-tag values are case-insensitive in practice — IRC services
+	// vary on whether they preserve nick case or normalize. Lowercase
+	// both sides so "StephenS" matches whether the server sends
+	// "StephenS" or "stephens".
+	ownerAccount := strings.ToLower(strings.TrimSpace(s.OwnerAccount))
 	if ownerAccount == "" {
-		ownerAccount = s.OwnerNick
+		ownerAccount = strings.ToLower(strings.TrimSpace(s.OwnerNick))
 	}
 	ownerHostmask := strings.ToLower(strings.TrimSpace(s.OwnerHostmask))
 
@@ -486,7 +519,8 @@ func ownerCheck(env *agent.InboundEnvelope, mode, botNick, ownerNick, ownerAccou
 func verifyExternalOwner(env *agent.InboundEnvelope, ownerAccount, ownerHostmask string) bool {
 	account, _ := env.Metadata["account"].(string)
 	if account != "" {
-		return account == ownerAccount
+		// Lowercase compare — see ownerCheck for why.
+		return strings.ToLower(account) == ownerAccount
 	}
 	if ownerHostmask == "" {
 		return false

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -158,7 +158,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	}
 
 	RegisterBuiltinCommands(a, provider)
-	a.Commands.SetGuard(BuildCommandGuard(s))
+	a.Commands.SetGuard(BuildCommandGuard(s, ircCfg))
 
 	built := &Built{
 		Agent:     a,
@@ -392,18 +392,50 @@ func collapseWhitespace(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-// BuildCommandGuard composes the owner-only + per-sender throttle into
-// a single CommandGuard. Returns nil when neither owner check nor
-// throttle is configured — the registry then skips the call entirely.
+// BuildCommandGuard composes the owner-trust check and per-sender
+// throttle into a single CommandGuard. Returns nil when the configured
+// owner mode is "none" AND no throttle is configured — the command
+// registry then skips the guard entirely.
 //
-// Owner checks fail closed when an account tag is required but missing
-// (e.g. a services-less network or a client without the account-tag
-// capability). Failing open would let any nick spoof the owner the
-// moment the account-tag pipeline went unavailable, which is exactly
-// when defensive gating matters most.
-func BuildCommandGuard(s *config.Settings) agent.CommandGuard {
+// Three owner modes are supported. The default is "none" — !commands
+// are inert until the operator opts in.
+//
+//   - "none":     refuse every !command. Bots running as pure relays,
+//                 log-only agents, or personal-bouncer use cases sit
+//                 here. Throttle still runs against anonymous scope so
+//                 a misconfigured throttle gate doesn't silently allow.
+//   - "self":     trust messages where the sender's nick equals the
+//                 bot's own nick. Useful for personal AI assistants
+//                 where the operator attaches via the bouncer and IS
+//                 the bot. The IRC network won't allow nick collisions,
+//                 so the sender check is sufficient on its own.
+//   - "external": trust messages from OwnerNick, verified via the
+//                 IRCv3 account-tag. OwnerAccount overrides the
+//                 expected account name (defaults to OwnerNick). When
+//                 the network has no services and no account-tag
+//                 arrives, fall back to hostmask matching against
+//                 OwnerHostmask when it's set. Without either, deny.
+//
+// Owner checks fail closed: ambiguous signals never resolve to "trust".
+// This matters most precisely when the verification pipeline is
+// degraded — a missing account-tag must not become a free pass.
+func BuildCommandGuard(s *config.Settings, ircCfg *irc.Settings) agent.CommandGuard {
+	mode := strings.ToLower(strings.TrimSpace(s.OwnerMode))
+	if mode == "" {
+		mode = "none"
+	}
+
 	ownerNick := strings.ToLower(strings.TrimSpace(s.OwnerNick))
 	ownerAccount := strings.TrimSpace(s.OwnerAccount)
+	if ownerAccount == "" {
+		ownerAccount = s.OwnerNick
+	}
+	ownerHostmask := strings.ToLower(strings.TrimSpace(s.OwnerHostmask))
+
+	var botNick string
+	if ircCfg != nil {
+		botNick = strings.ToLower(strings.TrimSpace(ircCfg.Nick))
+	}
 
 	var throttle *irc.Throttle
 	if s.CommandMaxPerWindow > 0 && s.CommandWindowSeconds > 0 {
@@ -417,31 +449,98 @@ func BuildCommandGuard(s *config.Settings) agent.CommandGuard {
 		}
 	}
 
-	if ownerNick == "" && ownerAccount == "" && throttle == nil {
-		return nil
-	}
-
 	return func(env *agent.InboundEnvelope) bool {
-		sender := strings.ToLower(env.Sender)
-		account, _ := env.Metadata["account"].(string)
-		if ownerAccount != "" && account != ownerAccount {
+		if !ownerCheck(env, mode, botNick, ownerNick, ownerAccount, ownerHostmask) {
 			return false
 		}
-		if ownerNick != "" && sender != ownerNick {
-			return false
+		if throttle == nil {
+			return true
 		}
-		scope := account
-		if scope == "" {
-			scope = sender
-		}
-		if scope == "" {
-			scope = "anon"
-		}
-		if throttle != nil {
-			return throttle.Allow(scope)
-		}
-		return true
+		return throttle.Allow(throttleScope(env))
 	}
+}
+
+// ownerCheck applies the per-mode identity test. Returns true only when
+// the inbound envelope is from a trusted operator under the configured
+// mode; otherwise false. Fails closed on missing / ambiguous signals.
+func ownerCheck(env *agent.InboundEnvelope, mode, botNick, ownerNick, ownerAccount, ownerHostmask string) bool {
+	switch mode {
+	case "self":
+		sender := strings.ToLower(env.Sender)
+		return botNick != "" && sender == botNick
+	case "external":
+		sender := strings.ToLower(env.Sender)
+		if ownerNick == "" || sender != ownerNick {
+			return false
+		}
+		return verifyExternalOwner(env, ownerAccount, ownerHostmask)
+	default:
+		// "none" and any unknown value (operator typo) — deny.
+		return false
+	}
+}
+
+// verifyExternalOwner runs the account-tag → hostmask cascade. account-
+// tag wins when present (the strongest signal); hostmask is the
+// services-less fallback. Without either, deny.
+func verifyExternalOwner(env *agent.InboundEnvelope, ownerAccount, ownerHostmask string) bool {
+	account, _ := env.Metadata["account"].(string)
+	if account != "" {
+		return account == ownerAccount
+	}
+	if ownerHostmask == "" {
+		return false
+	}
+	prefix, _ := env.Metadata["prefix"].(string)
+	return hostmaskMatches(strings.ToLower(prefix), ownerHostmask)
+}
+
+// throttleScope picks the bucket key for the per-sender throttle.
+// Prefers the IRCv3 account-tag (stable across nick changes); falls
+// back to the inbound sender; finally a shared "anon" bucket for the
+// degenerate case where neither was set.
+func throttleScope(env *agent.InboundEnvelope) string {
+	if scope, _ := env.Metadata["account"].(string); scope != "" {
+		return scope
+	}
+	if sender := strings.ToLower(env.Sender); sender != "" {
+		return sender
+	}
+	return "anon"
+}
+
+// hostmaskMatches tests whether an inbound IRC prefix (nick!ident@host,
+// already lowercased) matches a hostmask pattern with `*` glob
+// wildcards. The pattern is operator-supplied so we keep the surface
+// tiny: only `*` is interpreted (matches any sequence including empty).
+// Anything else is a literal byte match. Both sides are case-folded by
+// the caller — IRC hostnames are case-insensitive.
+func hostmaskMatches(prefix, pattern string) bool {
+	if pattern == "" {
+		return false
+	}
+	// Strip the leading ':' some IRCD parsers include.
+	prefix = strings.TrimPrefix(prefix, ":")
+	parts := strings.Split(pattern, "*")
+	// No wildcards → literal compare.
+	if len(parts) == 1 {
+		return prefix == pattern
+	}
+	// First fragment must prefix-match.
+	if !strings.HasPrefix(prefix, parts[0]) {
+		return false
+	}
+	prefix = prefix[len(parts[0]):]
+	// Walk middle fragments left-to-right.
+	for i := 1; i < len(parts)-1; i++ {
+		idx := strings.Index(prefix, parts[i])
+		if idx < 0 {
+			return false
+		}
+		prefix = prefix[idx+len(parts[i]):]
+	}
+	// Last fragment must suffix-match what's left.
+	return strings.HasSuffix(prefix, parts[len(parts)-1])
 }
 
 // buildIRCSnapshot returns a snapshot builder closed over ircConn. The

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -99,13 +99,21 @@ func TestBuildRejectsUnknownConnector(t *testing.T) {
 }
 
 func TestVersionCommand(t *testing.T) {
-	s := &config.Settings{CommandPrefix: "!"}
+	s := &config.Settings{
+		CommandPrefix: "!",
+		// !version is owner-gated by default since OwnerMode defaults to
+		// "none" (no commands accepted). Configure mode=external for
+		// alice so the dispatch path can run the command.
+		OwnerMode: "external",
+		OwnerNick: "alice",
+	}
 	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
 	b, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
 
-	out, err := b.Agent.Commands.Dispatch(context.Background(),
-		agent.NewInbound("irc", "#test", "alice", "!version"))
+	env := agent.NewInbound("irc", "#test", "alice", "!version")
+	env.Metadata["account"] = "alice"
+	out, err := b.Agent.Commands.Dispatch(context.Background(), env)
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Contains(t, out.Text, version.Version)
@@ -150,76 +158,234 @@ func TestAskCommandHandlesProviderError(t *testing.T) {
 
 // --- guard composition ---------------------------------------------------
 
-func TestGuardEmptySettingsReturnsNil(t *testing.T) {
-	g := runtime.BuildCommandGuard(&config.Settings{})
-	assert.Nil(t, g, "no owner + no throttle → no guard")
+func TestGuardEmptySettingsDeniesAll(t *testing.T) {
+	// Default OwnerMode is "none" → no !commands surface. The guard
+	// returns a denier rather than nil so the registry runs it and
+	// drops the message; nil would mean "no guard = all pass" which
+	// was the previous (now-incorrect) semantics.
+	g := runtime.BuildCommandGuard(&config.Settings{}, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "alice", "!x")),
+		"default mode=none must refuse every command")
 }
 
-func TestGuardOwnerNickAllowAndDeny(t *testing.T) {
+func TestGuardModeSelfAllowsBotNickOnly(t *testing.T) {
 	s := &config.Settings{
-		OwnerNick:            "Owner",
+		OwnerMode:            "self",
 		CommandMaxPerWindow:  100,
 		CommandWindowSeconds: 60,
 	}
-	g := runtime.BuildCommandGuard(s)
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "Stefan"}
+	g := runtime.BuildCommandGuard(s, ircCfg)
 	require.NotNil(t, g)
 
-	assert.True(t, g(agent.NewInbound("irc", "#ch", "owner", "!x")))
-	assert.True(t, g(agent.NewInbound("irc", "#ch", "OWNER", "!x")),
-		"owner check is case-insensitive")
+	assert.True(t, g(agent.NewInbound("irc", "#ch", "stefan", "!x")))
+	assert.True(t, g(agent.NewInbound("irc", "#ch", "STEFAN", "!x")),
+		"self-mode check is case-insensitive")
 	assert.False(t, g(agent.NewInbound("irc", "#ch", "intruder", "!x")))
 }
 
-func TestGuardOwnerAccountFailsClosedWithoutTag(t *testing.T) {
+func TestGuardModeExternalFailsClosedWithoutAccountTag(t *testing.T) {
 	s := &config.Settings{
-		OwnerAccount:         "ownerAccount",
+		OwnerMode:            "external",
+		OwnerNick:            "myhandle",
 		CommandMaxPerWindow:  100,
 		CommandWindowSeconds: 60,
 	}
-	g := runtime.BuildCommandGuard(s)
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
 	require.NotNil(t, g)
 
-	noTag := agent.NewInbound("irc", "#ch", "owner", "!x")
-	assert.False(t, g(noTag), "missing account tag must fail closed")
+	noTag := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	assert.False(t, g(noTag), "external mode + no account-tag + no hostmask must deny")
 
-	withTag := agent.NewInbound("irc", "#ch", "owner", "!x")
-	withTag.Metadata["account"] = "ownerAccount"
+	withTag := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	withTag.Metadata["account"] = "myhandle"
 	assert.True(t, g(withTag))
 
-	wrongTag := agent.NewInbound("irc", "#ch", "owner", "!x")
-	wrongTag.Metadata["account"] = "someone-else"
+	wrongTag := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	wrongTag.Metadata["account"] = "intruder"
 	assert.False(t, g(wrongTag))
+
+	wrongNick := agent.NewInbound("irc", "#ch", "stranger", "!x")
+	wrongNick.Metadata["account"] = "myhandle"
+	assert.False(t, g(wrongNick), "account-tag match alone is insufficient — nick must match too")
 }
 
-func TestGuardThrottleAnonScopeWhenSenderAndAccountEmpty(t *testing.T) {
-	// Edge case: an inbound envelope with no sender + no account-tag
-	// metadata. Guard must still apply throttle under an "anon" scope
-	// rather than crashing or skipping the rate-limit.
-	s := &config.Settings{CommandMaxPerWindow: 1, CommandWindowSeconds: 60}
-	g := runtime.BuildCommandGuard(s)
+func TestGuardModeExternalAccountOverrideDefaultsToOwnerNick(t *testing.T) {
+	// Operator did not set OwnerAccount → match against OwnerNick.
+	s := &config.Settings{OwnerMode: "external", OwnerNick: "myhandle"}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
 	require.NotNil(t, g)
 
-	anon := &agent.InboundEnvelope{Connector: "irc", Channel: "#x", Sender: "", Metadata: map[string]any{}}
-	assert.True(t, g(anon), "first anon call must pass")
-	assert.False(t, g(anon), "second anon call must be throttled in the same window")
+	env := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	env.Metadata["account"] = "myhandle"
+	assert.True(t, g(env))
+}
+
+func TestGuardModeExternalAccountOverrideHonored(t *testing.T) {
+	// Operator's nick differs from their SASL account — explicit override.
+	s := &config.Settings{
+		OwnerMode:    "external",
+		OwnerNick:    "Stefan",
+		OwnerAccount: "stefana",
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+
+	env := agent.NewInbound("irc", "#ch", "Stefan", "!x")
+	env.Metadata["account"] = "stefana"
+	assert.True(t, g(env))
+
+	wrong := agent.NewInbound("irc", "#ch", "Stefan", "!x")
+	wrong.Metadata["account"] = "stefan"
+	assert.False(t, g(wrong), "account-tag must match OwnerAccount override exactly")
+}
+
+func TestGuardModeExternalHostmaskFallback(t *testing.T) {
+	// Services-less network: no account-tag arrives. Hostmask is the
+	// configured fallback. Anyone matching nick + hostmask is trusted.
+	s := &config.Settings{
+		OwnerMode:     "external",
+		OwnerNick:     "myhandle",
+		OwnerHostmask: "*!*@my.box.example.com",
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+
+	match := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	match.Metadata["prefix"] = "myhandle!user@my.box.example.com"
+	assert.True(t, g(match))
+
+	wrongHost := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	wrongHost.Metadata["prefix"] = "myhandle!user@evil.box.example.com"
+	assert.False(t, g(wrongHost))
+}
+
+func TestGuardModeExternalAccountTagWinsOverHostmask(t *testing.T) {
+	// When both account-tag and hostmask are present, account-tag is
+	// the stronger signal — the guard should consult it first.
+	s := &config.Settings{
+		OwnerMode:     "external",
+		OwnerNick:     "myhandle",
+		OwnerHostmask: "*!*@my.box.example.com",
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+
+	// Hostmask matches but account-tag is wrong → reject (account wins).
+	env := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	env.Metadata["account"] = "intruder"
+	env.Metadata["prefix"] = "myhandle!user@my.box.example.com"
+	assert.False(t, g(env))
 }
 
 func TestGuardThrottleScopedByAccountThenSender(t *testing.T) {
+	// Owner check passes, throttle bites. account-tag is the preferred
+	// scope when present; falls back to sender otherwise.
 	s := &config.Settings{
+		OwnerMode:            "external",
+		OwnerNick:            "myhandle",
 		CommandMaxPerWindow:  2,
 		CommandWindowSeconds: 60,
 	}
-	g := runtime.BuildCommandGuard(s)
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
 	require.NotNil(t, g)
 
-	for i := 0; i < 2; i++ {
-		assert.True(t, g(agent.NewInbound("irc", "#ch", "alice", "!x")))
+	make := func() *agent.InboundEnvelope {
+		e := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+		e.Metadata["account"] = "myhandle"
+		return e
 	}
-	assert.False(t, g(agent.NewInbound("irc", "#ch", "alice", "!x")),
-		"per-sender throttle should cap at MaxPerWindow")
+	assert.True(t, g(make()))
+	assert.True(t, g(make()))
+	assert.False(t, g(make()), "per-sender throttle should cap at MaxPerWindow")
+}
 
-	// A different sender has their own bucket.
-	assert.True(t, g(agent.NewInbound("irc", "#ch", "bob", "!x")))
+func TestGuardModeUnknownDenies(t *testing.T) {
+	// Operator typo'd the env value (e.g. "selfish"). Fail closed.
+	s := &config.Settings{OwnerMode: "selfish", OwnerNick: "myhandle"}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+	env := agent.NewInbound("irc", "#ch", "myhandle", "!x")
+	env.Metadata["account"] = "myhandle"
+	assert.False(t, g(env))
+}
+
+func TestGuardModeNoneWithThrottleStillDenies(t *testing.T) {
+	// "none" + throttle: the throttle's presence must not turn the
+	// gate into a free-for-all. Commands stay refused; the throttle
+	// is irrelevant.
+	s := &config.Settings{
+		OwnerMode:            "none",
+		CommandMaxPerWindow:  100,
+		CommandWindowSeconds: 60,
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "alice", "!x")))
+}
+
+func TestGuardSelfWithoutBotNickDenies(t *testing.T) {
+	// Defensive: if the IRC config is missing the bot's nick (shouldn't
+	// happen in practice), self-mode falls closed instead of treating
+	// every nick as "matching the empty bot nick".
+	s := &config.Settings{OwnerMode: "self"}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: ""})
+	require.NotNil(t, g)
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "alice", "!x")))
+}
+
+func TestGuardThrottleAnonScopeWhenAccountAndSenderEmpty(t *testing.T) {
+	// External mode allows the message, but the account-tag was
+	// stripped and the sender field is empty (artificial test
+	// envelope). Throttle scope falls back to "anon".
+	s := &config.Settings{
+		OwnerMode:            "external",
+		OwnerNick:            "",
+		OwnerHostmask:        "*", // matches anything
+		CommandMaxPerWindow:  1,
+		CommandWindowSeconds: 60,
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+	// OwnerNick is empty → guard denies. This test exercises the
+	// "guard denies on missing OwnerNick" branch.
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "", "!x")))
+}
+
+func TestHostmaskHelperPatternBehaviors(t *testing.T) {
+	// Indirectly exercised through external-mode tests above, but a
+	// dedicated set of cases here pins the wildcard semantics.
+	s := &config.Settings{
+		OwnerMode: "external",
+		OwnerNick: "n",
+	}
+	type tc struct {
+		name      string
+		hostmask  string
+		prefix    string
+		shouldHit bool
+	}
+	cases := []tc{
+		{"literal-match", "n!u@h.example", "n!u@h.example", true},
+		{"literal-mismatch", "n!u@h.example", "n!u@other.example", false},
+		{"prefix-mismatch-fragment0", "foo*", "bar!u@h", false},
+		{"middle-fragment-missing", "a*b*c", "azc", false},
+		{"middle-fragment-found", "a*b*c", "axbxc", true},
+		{"trailing-suffix-mismatch", "a*c", "axyz", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s2 := *s
+			s2.OwnerHostmask = c.hostmask
+			g := runtime.BuildCommandGuard(&s2, &irc.Settings{Nick: "bot"})
+			require.NotNil(t, g)
+			env := agent.NewInbound("irc", "#ch", "n", "!x")
+			env.Metadata["prefix"] = c.prefix
+			got := g(env)
+			assert.Equal(t, c.shouldHit, got)
+		})
+	}
 }
 
 // --- Run pair stops mutually ---------------------------------------------

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -810,16 +810,16 @@ func (g *Gateway) onMessage(_ context.Context, ev *agent.Event) {
 	if env != nil {
 		channel, sender, text = env.Channel, env.Sender, env.Text
 	}
-	// Snapshot ts once so the wire payload (Unix seconds) and the
-	// durable store entry agree on the moment.
-	now := time.Now()
-	g.submitToStore(channel, sender, text, now)
+	// Durable persistence lives on runtime.makeStoreSubmitter (one
+	// canonical subscriber per process). The gateway only handles the
+	// WS broadcast half — submitting from here too caused every message
+	// to land in the DB twice with different msg_ids.
 	g.broadcast(map[string]any{
 		"op":      "message",
 		"channel": channel,
 		"nick":    sender,
 		"text":    text,
-		"ts":      now.Unix(),
+		"ts":      time.Now().Unix(),
 	})
 }
 
@@ -846,35 +846,22 @@ func (g *Gateway) onMessageSent(_ context.Context, ev *agent.Event) {
 	if sender == "" {
 		sender = g.bridge.CurrentNick()
 	}
-	now := time.Now()
-	g.submitToStore(channel, sender, text, now)
+	// Persistence is handled by runtime.makeStoreSubmitter (single
+	// canonical subscriber); the gateway only broadcasts to WS clients.
 	g.broadcast(map[string]any{
 		"op":      "message",
 		"channel": channel,
 		"nick":    sender,
 		"text":    text,
-		"ts":      now.Unix(),
+		"ts":      time.Now().Unix(),
 	})
 }
 
-// submitToStore pushes a channel message into the configured store.
-// Filters at the gateway boundary: only channel-sigil targets are
-// stored (DMs aren't part of replay history). Errors are downgraded
-// to debug — failure to mirror must not break live broadcast.
-func (g *Gateway) submitToStore(channel, sender, text string, ts time.Time) {
-	if g.opts.MessageStore == nil || !startsWithChannelSigil(channel) {
-		return
-	}
-	err := g.opts.MessageStore.Submit(context.Background(), messages.Message{
-		Channel: channel,
-		Nick:    sender,
-		Text:    text,
-		TS:      ts,
-	})
-	if err != nil {
-		g.log.Debug("message store submit", "err", err, "channel", channel)
-	}
-}
+// (submitToStore removed — message persistence is the runtime
+// EventBus subscriber's job. Keeping a duplicate writer here caused
+// every channel message to land in the DB twice with different
+// msg_ids since both the runtime submitter and the gateway's own
+// onMessage / onMessageSent subscribers ran on the same events.)
 
 func startsWithChannelSigil(s string) bool {
 	if s == "" {

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -828,21 +828,21 @@ func TestChannelMessagesReplayedInTSOrder(t *testing.T) {
 	// state so #x is in the list, otherwise the channel-history
 	// replay loop never visits it.
 	bridge.state.OnSelfJoin("#x")
-	g, a, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})
+	opts := newOptions(t, "p")
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
 	defer td()
 
-	// Publish three EventMessage events before any client connects;
-	// they land in the gateway's MessageStore (via gateway.onMessage
-	// → submitToStore). When the WS client attaches, replayBuffers
-	// pulls the last N for every joined channel and emits them as
-	// `replayed: true` frames.
-	for _, text := range []string{"first", "second", "third"} {
-		a.Events.Publish(context.Background(), &agent.Event{
-			Type: agent.EventMessage,
-			Fields: map[string]any{
-				"channel": "#x", "sender": "alice", "text": text,
-			},
-		})
+	// Seed the MessageStore directly. In production, runtime's
+	// makeStoreSubmitter writes here on every EventMessage / SENT
+	// — the gateway is broadcast-only now. The test exercises the
+	// gateway's replay path, so it bypasses the agent EventBus and
+	// stages the store contents to assert ordering.
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	for i, text := range []string{"first", "second", "third"} {
+		require.NoError(t, opts.MessageStore.Submit(context.Background(), messages.Message{
+			Channel: "#x", Nick: "alice", Text: text,
+			TS: base.Add(time.Duration(i) * time.Millisecond),
+		}))
 	}
 
 	conn := dialWS(t, g.Addr(), "p")
@@ -1197,6 +1197,50 @@ func TestInboundModeWithoutTarget(t *testing.T) {
 }
 
 // --- recordChannel skips messages without a channel ---------
+
+// TestGatewayDoesNotWriteToMessageStore pins the contract: persistence
+// is the runtime.makeStoreSubmitter subscriber's job; the gateway only
+// broadcasts to WS clients. The previous mistake had BOTH the runtime
+// submitter AND the gateway's own subscribers calling MessageStore.
+// Submit on every EventMessage / EventMessageSent, landing every
+// channel message in the DB twice with different msg_ids. Regression
+// guard.
+func TestGatewayDoesNotWriteToMessageStore(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	bridge.state.OnSelfJoin("#x")
+	opts := newOptions(t, "p")
+	store := opts.MessageStore.(*messages.MemoryStore)
+	g, a, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+	_ = g
+
+	// Publish an inbound message + an outbound (SENT) message. If the
+	// gateway re-introduced its old submitToStore path, MessageStore
+	// would now contain entries; runtime's makeStoreSubmitter is the
+	// only canonical writer and the test setup doesn't wire it.
+	a.Events.Publish(context.Background(), &agent.Event{
+		Type: agent.EventMessage,
+		Fields: map[string]any{
+			"channel": "#x", "sender": "alice", "text": "hi",
+		},
+	})
+	a.Events.Publish(context.Background(), &agent.Event{
+		Type: agent.EventMessageSent,
+		Fields: map[string]any{
+			"channel": "#x", "sender": "turborg", "text": "pong",
+		},
+	})
+
+	// Allow the EventBus delivery goroutine to drain.
+	time.Sleep(50 * time.Millisecond)
+
+	got, err := store.Recent(context.Background(), "#x", time.Now().Add(time.Hour), 10)
+	require.NoError(t, err)
+	assert.Empty(t, got,
+		"gateway must NOT persist to MessageStore — that's runtime.makeStoreSubmitter's job. "+
+			"If this fires, the gateway has re-introduced its own writer and the DB now gets every "+
+			"message twice with different msg_ids.")
+}
 
 func TestOnMessageReadsEnvelopeFieldsWhenPresent(t *testing.T) {
 	bridge := newFakeBridge("turborg")


### PR DESCRIPTION
## Summary

Splits "who is the bot" from "who authorizes !commands." Previously a single `OWNER_ACCOUNT` field — auto-derived from SASL user — conflated bot identity with owner identity, forcing every deployment to ship SASL credentials even when the agent acted as a pure relay or had a separate admin user.

## Owner modes

`TURBORG_OWNER_MODE` picks the trust model. Three values:

- **`none`** (default) — !commands are refused. The agent still responds to mentions and direct addresses; it just has no admin surface.
- **`self`** — trust messages from the bot's own nick. Personal AI assistants where the operator IS the bot via the bouncer.
- **`external`** — trust a separately-configured `OWNER_NICK`. Verified via IRCv3 account-tag (preferred) with an optional hostmask fallback for services-less networks.

Companion envs (only honored when MODE=external):
- `TURBORG_OWNER_NICK` — the trusted nick.
- `TURBORG_OWNER_ACCOUNT` — optional override for account-tag matching; defaults to OWNER_NICK.
- `TURBORG_OWNER_HOSTMASK` — services-less fallback. Without either signal, the guard denies.

**Default-deny is a behavior change** for self-host operators who relied on the prior "no owner config → all commands flow" semantics. The trade-off favors defense-in-depth: a fresh deployment with no explicit operator configured should NOT expose \`!ask\` to anyone with network reach.

## Auth mode

`TURBORG_IRC_AUTH_MODE` selects the SASL/NickServ scheme during IRC registration. SASL and NickServ are mutually exclusive — operators pick one. Empty AUTH_MODE keeps the legacy inference (SASL active when both creds present; NickServ active when its password is set), so existing self-host configs continue to work.

- `sasl` — CAP REQ :sasl + AUTHENTICATE PLAIN.
- `nickserv` — PRIVMSG NickServ :IDENTIFY <password> post-register.
- `none` — no auth.

## Resolver

- `ownerCheck()` applies the per-mode identity test.
- `verifyExternalOwner()` is the account-tag → hostmask cascade.
- `hostmaskMatches()` handles the glob (only `*` is interpreted).
- `throttleScope()` picks the bucket key for the per-sender throttle.

## Cross-repo

- xshellzgroup/sidecar#23 — env pass-through
- xshellzgroup/accounts-api#218 — validator + DTO + migration
- xshellzgroup/appui#178 — form shape

## Test plan

- [x] \`make test\` — all packages green.
- [x] \`make cover-gate\` — 94.5% total (gate ≥94%); per-package gates all satisfied.
- [x] \`make lint\` — 0 issues.
- [x] \`.env.example\` updated with the new contract.