### PR TITLE
feat(runtime): TURBORG_IGNORED_NICKS gates !commands at the guard

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -138,6 +138,18 @@ type Settings struct {
 	// summary delivered through IRC itself.
 	OwnerDMNudgeEvery int `env:"OWNER_DM_NUDGE_EVERY"`
 
+	// IgnoredNicks is the operator's (or, in SaaS, the end user's) chat-
+	// ignore list. Senders matching one of these nicks (case-insensitive)
+	// are denied early in the command guard — !commands never dispatch,
+	// future LLM triggers will skip them too. Distinct from the per-tier
+	// PlanCapabilities knobs above: this is per-USER policy, surfaced via
+	// the sidecar's IgnoredNicks SpawnRequest field. Hot-update path:
+	// /update-env recreates the container with the new CSV.
+	//
+	// Empty = no ignores. CSV in env (TURBORG_IGNORED_NICKS=alice,bob);
+	// whitespace + case are normalized at guard-build time.
+	IgnoredNicks []string `env:"IGNORED_NICKS" envSeparator:","`
+
 	// ActivityURL is an optional webhook the agent POSTs to whenever
 	// meaningful runtime activity occurs: the bot sending a message, a
 	// bouncer client attaching, or a WS gateway client completing the

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -454,6 +454,14 @@ func BuildCommandGuard(s *config.Settings, ircCfg *irc.Settings) agent.CommandGu
 		mode = "none"
 	}
 
+	// Pre-normalize the user's ignore set once at guard build. Each
+	// inbound !command check then does an O(1) map lookup instead of
+	// re-lowercasing the whole list per message. Built before
+	// ownerCheck so an ignored sender is denied even when they happen
+	// to also be the configured owner (security stance: explicit
+	// ignore is the strongest signal, and the user opted into it).
+	ignoredSenders := buildIgnoredSet(s.IgnoredNicks)
+
 	ownerNick := strings.ToLower(strings.TrimSpace(s.OwnerNick))
 	// account-tag values are case-insensitive in practice — IRC services
 	// vary on whether they preserve nick case or normalize. Lowercase
@@ -483,6 +491,13 @@ func BuildCommandGuard(s *config.Settings, ircCfg *irc.Settings) agent.CommandGu
 	}
 
 	return func(env *agent.InboundEnvelope) bool {
+		// Ignored senders are denied first — cheaper check, strongest
+		// signal (the user explicitly asked us to treat this nick as
+		// non-existent). Mode-based owner checks and throttling never
+		// observe them.
+		if isIgnoredSender(ignoredSenders, env) {
+			return false
+		}
 		if !ownerCheck(env, mode, botNick, ownerNick, ownerAccount, ownerHostmask) {
 			return false
 		}
@@ -491,6 +506,43 @@ func BuildCommandGuard(s *config.Settings, ircCfg *irc.Settings) agent.CommandGu
 		}
 		return throttle.Allow(throttleScope(env))
 	}
+}
+
+// buildIgnoredSet normalises the configured ignore list into a fast
+// lookup set. Lowercase + trim + drop empties. Returns nil when no
+// usable entries — callers short-circuit on the nil set so the no-op
+// case stays branch-free.
+func buildIgnoredSet(raw []string) map[string]struct{} {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(raw))
+	for _, n := range raw {
+		lower := strings.ToLower(strings.TrimSpace(n))
+		if lower == "" {
+			continue
+		}
+		out[lower] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// isIgnoredSender returns true when the envelope's sender nick is in
+// the user-configured ignore set. Nil set (no ignores configured) is
+// the hot-path: returns false without allocating.
+func isIgnoredSender(set map[string]struct{}, env *agent.InboundEnvelope) bool {
+	if set == nil || env == nil {
+		return false
+	}
+	sender := strings.ToLower(strings.TrimSpace(env.Sender))
+	if sender == "" {
+		return false
+	}
+	_, hit := set[sender]
+	return hit
 }
 
 // ownerCheck applies the per-mode identity test. Returns true only when

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -353,6 +353,52 @@ func TestGuardThrottleAnonScopeWhenAccountAndSenderEmpty(t *testing.T) {
 	assert.False(t, g(agent.NewInbound("irc", "#ch", "", "!x")))
 }
 
+func TestGuardIgnoresSenderDeniesEvenInSelfMode(t *testing.T) {
+	// Edge case: the operator's ignore list contains a nick that's ALSO
+	// configured as the owner (via self-mode mirror of bot nick). Explicit
+	// ignore must win — that's the contract the user opted into when they
+	// hit /ignore. Self-mode would otherwise allow them.
+	s := &config.Settings{
+		OwnerMode:    "self",
+		IgnoredNicks: []string{"stefan"},
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "Stefan"})
+	require.NotNil(t, g)
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "Stefan", "!ping")),
+		"explicit ignore beats self-mode owner match")
+}
+
+func TestGuardIgnoresSenderCaseAndWhitespaceNormalized(t *testing.T) {
+	// IRC nicks are case-insensitive; the ignore set is built with
+	// lowercase + trim, and the guard re-lowercases the sender on
+	// every check. Whitespace-only / empty entries in the configured
+	// list are filtered out at build time.
+	s := &config.Settings{
+		OwnerMode:    "self",
+		IgnoredNicks: []string{"Alice", "  BOB  ", "", "carol"},
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "alice", "!x")))
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "BOB", "!x")))
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "  carol", "!x")))
+	// Not on the list — falls through to owner-mode check (self vs "bot");
+	// dave is denied for the owner reason, not the ignore reason. Either
+	// way: denied.
+	assert.False(t, g(agent.NewInbound("irc", "#ch", "dave", "!x")))
+}
+
+func TestGuardEmptyIgnoredNicksIsNoOp(t *testing.T) {
+	// No ignores configured: guard behaviour is exactly as it was
+	// before the section existed. Self-mode allows the bot's own nick.
+	s := &config.Settings{
+		OwnerMode: "self",
+	}
+	g := runtime.BuildCommandGuard(s, &irc.Settings{Nick: "bot"})
+	require.NotNil(t, g)
+	assert.True(t, g(agent.NewInbound("irc", "#ch", "bot", "!x")))
+}
+
 func TestHostmaskHelperPatternBehaviors(t *testing.T) {
 	// Indirectly exercised through external-mode tests above, but a
 	// dedicated set of cases here pins the wildcard semantics.


### PR DESCRIPTION
## Summary

Adds a per-user ignore list to the command guard. Senders whose nick appears in \`TURBORG_IGNORED_NICKS\` (case-insensitive, CSV) are denied before owner-mode and throttling kick in — explicit ignore is the strongest signal, beating even self-mode owner matches.

\`Settings.IgnoredNicks\` is per-USER policy (sourced from the SaaS user's chat-ignore list, relayed via the sidecar's \`IgnoredNicks\` SpawnRequest field), distinct from the per-TIER \`PlanCapabilities\` knobs around it.

**Hot-update path:** sidecar's \`/update-env\` recreates the container with the new CSV; the rebuilt guard picks up the change at boot.

**Defensive:** empty / absent env → nil set → hot-path returns false without allocation, so installs that never set the field stay unaffected.

Today only !command dispatch consults the guard. When LLM triggers ship in turborg they should reuse the same guard so ignored senders are skipped automatically with zero additional code.

## Companion PRs (deploy order)

This is **PR 2 of 4** for the user-prefs sync feature (Flavor B: bot-enforced ignore).

1. ✅ **sidecar** (xshellzgroup/sidecar#26) — accept field on \`/spawn\` + emit env
2. ⬅️ **this PR (turborg)** — read env, gate the command guard
3. **accounts-api** — \`irc_user_prefs\` table, REST endpoints, extend \`SidecarClient::spawn\`, hot-update job
4. **appui** — hydrate \`IgnoreService\` + \`NickNotesService\` from server with debounced PUT on change

## Test plan

- [x] \`go test ./...\` — all suites green; 3 new guard tests pinning the ignore semantics (case-insensitive, beats self-mode, blank entries filtered)
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [ ] On staging with sidecar PR #26 deployed: \`docker exec turborg sh -c 'echo \$TURBORG_IGNORED_NICKS'\` shows the list when accounts-api ships and pushes a value
- [ ] Manual: ignored sender's \`!ping\` is silently dropped, non-ignored sender's \`!ping\` still works