### PR TITLE
feat(server): pooled multi-tenant runtime (M1–M5, M7, M8)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,14 @@ RUN CGO_ENABLED=0 go build \
     -ldflags="-s -w -X github.com/turborg/turborg/internal/version.Version=${VERSION}" \
     -o /turborg ./cmd/turborg
 
+# turborg-server: the pooled multi-tenant runtime. Shipped in the same image
+# so the hosted sidecar can run either binary — it overrides the entrypoint to
+# /turborg-server on pooled hosts. Single-tenant / OSS use keeps /turborg.
+RUN CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags="-s -w -X github.com/turborg/turborg/internal/version.Version=${VERSION}" \
+    -o /turborg-server ./cmd/turborg-server
+
 # Runtime stage: distroless/static is ~2 MB and ships nothing but a
 # CA bundle + tzdata. No shell, no package manager — minimal attack
 # surface. /etc/passwd is included so the non-root user resolves.
@@ -32,6 +40,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.description="turborg — modular AI agent framework"
 
 COPY --from=builder /turborg /turborg
+COPY --from=builder /turborg-server /turborg-server
 
 # Listen on the WS gateway port by default; container orchestrators
 # can publish or override as needed.

--- a/cmd/loadgen/fakeirc.go
+++ b/cmd/loadgen/fakeirc.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// fakeIRC is a minimal, non-test IRC sink for load generation: it completes
+// registration (CAP ACK + RPL_WELCOME), echoes JOINs, answers PINGs, and
+// drains everything else. Enough for N synthetic tenant connectors to reach
+// "registered" and JOIN so the pooled runtime's steady-state footprint can be
+// measured. (The tests/fixtures/fakeirc fixture requires a testing.TB, so it
+// can't be reused from a binary.)
+type fakeIRC struct {
+	ln   net.Listener
+	wg   sync.WaitGroup
+	live atomic.Int64 // currently-registered connections
+}
+
+func startFakeIRC() (*fakeIRC, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	f := &fakeIRC{ln: ln}
+	f.wg.Add(1)
+	go f.acceptLoop()
+	return f, nil
+}
+
+func (f *fakeIRC) addr() string    { return f.ln.Addr().String() }
+func (f *fakeIRC) registered() int { return int(f.live.Load()) }
+
+func (f *fakeIRC) acceptLoop() {
+	defer f.wg.Done()
+	for {
+		conn, err := f.ln.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		f.wg.Add(1)
+		go f.handle(conn)
+	}
+}
+
+func (f *fakeIRC) handle(conn net.Conn) {
+	defer f.wg.Done()
+	defer func() { _ = conn.Close() }()
+
+	r := bufio.NewReader(conn)
+	w := bufio.NewWriter(conn)
+	send := func(s string) {
+		_, _ = fmt.Fprintf(w, "%s\r\n", s)
+		_ = w.Flush()
+	}
+
+	nick := "user"
+	registered := false
+	defer func() {
+		if registered {
+			f.live.Add(-1)
+		}
+	}()
+
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		switch {
+		case strings.HasPrefix(line, "NICK "):
+			nick = strings.TrimSpace(line[len("NICK "):])
+		case strings.HasPrefix(line, "CAP LS"):
+			send(":fake CAP * LS :")
+		case strings.HasPrefix(line, "CAP REQ"):
+			if i := strings.Index(line, " :"); i >= 0 {
+				send(":fake CAP * ACK :" + line[i+2:])
+			}
+		case strings.HasPrefix(line, "USER "):
+			send(fmt.Sprintf(":fake 001 %s :Welcome", nick))
+			send(fmt.Sprintf(":fake 376 %s :End of MOTD", nick))
+			if !registered {
+				registered = true
+				f.live.Add(1)
+			}
+		case strings.HasPrefix(line, "PING "):
+			payload := strings.TrimPrefix(strings.TrimSpace(line[len("PING"):]), ":")
+			send(":fake PONG fake :" + payload)
+		case strings.HasPrefix(line, "JOIN "):
+			target := strings.TrimSpace(line[len("JOIN "):])
+			send(fmt.Sprintf(":%s!~u@host JOIN %s", nick, target))
+		}
+	}
+}
+
+func (f *fakeIRC) close() {
+	_ = f.ln.Close()
+	f.wg.Wait()
+}

--- a/cmd/loadgen/loadgen_test.go
+++ b/cmd/loadgen/loadgen_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLoadgenSmoke exercises the M8 harness end to end at a small scale: a
+// handful of synthetic tenants must all register against the in-process fake
+// IRC and the run must complete cleanly (boot → register → sample → drain).
+// The headline 10k numbers come from running the binary on real hardware.
+func TestLoadgenSmoke(t *testing.T) {
+	if err := run(25, 1, 20*time.Second, 200*time.Millisecond); err != nil {
+		t.Fatalf("loadgen run failed: %v", err)
+	}
+}
+
+func TestBuildSpecsShape(t *testing.T) {
+	specs := buildSpecs(3, 2, "127.0.0.1:6667")
+	if len(specs) != 3 {
+		t.Fatalf("want 3 specs, got %d", len(specs))
+	}
+	cfg := specs[0].Connectors[0].Config
+	if cfg["network"] != "127.0.0.1:6667" {
+		t.Fatalf("network not set: %v", cfg["network"])
+	}
+	chans, ok := cfg["channels"].([]any)
+	if !ok || len(chans) != 2 {
+		t.Fatalf("want 2 channels, got %v", cfg["channels"])
+	}
+}

--- a/cmd/loadgen/main.go
+++ b/cmd/loadgen/main.go
@@ -1,0 +1,139 @@
+// Command loadgen measures the pooled turborg runtime's footprint under load
+// (multi-tenancy plan WS2 M8). It boots N synthetic tenants against an
+// in-process fake IRC sink, waits for them all to register upstream, then
+// reports RAM + goroutine cost — the numbers that drive pool host sizing.
+//
+//	go run ./cmd/loadgen -tenants 10000 -channels 2 -duration 30s
+//
+// The 10k numbers must be taken on representative hardware; small runs work
+// anywhere and validate the harness.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/turborg/turborg/internal/server"
+)
+
+func main() {
+	tenants := flag.Int("tenants", 100, "number of synthetic tenants")
+	channels := flag.Int("channels", 2, "channels per tenant")
+	duration := flag.Duration("duration", 10*time.Second, "steady-state sampling duration")
+	settle := flag.Duration("settle", 60*time.Second, "max wait for all tenants to register upstream")
+	flag.Parse()
+
+	if err := run(*tenants, *channels, *settle, *duration); err != nil {
+		fmt.Fprintln(os.Stderr, "loadgen:", err)
+		os.Exit(1)
+	}
+}
+
+// run boots the load, waits for registration, samples, and prints a report.
+// Returns an error if not all tenants register within settle.
+func run(tenants, channels int, settle, duration time.Duration) error {
+	fake, err := startFakeIRC()
+	if err != nil {
+		return err
+	}
+	defer fake.close()
+
+	// Error-level logging only: per-tenant attach logs at Info would be
+	// N lines of noise and would themselves skew the measurement.
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	srv := server.New(&server.StaticSource{Tenants: buildSpecs(tenants, channels, fake.addr())}, log)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	start := time.Now()
+	if !waitFor(func() bool { return fake.registered() >= tenants }, settle) {
+		return fmt.Errorf("only %d/%d tenants registered within %s", fake.registered(), tenants, settle)
+	}
+	attachDur := time.Since(start)
+
+	// Steady-state: hold for duration, tracking peak goroutine count.
+	peakGoroutines := runtime.NumGoroutine()
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		if g := runtime.NumGoroutine(); g > peakGoroutines {
+			peakGoroutines = g
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	report(tenants, srv.Count(), attachDur, m, peakGoroutines)
+
+	cancel()
+	<-done
+	return nil
+}
+
+func buildSpecs(n, channels int, addr string) []server.TenantSpec {
+	specs := make([]server.TenantSpec, 0, n)
+	for i := 0; i < n; i++ {
+		chans := make([]any, 0, channels)
+		for c := 0; c < channels; c++ {
+			chans = append(chans, fmt.Sprintf("#load%d", c))
+		}
+		specs = append(specs, server.TenantSpec{
+			TurborgID:   fmt.Sprintf("load-%d", i),
+			RuntimeMode: "pooled",
+			Connectors: []server.ConnectorSpec{{
+				Type: "irc",
+				Config: map[string]any{
+					"network":   addr,
+					"use_tls":   false,
+					"nick":      fmt.Sprintf("ld%d", i),
+					"username":  fmt.Sprintf("ld%d", i),
+					"real_name": "loadgen",
+					"channels":  chans,
+				},
+				Secrets: map[string]any{},
+			}},
+		})
+	}
+	return specs
+}
+
+func waitFor(pred func() bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pred() {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return pred()
+}
+
+func report(requested, attached int, attachDur time.Duration, m runtime.MemStats, goroutines int) {
+	const mb = 1024 * 1024
+	perTenantKB := 0.0
+	goroutinesPer := 0.0
+	if attached > 0 {
+		perTenantKB = float64(m.HeapAlloc) / float64(attached) / 1024
+		goroutinesPer = float64(goroutines) / float64(attached)
+	}
+	fmt.Printf("\n=== turborg-server pooled load report ===\n")
+	fmt.Printf("tenants requested   : %d\n", requested)
+	fmt.Printf("tenants attached    : %d\n", attached)
+	fmt.Printf("time to register all: %s\n", attachDur.Round(time.Millisecond))
+	fmt.Printf("heap in use         : %.1f MB\n", float64(m.HeapAlloc)/mb)
+	fmt.Printf("sys reserved        : %.1f MB\n", float64(m.Sys)/mb)
+	fmt.Printf("per-tenant heap     : %.1f KB\n", perTenantKB)
+	fmt.Printf("goroutines          : %d\n", goroutines)
+	fmt.Printf("goroutines/tenant   : %.1f\n", goroutinesPer)
+	fmt.Printf("=========================================\n")
+}

--- a/cmd/turborg-server/main.go
+++ b/cmd/turborg-server/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -71,10 +72,8 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 		return err
 	}
 
-	path := envOr("TURBORG_TENANTS_FILE", defaultTenantsFile)
-	source := &server.FileSource{Path: path}
-
-	log.Info("turborg-server starting", "version", version.Version, "tenants_file", path)
+	source, desc := selectSource(log)
+	log.Info("turborg-server starting", "version", version.Version, "source", desc)
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -85,6 +84,22 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	}
 	log.Info("turborg-server exited cleanly")
 	return nil
+}
+
+// selectSource picks the tenant source from the environment. When
+// TURBORG_CONTROL_PLANE_URL is set, the hosted HTTP feed (accounts-api) is
+// used; otherwise tenants come from the local JSON file (OSS / self-host).
+func selectSource(log *slog.Logger) (server.TenantSource, string) {
+	if base := os.Getenv("TURBORG_CONTROL_PLANE_URL"); base != "" {
+		return &server.HTTPSource{
+			BaseURL: base,
+			Bearer:  os.Getenv("TURBORG_CONTROL_PLANE_TOKEN"),
+			HostID:  os.Getenv("TURBORG_HOST_ID"),
+			Log:     log,
+		}, "http:" + base
+	}
+	path := envOr("TURBORG_TENANTS_FILE", defaultTenantsFile)
+	return &server.FileSource{Path: path}, "file:" + path
 }
 
 func envOr(key, fallback string) string {

--- a/cmd/turborg-server/main.go
+++ b/cmd/turborg-server/main.go
@@ -1,0 +1,95 @@
+// Command turborg-server runs the multi-tenant ("pooled") turborg runtime:
+// one process that holds N tenants, each an isolated agent. It runs alongside
+// the single-tenant `turborg` binary, which stays the default for env-driven
+// hobbyist/OSS deployments.
+//
+// M1 is lifecycle-only — tenants attach/detach from a file source but run no
+// connector behaviour yet. See accounts-api/dev/PLAN-multi-tenancy.md (WS2).
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/joho/godotenv"
+	"github.com/spf13/cobra"
+	"github.com/turborg/turborg/internal/logging"
+	"github.com/turborg/turborg/internal/server"
+	"github.com/turborg/turborg/internal/version"
+)
+
+const defaultTenantsFile = "/etc/turborg/tenants.json"
+
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:           "turborg-server",
+		Short:         "turborg-server — pooled multi-tenant turborg runtime",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Version:       version.Version,
+	}
+	root.SetVersionTemplate("{{.Version}}\n")
+	root.AddCommand(newRunCmd())
+	return root
+}
+
+func newRunCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "run",
+		Short: "Run the pooled runtime, sourcing tenants from a JSON file.",
+		Long: `Run the pooled multi-tenant runtime.
+
+Tenants are loaded from the file at TURBORG_TENANTS_FILE (default
+` + defaultTenantsFile + `), a JSON document of the shape:
+
+  {"tenants": [{"turborg_id": "...", "runtime_mode": "pooled", ...}]}
+
+M1 is lifecycle-only: tenants attach and detach but run no connector
+behaviour yet.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runE(cmd.OutOrStderr())
+		},
+	}
+}
+
+func runE(stderr interface{ Write(p []byte) (int, error) }) error {
+	// Best-effort .env load — real env vars take precedence.
+	_ = godotenv.Load()
+
+	log, err := logging.New(stderr, envOr("TURBORG_LOG_LEVEL", "info"), envOr("TURBORG_LOG_FORMAT", "json"))
+	if err != nil {
+		return err
+	}
+
+	path := envOr("TURBORG_TENANTS_FILE", defaultTenantsFile)
+	source := &server.FileSource{Path: path}
+
+	log.Info("turborg-server starting", "version", version.Version, "tenants_file", path)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	srv := server.New(source, log)
+	if err := srv.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("pooled server: %w", err)
+	}
+	log.Info("turborg-server exited cleanly")
+	return nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/cmd/turborg-server/main.go
+++ b/cmd/turborg-server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"github.com/turborg/turborg/internal/logging"
+	"github.com/turborg/turborg/internal/safe"
 	"github.com/turborg/turborg/internal/server"
 	"github.com/turborg/turborg/internal/version"
 )
@@ -71,6 +72,10 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	if err != nil {
 		return err
 	}
+
+	// Pooled runtime: a panicking goroutine must not take down the process
+	// (and every other tenant in it). Recover + log instead of exiting.
+	safe.SetPanicPolicy(safe.RecoverPolicy)
 
 	source, desc := selectSource(log)
 	log.Info("turborg-server starting", "version", version.Version, "source", desc)

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/messages"
+	"github.com/turborg/turborg/internal/safe"
 	"github.com/turborg/turborg/internal/version"
 	"golang.org/x/sync/errgroup"
 )
@@ -1256,7 +1257,7 @@ func (c *Connector) runEscalationWatchdog(ctx context.Context) <-chan struct{} {
 		return done
 	}
 
-	go func() {
+	safe.Go("irc-escalation-watchdog", func() {
 		defer close(done)
 
 		var (
@@ -1333,7 +1334,7 @@ func (c *Connector) runEscalationWatchdog(ctx context.Context) <-chan struct{} {
 				return
 			}
 		}
-	}()
+	})
 
 	return done
 }

--- a/internal/safe/safe.go
+++ b/internal/safe/safe.go
@@ -1,0 +1,70 @@
+// Package safe provides panic-recovering goroutine launches. Every long-lived
+// goroutine in turborg should start via safe.Go so a panic becomes a logged,
+// policy-controlled event instead of an unrecovered crash with a raw stack.
+//
+// The post-recovery action is a process-wide policy (multi-tenancy plan E4):
+//
+//   - single-tenant turborg: the default Exit policy — log + os.Exit(1),
+//     preserving today's crash-then-container-restart semantics but with a
+//     structured log + stack first.
+//   - pooled turborg-server: Recover policy — log and keep the process alive,
+//     so one tenant's panicking goroutine can't take down the whole pool.
+//
+// Set the policy once at process boot via SetPanicPolicy.
+package safe
+
+import (
+	"log/slog"
+	"os"
+	"runtime/debug"
+	"sync/atomic"
+)
+
+// PanicPolicy decides what happens after a recovered goroutine panic. name
+// labels the goroutine; recovered is the panic value; stack is the captured
+// debug stack.
+type PanicPolicy func(name string, recovered any, stack []byte)
+
+// exitFunc is the process-exit hook, swappable in tests so the default policy
+// is exercisable without killing the test binary.
+var exitFunc = os.Exit
+
+var policy atomic.Pointer[PanicPolicy]
+
+func init() {
+	p := PanicPolicy(ExitPolicy)
+	policy.Store(&p)
+}
+
+// SetPanicPolicy installs the process-wide policy. Call once at boot.
+func SetPanicPolicy(p PanicPolicy) {
+	policy.Store(&p)
+}
+
+// Go runs fn in a goroutine, recovering any panic and routing it to the
+// configured policy. name is a stable label for logs/metrics.
+func Go(name string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				(*policy.Load())(name, r, debug.Stack())
+			}
+		}()
+		fn()
+	}()
+}
+
+// ExitPolicy logs the panic and terminates the process (default). Single-
+// tenant semantics: a panicking goroutine crashes the container, which the
+// orchestrator restarts — same as before, now with a structured log first.
+func ExitPolicy(name string, recovered any, stack []byte) {
+	slog.Error("fatal goroutine panic", "goroutine", name, "panic", recovered, "stack", string(stack))
+	exitFunc(1)
+}
+
+// RecoverPolicy logs the panic and lets the process continue. Pooled
+// semantics: the offending goroutine dies, but the process — and every other
+// tenant in it — survives.
+func RecoverPolicy(name string, recovered any, stack []byte) {
+	slog.Error("recovered goroutine panic", "goroutine", name, "panic", recovered, "stack", string(stack))
+}

--- a/internal/safe/safe_test.go
+++ b/internal/safe/safe_test.go
@@ -1,0 +1,82 @@
+package safe
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// restorePolicy resets the global policy after a test mutates it.
+func restorePolicy(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		p := PanicPolicy(ExitPolicy)
+		policy.Store(&p)
+	})
+}
+
+func TestGoRunsFn(t *testing.T) {
+	restorePolicy(t)
+	done := make(chan struct{})
+	Go("noop", func() { close(done) })
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("fn did not run")
+	}
+}
+
+func TestGoRoutesPanicToPolicy(t *testing.T) {
+	restorePolicy(t)
+	var (
+		mu      sync.Mutex
+		gotName string
+		gotPan  any
+	)
+	SetPanicPolicy(func(name string, recovered any, _ []byte) {
+		mu.Lock()
+		gotName, gotPan = name, recovered
+		mu.Unlock()
+	})
+
+	Go("boom", func() { panic("kaboom") })
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mu.Lock()
+		n, p := gotName, gotPan
+		mu.Unlock()
+		if n == "boom" && p == "kaboom" {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("policy not invoked with panic; name=%q panic=%v", n, p)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+}
+
+func TestExitPolicyCallsExit(t *testing.T) {
+	restorePolicy(t)
+	orig := exitFunc
+	t.Cleanup(func() { exitFunc = orig })
+
+	var code int
+	called := false
+	exitFunc = func(c int) { code, called = c, true }
+
+	ExitPolicy("g", "boom", []byte("stack"))
+	if !called || code != 1 {
+		t.Fatalf("ExitPolicy should exit(1); called=%v code=%d", called, code)
+	}
+}
+
+func TestRecoverPolicyDoesNotExit(t *testing.T) {
+	restorePolicy(t)
+	orig := exitFunc
+	t.Cleanup(func() { exitFunc = orig })
+	exitFunc = func(int) { t.Fatal("RecoverPolicy must not exit") }
+
+	RecoverPolicy("g", "boom", []byte("stack")) // must simply return
+}

--- a/internal/server/connector_irc.go
+++ b/internal/server/connector_irc.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// settingsFromConnectorSpec maps a tenant's IRC ConnectorSpec (the
+// accounts-api/sidecar wire shape: config map + secrets map) onto irc.Settings.
+// Pure — no IO. The single-tenant binary derives the same struct from env via
+// irc.LoadSettings; this is the pooled-mode equivalent sourced from a spec.
+//
+// The per-tenant bouncer is intentionally NOT wired here: N tenants in one
+// process can't each bind a host bouncer port. Pooled bouncer attach is the
+// SNI-router milestone (M6); until then pooled tenants run upstream-only.
+func settingsFromConnectorSpec(cs ConnectorSpec) (*irc.Settings, error) {
+	host, port, err := splitNetwork(stringField(cs.Config, "network"))
+	if err != nil {
+		return nil, err
+	}
+	nick := stringField(cs.Config, "nick")
+	if nick == "" {
+		return nil, fmt.Errorf("irc connector: empty nick")
+	}
+
+	s := &irc.Settings{
+		Hostname: host,
+		Port:     port,
+		UseTLS:   boolField(cs.Config, "use_tls", true),
+		Nick:     nick,
+		Username: stringField(cs.Config, "username"),
+		RealName: stringFieldOr(cs.Config, "real_name", "turborg agent"),
+		AuthMode: stringField(cs.Config, "auth_mode"),
+		Channels: stringSlice(cs.Config, "channels"),
+
+		SASLUser:         stringField(cs.Secrets, "sasl_user"),
+		SASLPassword:     stringField(cs.Secrets, "sasl_password"),
+		NickServPassword: stringField(cs.Secrets, "nickserv_password"),
+		ServerPassword:   stringField(cs.Secrets, "server_password"),
+	}
+
+	if err := s.Validate(); err != nil {
+		return nil, fmt.Errorf("irc settings: %w", err)
+	}
+	return s, nil
+}
+
+// splitNetwork parses "host:port" (the wire shape accounts-api emits). A bare
+// host defaults to 6697 (TLS IRC). Returns an error for an empty host.
+func splitNetwork(network string) (string, int, error) {
+	network = strings.TrimSpace(network)
+	if network == "" {
+		return "", 0, fmt.Errorf("irc connector: empty network")
+	}
+	host, portStr, found := strings.Cut(network, ":")
+	if !found {
+		return network, 6697, nil
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("irc connector: invalid port in %q: %w", network, err)
+	}
+	return host, port, nil
+}
+
+// stringField reads a string value from a JSON-decoded config map, returning
+// "" when absent or not a string.
+func stringField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func stringFieldOr(m map[string]any, key, fallback string) string {
+	if v := stringField(m, key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// boolField reads a bool, tolerating absent keys (returns fallback).
+func boolField(m map[string]any, key string, fallback bool) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return fallback
+}
+
+// stringSlice reads a []string from a JSON-decoded array ([]any of strings).
+func stringSlice(m map[string]any, key string) []string {
+	raw, ok := m[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/server/connector_irc_test.go
+++ b/internal/server/connector_irc_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ircConfig(overrides map[string]any) ConnectorSpec {
+	cfg := map[string]any{
+		"network":  "irc.libera.chat:6697",
+		"nick":     "bot",
+		"channels": []any{"#a", "#b"},
+	}
+	for k, v := range overrides {
+		cfg[k] = v
+	}
+	return ConnectorSpec{Type: "irc", Config: cfg, Secrets: map[string]any{}}
+}
+
+func TestSettingsFromConnectorSpec(t *testing.T) {
+	cs := ircConfig(map[string]any{
+		"use_tls":   false,
+		"username":  "ident",
+		"real_name": "Real Name",
+		"auth_mode": "sasl",
+	})
+	cs.Secrets = map[string]any{"sasl_user": "u", "sasl_password": "p"}
+
+	s, err := settingsFromConnectorSpec(cs)
+	require.NoError(t, err)
+	require.Equal(t, "irc.libera.chat", s.Hostname)
+	require.Equal(t, 6697, s.Port)
+	require.False(t, s.UseTLS)
+	require.Equal(t, "bot", s.Nick)
+	require.Equal(t, "ident", s.Username)
+	require.Equal(t, "Real Name", s.RealName)
+	require.Equal(t, "sasl", s.AuthMode)
+	require.Equal(t, []string{"#a", "#b"}, s.Channels)
+	require.Equal(t, "u", s.SASLUser)
+	require.Equal(t, "p", s.SASLPassword)
+}
+
+func TestSettingsRealNameDefaults(t *testing.T) {
+	s, err := settingsFromConnectorSpec(ircConfig(nil))
+	require.NoError(t, err)
+	require.Equal(t, "turborg agent", s.RealName)
+	require.True(t, s.UseTLS, "use_tls defaults true when absent")
+}
+
+func TestSettingsBareHostDefaultsPort(t *testing.T) {
+	s, err := settingsFromConnectorSpec(ircConfig(map[string]any{"network": "irc.oftc.net"}))
+	require.NoError(t, err)
+	require.Equal(t, "irc.oftc.net", s.Hostname)
+	require.Equal(t, 6697, s.Port)
+}
+
+func TestSettingsRejectsEmptyNetwork(t *testing.T) {
+	_, err := settingsFromConnectorSpec(ircConfig(map[string]any{"network": ""}))
+	require.Error(t, err)
+}
+
+func TestSettingsRejectsBadPort(t *testing.T) {
+	_, err := settingsFromConnectorSpec(ircConfig(map[string]any{"network": "host:nope"}))
+	require.Error(t, err)
+}
+
+func TestSettingsRejectsMissingNick(t *testing.T) {
+	cs := ircConfig(nil)
+	delete(cs.Config, "nick")
+	_, err := settingsFromConnectorSpec(cs)
+	require.Error(t, err, "irc.Settings.Validate requires a nick")
+}
+
+func TestSplitNetwork(t *testing.T) {
+	host, port, err := splitNetwork("example.net:7000")
+	require.NoError(t, err)
+	require.Equal(t, "example.net", host)
+	require.Equal(t, 7000, port)
+}

--- a/internal/server/coverage_test.go
+++ b/internal/server/coverage_test.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantStatusString(t *testing.T) {
+	require.Equal(t, "running", StatusRunning.String())
+	require.Equal(t, "quarantined", StatusQuarantined.String())
+	require.Equal(t, "unknown", TenantStatus(99).String())
+}
+
+func TestFileSourceWatchClosesOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := (&FileSource{Path: "/does/not/matter"}).Watch(ctx)
+	require.NoError(t, err)
+	cancel()
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "channel should close on cancel")
+	case <-time.After(time.Second):
+		t.Fatal("Watch channel did not close on cancel")
+	}
+}
+
+// errSource drives Server.Run's error and stream-closed branches.
+type errSource struct {
+	initialErr error
+	watchErr   error
+	closed     bool
+}
+
+func (e *errSource) Initial(context.Context) ([]TenantSpec, error) { return nil, e.initialErr }
+
+func (e *errSource) Watch(context.Context) (<-chan TenantEvent, error) {
+	if e.watchErr != nil {
+		return nil, e.watchErr
+	}
+	ch := make(chan TenantEvent)
+	if e.closed {
+		close(ch)
+	}
+	return ch, nil
+}
+
+func TestServerRunInitialError(t *testing.T) {
+	boom := errors.New("initial boom")
+	err := New(&errSource{initialErr: boom}, testLogger()).Run(context.Background())
+	require.ErrorIs(t, err, boom)
+}
+
+func TestServerRunWatchError(t *testing.T) {
+	boom := errors.New("watch boom")
+	err := New(&errSource{watchErr: boom}, testLogger()).Run(context.Background())
+	require.ErrorIs(t, err, boom)
+}
+
+func TestServerRunStreamClosed(t *testing.T) {
+	err := New(&errSource{closed: true}, testLogger()).Run(context.Background())
+	require.ErrorContains(t, err, "stream closed")
+}
+
+func TestWorkErrorIsLoggedNotQuarantined(t *testing.T) {
+	src := &StaticSource{Tenants: []TenantSpec{spec("e")}}
+	srv := New(src, testLogger())
+	srv.workFactory = func(_ *Tenant) func(context.Context) error {
+		return func(context.Context) error { return errors.New("work failure, not a panic") }
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		st, ok := srv.Status("e")
+		return ok && st == StatusRunning // an error (vs panic) must not quarantine
+	}, time.Second, 5*time.Millisecond)
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestHTTPSourceDefaultClientAndLogger(t *testing.T) {
+	src, feed := newHTTPSourceTest(t)
+	feed.set(spec("a"))
+	// Exercise the default-client branch (Client left nil).
+	src.Client = nil
+	specs, err := src.Initial(context.Background())
+	require.NoError(t, err)
+	require.Len(t, specs, 1)
+
+	// Exercise logger() default + the poll fetch-error branch: bad URL, no Log.
+	bad := &HTTPSource{BaseURL: "http://127.0.0.1:1/v1/internal", HostID: "x", Interval: 10 * time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := bad.Watch(ctx)
+	require.NoError(t, err)
+	time.Sleep(40 * time.Millisecond) // let at least one failed poll log
+	cancel()
+	<-ch // drains/closes
+}

--- a/internal/server/hot_reload_test.go
+++ b/internal/server/hot_reload_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func specWithChannel(id, channel string) TenantSpec {
+	return TenantSpec{
+		TurborgID:   id,
+		RuntimeMode: "pooled",
+		Connectors: []ConnectorSpec{{
+			Type:    "irc",
+			Config:  map[string]any{"channels": []any{channel}},
+			Secrets: map[string]any{},
+		}},
+	}
+}
+
+// TestUpdateRestartsTenantWithNewSpec is the M7 deliverable: changing a
+// running tenant's spec restarts its work with the new config, without losing
+// the tenant or disturbing the process.
+func TestUpdateRestartsTenantWithNewSpec(t *testing.T) {
+	var runs atomic.Int32
+	seen := make(chan string, 8)
+
+	events := make(chan TenantEvent)
+	src := &StaticSource{Tenants: []TenantSpec{specWithChannel("x", "#one")}, Events: events}
+	srv := New(src, testLogger())
+	srv.workFactory = func(tn *Tenant) func(context.Context) error {
+		return func(ctx context.Context) error {
+			runs.Add(1)
+			tn.mu.Lock()
+			ch := fmt.Sprint(tn.spec.Connectors[0].Config["channels"])
+			tn.mu.Unlock()
+			seen <- ch
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Equal(t, "[#one]", waitStr(t, seen), "first run should see the initial channel")
+
+	// Change the channel — the tenant must restart and observe the new spec.
+	events <- TenantEvent{Kind: TenantUpserted, Spec: specWithChannel("x", "#two")}
+	require.Equal(t, "[#two]", waitStr(t, seen), "restart should see the updated channel")
+	require.GreaterOrEqual(t, int(runs.Load()), 2)
+	require.Equal(t, 1, srv.Count(), "update must not duplicate the tenant")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func TestIdenticalUpsertDoesNotRestart(t *testing.T) {
+	var runs atomic.Int32
+
+	events := make(chan TenantEvent)
+	src := &StaticSource{Tenants: []TenantSpec{specWithChannel("x", "#one")}, Events: events}
+	srv := New(src, testLogger())
+	srv.workFactory = func(_ *Tenant) func(context.Context) error {
+		return func(ctx context.Context) error {
+			runs.Add(1)
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return runs.Load() == 1 }, time.Second, 5*time.Millisecond)
+
+	// Re-upsert the identical spec: must be a no-op (no restart).
+	events <- TenantEvent{Kind: TenantUpserted, Spec: specWithChannel("x", "#one")}
+	require.Never(t, func() bool { return runs.Load() != 1 }, 150*time.Millisecond, 15*time.Millisecond,
+		"identical spec must not restart the tenant")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+func waitStr(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case s := <-ch:
+		return s
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for run observation")
+		return ""
+	}
+}

--- a/internal/server/http_source.go
+++ b/internal/server/http_source.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"reflect"
+	"time"
+)
+
+// HTTPSource feeds tenants from the hosted control plane (accounts-api),
+// the xshellz production TenantSource (plan WS1 F2 / WS2 M5). It fetches the
+// snapshot of pooled tenants assigned to this host and watches for changes.
+//
+// Watch is poll-and-diff rather than SSE: it re-fetches the snapshot every
+// Interval and emits the delta. That trades a few seconds of propagation
+// latency for far less moving infrastructure (no long-lived stream or
+// server-side broadcast) and trivially survives accounts-api restarts. An
+// SSE/long-poll upgrade can replace the poll loop later without changing the
+// TenantSource contract.
+type HTTPSource struct {
+	// BaseURL is the internal API root, e.g. https://accounts-api/v1/internal
+	BaseURL string
+	Bearer  string
+	HostID  string
+
+	// Interval is the poll cadence (default 5s).
+	Interval time.Duration
+	// Client is the HTTP client (default http.DefaultClient).
+	Client *http.Client
+	Log    *slog.Logger
+}
+
+type tenantsEnvelope struct {
+	Tenants []TenantSpec `json:"tenants"`
+}
+
+// Initial fetches the current snapshot of this host's pooled tenants.
+func (h *HTTPSource) Initial(ctx context.Context) ([]TenantSpec, error) {
+	return h.fetch(ctx)
+}
+
+// Watch polls the snapshot on Interval and emits upsert/remove deltas. The
+// returned channel closes when ctx is cancelled.
+//
+// The baseline is seeded synchronously before returning: the Server already
+// booted the initial snapshot via Initial(), so Watch only emits changes
+// observed from this point on (no redundant re-upsert of the booted set).
+func (h *HTTPSource) Watch(ctx context.Context) (<-chan TenantEvent, error) {
+	known := map[string]TenantSpec{}
+	if specs, err := h.fetch(ctx); err == nil {
+		for _, s := range specs {
+			known[s.TurborgID] = s
+		}
+	}
+
+	out := make(chan TenantEvent)
+	go h.poll(ctx, out, known)
+	return out, nil
+}
+
+func (h *HTTPSource) poll(ctx context.Context, out chan<- TenantEvent, known map[string]TenantSpec) {
+	defer close(out)
+
+	interval := h.Interval
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			specs, err := h.fetch(ctx)
+			if err != nil {
+				h.logger().Warn("tenant snapshot poll failed", "err", err)
+				continue
+			}
+			if !h.diff(ctx, known, specs, out) {
+				return
+			}
+		}
+	}
+}
+
+// diff emits upsert events for new/changed specs and remove events for specs
+// that disappeared, then updates known in place. Returns false if ctx was
+// cancelled mid-emit (caller should stop).
+func (h *HTTPSource) diff(ctx context.Context, known map[string]TenantSpec, specs []TenantSpec, out chan<- TenantEvent) bool {
+	seen := make(map[string]struct{}, len(specs))
+	for _, s := range specs {
+		seen[s.TurborgID] = struct{}{}
+		if prev, ok := known[s.TurborgID]; ok && reflect.DeepEqual(prev, s) {
+			continue
+		}
+		if !send(ctx, out, TenantEvent{Kind: TenantUpserted, Spec: s}) {
+			return false
+		}
+		known[s.TurborgID] = s
+	}
+	for id := range known {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		if !send(ctx, out, TenantEvent{Kind: TenantRemoved, TurborgID: id}) {
+			return false
+		}
+		delete(known, id)
+	}
+	return true
+}
+
+func send(ctx context.Context, out chan<- TenantEvent, ev TenantEvent) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case out <- ev:
+		return true
+	}
+}
+
+func (h *HTTPSource) fetch(ctx context.Context) ([]TenantSpec, error) {
+	endpoint := fmt.Sprintf("%s/tenants?host_id=%s", h.BaseURL, url.QueryEscape(h.HostID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+h.Bearer)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.client().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("tenant feed %s: status %d", endpoint, resp.StatusCode)
+	}
+
+	var env tenantsEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		return nil, fmt.Errorf("decode tenant feed: %w", err)
+	}
+	return env.Tenants, nil
+}
+
+func (h *HTTPSource) client() *http.Client {
+	if h.Client != nil {
+		return h.Client
+	}
+	return http.DefaultClient
+}
+
+func (h *HTTPSource) logger() *slog.Logger {
+	if h.Log != nil {
+		return h.Log
+	}
+	return slog.Default()
+}

--- a/internal/server/http_source.go
+++ b/internal/server/http_source.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"reflect"
 	"time"
+
+	"github.com/turborg/turborg/internal/safe"
 )
 
 // HTTPSource feeds tenants from the hosted control plane (accounts-api),
@@ -58,7 +60,7 @@ func (h *HTTPSource) Watch(ctx context.Context) (<-chan TenantEvent, error) {
 	}
 
 	out := make(chan TenantEvent)
-	go h.poll(ctx, out, known)
+	safe.Go("httpsource-poll", func() { h.poll(ctx, out, known) })
 	return out, nil
 }
 

--- a/internal/server/http_source_test.go
+++ b/internal/server/http_source_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFeed is a controllable /tenants endpoint whose returned snapshot the
+// test can swap between polls.
+type fakeFeed struct {
+	mu      sync.Mutex
+	tenants []TenantSpec
+	bearer  string
+	gotAuth string
+	gotHost string
+}
+
+func (f *fakeFeed) set(specs ...TenantSpec) {
+	f.mu.Lock()
+	f.tenants = specs
+	f.mu.Unlock()
+}
+
+func (f *fakeFeed) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.gotAuth = r.Header.Get("Authorization")
+		f.gotHost = r.URL.Query().Get("host_id")
+		out := tenantsEnvelope{Tenants: f.tenants}
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}
+
+func newHTTPSourceTest(t *testing.T) (*HTTPSource, *fakeFeed) {
+	feed := &fakeFeed{bearer: "secret"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/internal/tenants", feed.handler())
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return &HTTPSource{
+		BaseURL:  srv.URL + "/v1/internal",
+		Bearer:   "secret",
+		HostID:   "host-7",
+		Interval: 15 * time.Millisecond,
+		Client:   srv.Client(),
+		Log:      testLogger(),
+	}, feed
+}
+
+func TestHTTPSourceInitial(t *testing.T) {
+	src, feed := newHTTPSourceTest(t)
+	feed.set(spec("a", "irc"), spec("b"))
+
+	specs, err := src.Initial(context.Background())
+	require.NoError(t, err)
+	require.Len(t, specs, 2)
+	require.Equal(t, "Bearer secret", feed.gotAuth, "bearer must be sent")
+	require.Equal(t, "host-7", feed.gotHost, "host_id must be sent")
+}
+
+func TestHTTPSourceInitialNon200(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/internal/tenants", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	src := &HTTPSource{BaseURL: srv.URL + "/v1/internal", Client: srv.Client()}
+	_, err := src.Initial(context.Background())
+	require.Error(t, err)
+}
+
+func TestHTTPSourceWatchEmitsDeltas(t *testing.T) {
+	src, feed := newHTTPSourceTest(t)
+	feed.set(spec("a")) // baseline: poll seeds this silently
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events, err := src.Watch(ctx)
+	require.NoError(t, err)
+
+	// Add "b": expect a single upsert for b (a is unchanged, not re-emitted).
+	feed.set(spec("a"), spec("b", "irc"))
+	ev := waitEvent(t, events)
+	require.Equal(t, TenantUpserted, ev.Kind)
+	require.Equal(t, "b", ev.Spec.TurborgID)
+
+	// Drop "a": expect a remove for a.
+	feed.set(spec("b", "irc"))
+	ev = waitEvent(t, events)
+	require.Equal(t, TenantRemoved, ev.Kind)
+	require.Equal(t, "a", ev.TurborgID)
+}
+
+func waitEvent(t *testing.T, ch <-chan TenantEvent) TenantEvent {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for tenant event")
+		return TenantEvent{}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,13 +6,24 @@ import (
 	"log/slog"
 	"sort"
 	"sync"
+	"time"
 )
+
+// defaultQuarantineBase is the first backoff step a tenant waits after a
+// panic before the supervisor revives it (doubled per consecutive failure).
+const defaultQuarantineBase = time.Second
 
 // Server is the pooled runtime: it reconciles the live set of running
 // Tenants against a TenantSource. One instance per process.
 type Server struct {
 	source TenantSource
 	log    *slog.Logger
+
+	// quarantineBase is the first crash-backoff step handed to each tenant.
+	quarantineBase time.Duration
+	// workFactory builds a tenant's work body. Defaults to the production
+	// agent run; overridable in tests to inject panics or controllable work.
+	workFactory func(*Tenant) func(context.Context) error
 
 	mu      sync.Mutex
 	tenants map[string]*Tenant
@@ -21,9 +32,11 @@ type Server struct {
 // New builds a Server backed by the given tenant source.
 func New(source TenantSource, log *slog.Logger) *Server {
 	return &Server{
-		source:  source,
-		log:     log,
-		tenants: make(map[string]*Tenant),
+		source:         source,
+		log:            log,
+		quarantineBase: defaultQuarantineBase,
+		workFactory:    func(t *Tenant) func(context.Context) error { return t.defaultWork() },
+		tenants:        make(map[string]*Tenant),
 	}
 }
 
@@ -90,7 +103,7 @@ func (s *Server) upsert(ctx context.Context, spec TenantSpec) {
 		existing.update(spec)
 		return
 	}
-	s.tenants[spec.TurborgID] = startTenant(ctx, spec, s.log)
+	s.tenants[spec.TurborgID] = startTenant(ctx, spec, s.log, s.quarantineBase, s.workFactory)
 }
 
 // remove detaches a tenant, draining its goroutine. No-op when absent.
@@ -142,6 +155,17 @@ func (s *Server) Has(id string) bool {
 	defer s.mu.Unlock()
 	_, ok := s.tenants[id]
 	return ok
+}
+
+// Status returns a tenant's supervision phase, and whether it is attached.
+func (s *Server) Status(id string) (TenantStatus, bool) {
+	s.mu.Lock()
+	t, ok := s.tenants[id]
+	s.mu.Unlock()
+	if !ok {
+		return StatusRunning, false
+	}
+	return t.Status(), true
 }
 
 // TenantIDs returns the attached tenant ids, sorted for stable output.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sort"
+	"sync"
+)
+
+// Server is the pooled runtime: it reconciles the live set of running
+// Tenants against a TenantSource. One instance per process.
+type Server struct {
+	source TenantSource
+	log    *slog.Logger
+
+	mu      sync.Mutex
+	tenants map[string]*Tenant
+}
+
+// New builds a Server backed by the given tenant source.
+func New(source TenantSource, log *slog.Logger) *Server {
+	return &Server{
+		source:  source,
+		log:     log,
+		tenants: make(map[string]*Tenant),
+	}
+}
+
+// Run boots every tenant from the source's initial snapshot, then applies
+// streamed events until ctx is cancelled, at which point it drains all
+// tenants and returns ctx.Err().
+func (s *Server) Run(ctx context.Context) error {
+	initial, err := s.source.Initial(ctx)
+	if err != nil {
+		return err
+	}
+	for _, spec := range initial {
+		s.upsert(ctx, spec)
+	}
+	s.log.Info("pooled server booted", "tenants", s.Count())
+
+	events, err := s.source.Watch(ctx)
+	if err != nil {
+		s.shutdown()
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.shutdown()
+			return ctx.Err()
+		case ev, ok := <-events:
+			if !ok {
+				// Source closed its stream (typically on ctx cancel).
+				s.shutdown()
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return errors.New("tenant source stream closed")
+			}
+			s.apply(ctx, ev)
+		}
+	}
+}
+
+// apply routes one source event to attach/update or detach.
+func (s *Server) apply(ctx context.Context, ev TenantEvent) {
+	switch ev.Kind {
+	case TenantUpserted:
+		s.upsert(ctx, ev.Spec)
+	case TenantRemoved:
+		s.remove(ev.TurborgID)
+	default:
+		s.log.Warn("unknown tenant event kind", "kind", int(ev.Kind))
+	}
+}
+
+// upsert creates the tenant if new, or updates it in place. Idempotent:
+// re-applying an identical spec is a cheap no-op update.
+func (s *Server) upsert(ctx context.Context, spec TenantSpec) {
+	if spec.TurborgID == "" {
+		s.log.Warn("ignoring tenant spec with empty turborg_id")
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.tenants[spec.TurborgID]; ok {
+		existing.update(spec)
+		return
+	}
+	s.tenants[spec.TurborgID] = startTenant(ctx, spec, s.log)
+}
+
+// remove detaches a tenant, draining its goroutine. No-op when absent.
+func (s *Server) remove(id string) {
+	s.mu.Lock()
+	t, ok := s.tenants[id]
+	if ok {
+		delete(s.tenants, id)
+	}
+	s.mu.Unlock()
+	if ok {
+		t.stop()
+	}
+}
+
+// shutdown drains every tenant. Tenants stop concurrently; shutdown returns
+// once all have drained.
+func (s *Server) shutdown() {
+	s.mu.Lock()
+	tenants := make([]*Tenant, 0, len(s.tenants))
+	for id, t := range s.tenants {
+		tenants = append(tenants, t)
+		delete(s.tenants, id)
+	}
+	s.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, t := range tenants {
+		wg.Add(1)
+		go func(t *Tenant) {
+			defer wg.Done()
+			t.stop()
+		}(t)
+	}
+	wg.Wait()
+	s.log.Info("pooled server drained", "tenants", len(tenants))
+}
+
+// Count returns the number of attached tenants.
+func (s *Server) Count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.tenants)
+}
+
+// Has reports whether a tenant with the given id is attached.
+func (s *Server) Has(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.tenants[id]
+	return ok
+}
+
+// TenantIDs returns the attached tenant ids, sorted for stable output.
+func (s *Server) TenantIDs() []string {
+	s.mu.Lock()
+	ids := make([]string, 0, len(s.tenants))
+	for id := range s.tenants {
+		ids = append(ids, id)
+	}
+	s.mu.Unlock()
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/turborg/turborg/internal/safe"
 )
 
 // defaultQuarantineBase is the first backoff step a tenant waits after a
@@ -133,10 +135,10 @@ func (s *Server) shutdown() {
 	var wg sync.WaitGroup
 	for _, t := range tenants {
 		wg.Add(1)
-		go func(t *Tenant) {
+		safe.Go("drain/"+t.ID, func() {
 			defer wg.Done()
 			t.stop()
-		}(t)
+		})
 	}
 	wg.Wait()
 	s.log.Info("pooled server drained", "tenants", len(tenants))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// goleak guards the core M1 promise: attach/detach and shutdown drain every
+// tenant goroutine — no leaks.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func spec(id string, connectors ...string) TenantSpec {
+	cs := make([]ConnectorSpec, 0, len(connectors))
+	for _, c := range connectors {
+		cs = append(cs, ConnectorSpec{Type: c, Config: map[string]any{}, Secrets: map[string]any{}})
+	}
+	return TenantSpec{TurborgID: id, RuntimeMode: "pooled", Connectors: cs}
+}
+
+func TestServerBootsInitialTenants(t *testing.T) {
+	src := &StaticSource{Tenants: []TenantSpec{spec("a", "irc"), spec("b")}}
+	srv := New(src, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return srv.Count() == 2 }, time.Second, 5*time.Millisecond)
+	require.True(t, srv.Has("a"))
+	require.True(t, srv.Has("b"))
+	require.Equal(t, []string{"a", "b"}, srv.TenantIDs())
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+	require.Equal(t, 0, srv.Count(), "shutdown must drain every tenant")
+}
+
+func TestServerAttachAndDetachViaEvents(t *testing.T) {
+	events := make(chan TenantEvent)
+	src := &StaticSource{Events: events}
+	srv := New(src, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	events <- TenantEvent{Kind: TenantUpserted, Spec: spec("x", "irc")}
+	require.Eventually(t, func() bool { return srv.Has("x") }, time.Second, 5*time.Millisecond)
+
+	events <- TenantEvent{Kind: TenantRemoved, TurborgID: "x"}
+	require.Eventually(t, func() bool { return !srv.Has("x") }, time.Second, 5*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+func TestServerUpsertUpdatesInPlace(t *testing.T) {
+	events := make(chan TenantEvent)
+	src := &StaticSource{Tenants: []TenantSpec{spec("x", "irc")}, Events: events}
+	srv := New(src, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return srv.Has("x") }, time.Second, 5*time.Millisecond)
+
+	// Re-upserting the same id must update in place, not add a tenant.
+	events <- TenantEvent{Kind: TenantUpserted, Spec: spec("x", "irc", "discord")}
+	require.Never(t, func() bool { return srv.Count() != 1 }, 100*time.Millisecond, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+func TestServerIgnoresEmptyTurborgID(t *testing.T) {
+	src := &StaticSource{Tenants: []TenantSpec{spec(""), spec("ok")}}
+	srv := New(src, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return srv.Has("ok") }, time.Second, 5*time.Millisecond)
+	require.Equal(t, 1, srv.Count(), "empty-id spec must be ignored")
+
+	cancel()
+	<-done
+}
+
+func TestFileSourceInitial(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tenants.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"tenants":[
+		{"turborg_id":"f1","runtime_mode":"pooled","connectors":[{"type":"irc","config":{},"secrets":{}}]},
+		{"turborg_id":"f2","runtime_mode":"pooled","connectors":[]}
+	]}`), 0o600))
+
+	specs, err := (&FileSource{Path: path}).Initial(context.Background())
+	require.NoError(t, err)
+	require.Len(t, specs, 2)
+	require.Equal(t, "f1", specs[0].TurborgID)
+	require.Equal(t, "irc", specs[0].Connectors[0].Type)
+}
+
+func TestFileSourceMissingFile(t *testing.T) {
+	_, err := (&FileSource{Path: filepath.Join(t.TempDir(), "nope.json")}).Initial(context.Background())
+	require.Error(t, err)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,12 +10,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/safe"
 	"go.uber.org/goleak"
 )
 
 // goleak guards the core M1 promise: attach/detach and shutdown drain every
-// tenant goroutine — no leaks.
+// tenant goroutine — no leaks. RecoverPolicy matches the pooled runtime (and
+// keeps an unexpected goroutine panic from os.Exit-ing the test binary).
 func TestMain(m *testing.M) {
+	safe.SetPanicPolicy(safe.RecoverPolicy)
 	goleak.VerifyTestMain(m)
 }
 

--- a/internal/server/supervisor_test.go
+++ b/internal/server/supervisor_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// callCounter is a tiny concurrency-safe per-id counter for the panic tests.
+type callCounter struct {
+	mu sync.Mutex
+	m  map[string]int
+}
+
+func newCallCounter() *callCounter { return &callCounter{m: map[string]int{}} }
+
+func (c *callCounter) Inc(id string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[id]++
+	return c.m[id]
+}
+
+func (c *callCounter) Get(id string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.m[id]
+}
+
+// TestPanicQuarantinesOnlyOffendingTenant is the core M3 promise: a panic in
+// one tenant's work loop quarantines ONLY that tenant — the process survives
+// (this test completing proves it) and sibling tenants keep running — and the
+// quarantined tenant auto-revives after backoff.
+func TestPanicQuarantinesOnlyOffendingTenant(t *testing.T) {
+	var boomCalls atomic.Int32
+
+	src := &StaticSource{Tenants: []TenantSpec{spec("boom"), spec("ok")}}
+	srv := New(src, testLogger())
+	srv.quarantineBase = 20 * time.Millisecond
+	srv.workFactory = func(tn *Tenant) func(context.Context) error {
+		return func(ctx context.Context) error {
+			if tn.ID == "boom" && boomCalls.Add(1) == 1 {
+				panic("boom: first run only")
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	// boom panics, is quarantined, then revived — proven by a second call.
+	require.Eventually(t, func() bool { return boomCalls.Load() >= 2 }, 2*time.Second, 5*time.Millisecond,
+		"quarantined tenant was not revived")
+	require.Eventually(t, func() bool {
+		st, ok := srv.Status("boom")
+		return ok && st == StatusRunning
+	}, 2*time.Second, 5*time.Millisecond, "revived tenant should be running again")
+
+	boom := srv.tenants["boom"]
+	require.GreaterOrEqual(t, boom.Failures(), 1, "panic should have been recorded")
+
+	// The sibling must never have been quarantined.
+	require.Never(t, func() bool {
+		st, _ := srv.Status("ok")
+		return st != StatusRunning
+	}, 200*time.Millisecond, 20*time.Millisecond, "sibling tenant must be unaffected by another tenant's panic")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+// TestManyPanicsIsolated stress-checks isolation: of N tenants, a subset
+// panic once each; the rest must stay running and the process must survive.
+func TestManyPanicsIsolated(t *testing.T) {
+	const total = 20
+	panicSet := map[string]bool{"t-1": true, "t-4": true, "t-9": true, "t-14": true, "t-17": true}
+	calls := newCallCounter()
+
+	specs := make([]TenantSpec, 0, total)
+	for i := 0; i < total; i++ {
+		specs = append(specs, spec(fmt.Sprintf("t-%d", i)))
+	}
+
+	srv := New(&StaticSource{Tenants: specs}, testLogger())
+	srv.quarantineBase = 10 * time.Millisecond
+	srv.workFactory = func(tn *Tenant) func(context.Context) error {
+		return func(ctx context.Context) error {
+			if panicSet[tn.ID] && calls.Inc(tn.ID) == 1 {
+				panic("isolated panic")
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	// Every panicking tenant revives (second call); the rest never panic.
+	require.Eventually(t, func() bool {
+		for id := range panicSet {
+			if calls.Get(id) < 2 {
+				return false
+			}
+		}
+		return true
+	}, 3*time.Second, 10*time.Millisecond, "all panicking tenants should revive")
+
+	require.Equal(t, total, srv.Count(), "no tenant should be lost to a panic")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// Tenant is one isolated agent inside the pooled process. M1 is lifecycle
+// only: it owns a cancellable context and a supervised goroutine that starts,
+// idles until cancelled, and stops cleanly. Connector wiring (M2), crash
+// isolation (M3), and per-tenant limits (M4) build on this shell.
+//
+// Discipline rule (enforced from M2 on): anything a Tenant holds is
+// tenant-owned; shared subsystems live on the Server. A Tenant must never
+// reference another tenant's state.
+type Tenant struct {
+	ID  string
+	log *slog.Logger
+
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu   sync.Mutex
+	spec TenantSpec
+}
+
+// startTenant launches a tenant goroutine under a child of parent. The
+// returned Tenant is running; call stop() to drain it.
+func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger) *Tenant {
+	ctx, cancel := context.WithCancel(parent)
+	t := &Tenant{
+		ID:     spec.TurborgID,
+		log:    log.With("turborg_id", spec.TurborgID),
+		cancel: cancel,
+		done:   make(chan struct{}),
+		spec:   spec,
+	}
+	go t.run(ctx)
+	return t
+}
+
+// run is the tenant's supervised lifecycle. M1: no connector behaviour —
+// it logs attach, blocks until cancellation, then logs detach. Later
+// milestones replace the idle wait with the connector run loop.
+func (t *Tenant) run(ctx context.Context) {
+	defer close(t.done)
+	t.log.Info("tenant attached", "connectors", t.connectorTypes())
+	<-ctx.Done()
+	t.log.Info("tenant detaching")
+}
+
+// update applies a new desired spec to a running tenant. M1 swaps the stored
+// spec and logs; connector-aware diffing (JOIN/PART, nick, rate limits) is
+// the hot-reload milestone (M7).
+func (t *Tenant) update(spec TenantSpec) {
+	t.mu.Lock()
+	t.spec = spec
+	t.mu.Unlock()
+	t.log.Info("tenant spec updated", "connectors", t.connectorTypes())
+}
+
+// stop cancels the tenant and waits for its goroutine to drain.
+func (t *Tenant) stop() {
+	t.cancel()
+	<-t.done
+}
+
+// connectorTypes lists the configured connector types, for logging.
+func (t *Tenant) connectorTypes() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]string, 0, len(t.spec.Connectors))
+	for _, c := range t.spec.Connectors {
+		out = append(out, c.Type)
+	}
+	return out
+}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -197,6 +197,7 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 func (t *Tenant) buildConnectors(a *agent.Agent) {
 	t.mu.Lock()
 	connectors := t.spec.Connectors
+	caps := t.spec.PlanCapabilities
 	t.mu.Unlock()
 
 	for _, cs := range connectors {
@@ -207,7 +208,12 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 				t.log.Error("skipping invalid irc connector", "err", err)
 				continue
 			}
-			a.AddConnector(irc.New(settings, t.log, nil))
+			conn := irc.New(settings, t.log, nil)
+			if err := applyPlanLimits(conn, caps); err != nil {
+				t.log.Error("skipping irc connector: invalid plan limits", "err", err)
+				continue
+			}
+			a.AddConnector(conn)
 		default:
 			t.log.Warn("connector type not supported in pooled mode yet", "type", cs.Type)
 		}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/safe"
 )
 
 // TenantStatus is the supervised lifecycle phase of a tenant.
@@ -89,7 +90,7 @@ func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger, quar
 		status:         StatusRunning,
 	}
 	t.work = workFactory(t)
-	go t.supervise(ctx)
+	safe.Go("supervise/"+spec.TurborgID, func() { t.supervise(ctx) })
 	return t
 }
 

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -56,6 +57,10 @@ type Tenant struct {
 
 	cancel context.CancelFunc
 	done   chan struct{}
+	// restartCh signals the supervisor to tear down the current run and
+	// re-run with the latest spec (M7 hot reload). Buffered(1) + non-blocking
+	// send coalesces rapid updates into a single pending restart.
+	restartCh chan struct{}
 
 	mu              sync.Mutex
 	spec            TenantSpec
@@ -63,6 +68,8 @@ type Tenant struct {
 	failures        int
 	lastErr         error
 	quarantineUntil time.Time
+	// runCancel cancels the in-flight work run so update() can restart it.
+	runCancel context.CancelFunc
 }
 
 // startTenant launches a self-supervising tenant under a child of parent.
@@ -77,6 +84,7 @@ func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger, quar
 		quarantineBase: quarantineBase,
 		cancel:         cancel,
 		done:           make(chan struct{}),
+		restartCh:      make(chan struct{}, 1),
 		spec:           spec,
 		status:         StatusRunning,
 	}
@@ -86,39 +94,59 @@ func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger, quar
 }
 
 // supervise runs the tenant's work loop, recovering panics and quarantining
-// (with exponential backoff) before reviving. Returns when ctx is cancelled.
-func (t *Tenant) supervise(ctx context.Context) {
+// (with exponential backoff) before reviving, and restarting the run when the
+// spec changes (M7). Returns when the parent ctx is cancelled.
+func (t *Tenant) supervise(parent context.Context) {
 	defer close(t.done)
 
 	for {
-		if ctx.Err() != nil {
+		if parent.Err() != nil {
 			return
 		}
 
-		panicked := t.runOnce(ctx)
+		// Per-run context so update() can cancel just this run (restart)
+		// without tearing down the tenant.
+		runCtx, cancel := context.WithCancel(parent)
+		t.setRunCancel(cancel)
+		panicked := t.runOnce(runCtx)
+		cancel()
 
-		if ctx.Err() != nil {
+		if parent.Err() != nil {
 			return
 		}
 
-		if !panicked {
-			// Work returned without panic and the tenant wasn't cancelled
-			// (e.g. no runnable connectors). Idle until cancelled so the
-			// Server's view of attached tenants stays consistent.
-			<-ctx.Done()
-			return
+		if panicked {
+			backoff := t.enterQuarantine()
+			t.log.Warn("tenant quarantined after panic", "backoff", backoff, "failures", t.Failures())
+			select {
+			case <-parent.Done():
+				return
+			case <-t.restartCh:
+				t.markRunning()
+				t.log.Info("restarting quarantined tenant after config change")
+			case <-time.After(backoff):
+				t.markRunning()
+				t.log.Info("reviving quarantined tenant")
+			}
+			continue
 		}
 
-		backoff := t.enterQuarantine()
-		t.log.Warn("tenant quarantined after panic", "backoff", backoff, "failures", t.Failures())
+		// Work ended without panic: either update() cancelled the run to
+		// apply a config change, or the work returned on its own (e.g. no
+		// runnable connectors). Wait for a restart signal or cancellation.
 		select {
-		case <-ctx.Done():
+		case <-parent.Done():
 			return
-		case <-time.After(backoff):
-			t.markRunning()
-			t.log.Info("reviving quarantined tenant")
+		case <-t.restartCh:
+			t.log.Info("restarting tenant after config change")
 		}
 	}
+}
+
+func (t *Tenant) setRunCancel(cancel context.CancelFunc) {
+	t.mu.Lock()
+	t.runCancel = cancel
+	t.mu.Unlock()
 }
 
 // runOnce executes the work body once, recovering any panic. Returns true if
@@ -220,14 +248,36 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 	}
 }
 
-// update applies a new desired spec to a running tenant. M3 swaps the stored
-// spec and logs; connector-aware diffing (JOIN/PART, nick, rate limits) is
-// the hot-reload milestone (M7).
+// update applies a new desired spec to a running tenant (M7, conservative
+// hot reload). When the spec actually changed it restarts the tenant's run so
+// the new connectors/limits take effect; an identical spec is a no-op.
+//
+// Conservative by design: any change triggers a full reconnect rather than a
+// surgical JOIN/PART. The plan's aggressive in-place reload (no reconnect on
+// channel-only edits) is a later refinement; reconnect-on-change is correct
+// and simple, and avoids silent state divergence.
 func (t *Tenant) update(spec TenantSpec) {
 	t.mu.Lock()
+	unchanged := reflect.DeepEqual(t.spec, spec)
+	if unchanged {
+		t.mu.Unlock()
+		return
+	}
 	t.spec = spec
+	cancel := t.runCancel
 	t.mu.Unlock()
-	t.log.Info("tenant spec updated", "connectors", t.connectorTypes())
+
+	t.log.Info("tenant spec changed; restarting", "connectors", t.connectorTypes())
+
+	// Cancel the in-flight run, then signal the supervisor to re-run with the
+	// new spec. Non-blocking send coalesces concurrent updates.
+	if cancel != nil {
+		cancel()
+	}
+	select {
+	case t.restartCh <- struct{}{}:
+	default:
+	}
 }
 
 // stop cancels the tenant and waits for its goroutine to drain.

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -2,8 +2,12 @@ package server
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
 )
 
 // Tenant is one isolated agent inside the pooled process. M1 is lifecycle
@@ -40,14 +44,52 @@ func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger) *Ten
 	return t
 }
 
-// run is the tenant's supervised lifecycle. M1: no connector behaviour —
-// it logs attach, blocks until cancellation, then logs detach. Later
-// milestones replace the idle wait with the connector run loop.
+// run is the tenant's supervised lifecycle. M2: build a per-tenant agent,
+// attach this tenant's connectors to it, and run it under the tenant's
+// context. The agent + its connectors + their event bus are entirely
+// tenant-owned — nothing is shared with other tenants (the isolation rule).
+//
+// If the agent run loop returns before cancellation (e.g. a tenant with no
+// runnable connectors), the tenant still idles until cancelled so the
+// Server's view of attached tenants stays consistent.
 func (t *Tenant) run(ctx context.Context) {
 	defer close(t.done)
+
+	a := agent.New(t.log)
+	t.buildConnectors(a)
+
 	t.log.Info("tenant attached", "connectors", t.connectorTypes())
-	<-ctx.Done()
+	if err := a.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		t.log.Error("tenant agent stopped with error", "err", err)
+	}
+	if ctx.Err() == nil {
+		<-ctx.Done()
+	}
 	t.log.Info("tenant detaching")
+}
+
+// buildConnectors constructs this tenant's connectors from its spec and
+// registers them on the tenant-owned agent. Unsupported types are logged and
+// skipped (pooled mode ships connectors incrementally). A connector whose
+// spec is invalid is skipped rather than failing the whole tenant.
+func (t *Tenant) buildConnectors(a *agent.Agent) {
+	t.mu.Lock()
+	connectors := t.spec.Connectors
+	t.mu.Unlock()
+
+	for _, cs := range connectors {
+		switch cs.Type {
+		case "irc":
+			settings, err := settingsFromConnectorSpec(cs)
+			if err != nil {
+				t.log.Error("skipping invalid irc connector", "err", err)
+				continue
+			}
+			a.AddConnector(irc.New(settings, t.log, nil))
+		default:
+			t.log.Warn("connector type not supported in pooled mode yet", "type", cs.Type)
+		}
+	}
 }
 
 // update applies a new desired spec to a running tenant. M1 swaps the stored

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -3,69 +3,191 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
+	"time"
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
 )
 
-// Tenant is one isolated agent inside the pooled process. M1 is lifecycle
-// only: it owns a cancellable context and a supervised goroutine that starts,
-// idles until cancelled, and stops cleanly. Connector wiring (M2), crash
-// isolation (M3), and per-tenant limits (M4) build on this shell.
+// TenantStatus is the supervised lifecycle phase of a tenant.
+type TenantStatus int
+
+const (
+	// StatusRunning: the tenant's work loop is executing.
+	StatusRunning TenantStatus = iota
+	// StatusQuarantined: the work loop panicked; the tenant is paused for a
+	// backoff interval before the supervisor revives it.
+	StatusQuarantined
+)
+
+func (s TenantStatus) String() string {
+	switch s {
+	case StatusRunning:
+		return "running"
+	case StatusQuarantined:
+		return "quarantined"
+	default:
+		return "unknown"
+	}
+}
+
+// Tenant is one isolated agent inside the pooled process, self-supervised so
+// a panic in its work loop quarantines ONLY this tenant — never the process
+// or its siblings (M3). The agent + connectors + event bus it owns are
+// tenant-private; a Tenant must never reference another tenant's state.
 //
-// Discipline rule (enforced from M2 on): anything a Tenant holds is
-// tenant-owned; shared subsystems live on the Server. A Tenant must never
-// reference another tenant's state.
+// Caveat (tracked for plan E4): only panics on the tenant's own work
+// goroutine are recovered here. Panics in goroutines the agent/connectors
+// spawn internally are caught once those packages adopt the same goSafe
+// discipline; until then this is the supervision boundary, not a guarantee.
 type Tenant struct {
 	ID  string
 	log *slog.Logger
 
+	// work is the unit of supervised work, re-invoked on each (re)start.
+	// Injected so tests can substitute a panicking or controllable body.
+	work func(context.Context) error
+
+	quarantineBase time.Duration
+
 	cancel context.CancelFunc
 	done   chan struct{}
 
-	mu   sync.Mutex
-	spec TenantSpec
+	mu              sync.Mutex
+	spec            TenantSpec
+	status          TenantStatus
+	failures        int
+	lastErr         error
+	quarantineUntil time.Time
 }
 
-// startTenant launches a tenant goroutine under a child of parent. The
-// returned Tenant is running; call stop() to drain it.
-func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger) *Tenant {
+// startTenant launches a self-supervising tenant under a child of parent.
+// workFactory builds the body to run (and re-run after a panic) from the
+// constructed Tenant; quarantineBase is the first backoff step (doubled per
+// consecutive failure, capped).
+func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger, quarantineBase time.Duration, workFactory func(*Tenant) func(context.Context) error) *Tenant {
 	ctx, cancel := context.WithCancel(parent)
 	t := &Tenant{
-		ID:     spec.TurborgID,
-		log:    log.With("turborg_id", spec.TurborgID),
-		cancel: cancel,
-		done:   make(chan struct{}),
-		spec:   spec,
+		ID:             spec.TurborgID,
+		log:            log.With("turborg_id", spec.TurborgID),
+		quarantineBase: quarantineBase,
+		cancel:         cancel,
+		done:           make(chan struct{}),
+		spec:           spec,
+		status:         StatusRunning,
 	}
-	go t.run(ctx)
+	t.work = workFactory(t)
+	go t.supervise(ctx)
 	return t
 }
 
-// run is the tenant's supervised lifecycle. M2: build a per-tenant agent,
-// attach this tenant's connectors to it, and run it under the tenant's
-// context. The agent + its connectors + their event bus are entirely
-// tenant-owned — nothing is shared with other tenants (the isolation rule).
-//
-// If the agent run loop returns before cancellation (e.g. a tenant with no
-// runnable connectors), the tenant still idles until cancelled so the
-// Server's view of attached tenants stays consistent.
-func (t *Tenant) run(ctx context.Context) {
+// supervise runs the tenant's work loop, recovering panics and quarantining
+// (with exponential backoff) before reviving. Returns when ctx is cancelled.
+func (t *Tenant) supervise(ctx context.Context) {
 	defer close(t.done)
 
-	a := agent.New(t.log)
-	t.buildConnectors(a)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
 
-	t.log.Info("tenant attached", "connectors", t.connectorTypes())
-	if err := a.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		t.log.Error("tenant agent stopped with error", "err", err)
+		panicked := t.runOnce(ctx)
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		if !panicked {
+			// Work returned without panic and the tenant wasn't cancelled
+			// (e.g. no runnable connectors). Idle until cancelled so the
+			// Server's view of attached tenants stays consistent.
+			<-ctx.Done()
+			return
+		}
+
+		backoff := t.enterQuarantine()
+		t.log.Warn("tenant quarantined after panic", "backoff", backoff, "failures", t.Failures())
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+			t.markRunning()
+			t.log.Info("reviving quarantined tenant")
+		}
 	}
-	if ctx.Err() == nil {
-		<-ctx.Done()
+}
+
+// runOnce executes the work body once, recovering any panic. Returns true if
+// the body panicked.
+func (t *Tenant) runOnce(ctx context.Context) (panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panicked = true
+			t.setErr(fmt.Errorf("panic: %v", r))
+			t.log.Error("recovered tenant panic", "panic", r, "stack", string(debug.Stack()))
+		}
+	}()
+
+	if err := t.work(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		t.setErr(err)
+		t.log.Error("tenant work returned error", "err", err)
 	}
-	t.log.Info("tenant detaching")
+	return false
+}
+
+// enterQuarantine records the panic, bumps the failure count, computes the
+// next backoff (base * 2^(failures-1), capped at 32× base), stamps the
+// quarantine deadline, and returns the backoff duration.
+func (t *Tenant) enterQuarantine() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.failures++
+	backoff := t.quarantineBase << min(t.failures-1, 5) // cap at 32× base
+	t.status = StatusQuarantined
+	t.quarantineUntil = time.Now().Add(backoff)
+	return backoff
+}
+
+func (t *Tenant) markRunning() {
+	t.mu.Lock()
+	t.status = StatusRunning
+	t.mu.Unlock()
+}
+
+func (t *Tenant) setErr(err error) {
+	t.mu.Lock()
+	t.lastErr = err
+	t.mu.Unlock()
+}
+
+// Status reports the tenant's current supervision phase.
+func (t *Tenant) Status() TenantStatus {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.status
+}
+
+// Failures reports how many times the work loop has panicked.
+func (t *Tenant) Failures() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.failures
+}
+
+// defaultTenantWork builds the production work body: a tenant-owned agent
+// with this tenant's connectors, run under the tenant context. Rebuilt on
+// each (re)start so a revived tenant gets a fresh agent.
+func (t *Tenant) defaultWork() func(context.Context) error {
+	return func(ctx context.Context) error {
+		a := agent.New(t.log)
+		t.buildConnectors(a)
+		t.log.Info("tenant attached", "connectors", t.connectorTypes())
+		return a.Run(ctx)
+	}
 }
 
 // buildConnectors constructs this tenant's connectors from its spec and
@@ -92,7 +214,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 	}
 }
 
-// update applies a new desired spec to a running tenant. M1 swaps the stored
+// update applies a new desired spec to a running tenant. M3 swaps the stored
 // spec and logs; connector-aware diffing (JOIN/PART, nick, rate limits) is
 // the hot-reload milestone (M7).
 func (t *Tenant) update(spec TenantSpec) {

--- a/internal/server/tenant_irc_test.go
+++ b/internal/server/tenant_irc_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/tests/fixtures/fakeirc"
+)
+
+func ircTenantSpec(id string, port int, nick, channel string) TenantSpec {
+	return TenantSpec{
+		TurborgID:   id,
+		RuntimeMode: "pooled",
+		Connectors: []ConnectorSpec{{
+			Type: "irc",
+			Config: map[string]any{
+				"network":   fmt.Sprintf("127.0.0.1:%d", port),
+				"use_tls":   false,
+				"nick":      nick,
+				"username":  nick,
+				"real_name": "pooled tenant",
+				"channels":  []any{channel},
+			},
+			Secrets: map[string]any{},
+		}},
+	}
+}
+
+func lineContaining(sub string) func([]string) bool {
+	return func(lines []string) bool {
+		for _, l := range lines {
+			if strings.Contains(l, sub) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// TestTwoTenantsConnectIndependently is the M2 deliverable: two pooled
+// tenants in one Server, each pointed at its own upstream, both register and
+// JOIN — and neither tenant's traffic leaks onto the other's server.
+func TestTwoTenantsConnectIndependently(t *testing.T) {
+	fsA := fakeirc.New(t)
+	defer fsA.Close()
+	fsB := fakeirc.New(t)
+	defer fsB.Close()
+
+	src := &StaticSource{Tenants: []TenantSpec{
+		ircTenantSpec("tenant-a", fsA.Port(), "nicka", "#aaa"),
+		ircTenantSpec("tenant-b", fsB.Port(), "nickb", "#bbb"),
+	}}
+	srv := New(src, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.True(t, fsA.WaitFor(lineContaining("JOIN #aaa"), 3*time.Second),
+		"tenant A did not JOIN its channel; received: %v", fsA.Received())
+	require.True(t, fsB.WaitFor(lineContaining("JOIN #bbb"), 3*time.Second),
+		"tenant B did not JOIN its channel; received: %v", fsB.Received())
+
+	// No cross-talk: each upstream sees only its own tenant's identity and
+	// channel. (A short wait that must NOT become true.)
+	require.False(t, fsA.WaitFor(lineContaining("#bbb"), 250*time.Millisecond),
+		"tenant B's channel leaked onto tenant A's server: %v", fsA.Received())
+	require.False(t, fsA.WaitFor(lineContaining("nickb"), 250*time.Millisecond),
+		"tenant B's nick leaked onto tenant A's server: %v", fsA.Received())
+	require.False(t, fsB.WaitFor(lineContaining("nicka"), 250*time.Millisecond),
+		"tenant A's nick leaked onto tenant B's server: %v", fsB.Received())
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("server did not drain within 3s of cancel")
+	}
+}

--- a/internal/server/tenant_limits.go
+++ b/internal/server/tenant_limits.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// applyPlanLimits enforces a tenant's plan-tier caps on one IRC connector
+// (M4). In container mode the host's cgroups + the connector env handle this;
+// in pooled mode N tenants share one process, so the per-tenant outbound
+// throttle and channel/identity locks must be enforced in-process — the same
+// mechanism the single-tenant runtime wires from env, sourced here from the
+// tenant spec instead.
+//
+// nil caps (self-host / spec without a plan block) leaves the connector at
+// its unrestricted defaults.
+func applyPlanLimits(conn *irc.Connector, caps *PlanCapabilities) error {
+	if caps == nil {
+		return nil
+	}
+
+	conn.SetClientLimits(irc.ClientLimits{
+		NickLocked:     caps.NickLocked,
+		RealnameLocked: caps.RealnameLocked,
+		MaxChannels:    caps.MaxChannels,
+	})
+
+	if caps.OutboundMsgsPerWindow > 0 && caps.OutboundWindowSeconds > 0 {
+		throttle, err := irc.NewThrottle(
+			caps.OutboundMsgsPerWindow,
+			time.Duration(caps.OutboundWindowSeconds)*time.Second,
+			nil,
+		)
+		if err != nil {
+			return fmt.Errorf("outbound throttle: %w", err)
+		}
+		conn.SetOutboundThrottle(throttle)
+	}
+
+	return nil
+}

--- a/internal/server/tenant_limits_test.go
+++ b/internal/server/tenant_limits_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+func newBareConnector() *irc.Connector {
+	return irc.New(&irc.Settings{Hostname: "h", Port: 6697, Nick: "n"}, nil, nil)
+}
+
+func TestApplyPlanLimitsSetsThrottleAndLocks(t *testing.T) {
+	conn := newBareConnector()
+	err := applyPlanLimits(conn, &PlanCapabilities{
+		NickLocked:            true,
+		RealnameLocked:        true,
+		MaxChannels:           5,
+		OutboundMsgsPerWindow: 5,
+		OutboundWindowSeconds: 30,
+	})
+	require.NoError(t, err)
+
+	limits := conn.ClientLimits()
+	require.True(t, limits.NickLocked)
+	require.True(t, limits.RealnameLocked)
+	require.Equal(t, 5, limits.MaxChannels)
+	require.NotNil(t, conn.OutboundThrottle(), "outbound throttle should be installed")
+}
+
+func TestApplyPlanLimitsNilCapsLeavesDefaults(t *testing.T) {
+	conn := newBareConnector()
+	require.NoError(t, applyPlanLimits(conn, nil))
+
+	require.Equal(t, 0, conn.ClientLimits().MaxChannels)
+	require.Nil(t, conn.OutboundThrottle(), "no throttle without caps")
+}
+
+func TestApplyPlanLimitsNoThrottleWhenWindowZero(t *testing.T) {
+	conn := newBareConnector()
+	require.NoError(t, applyPlanLimits(conn, &PlanCapabilities{
+		MaxChannels:           10,
+		OutboundMsgsPerWindow: 5,
+		OutboundWindowSeconds: 0, // disabled
+	}))
+
+	require.Equal(t, 10, conn.ClientLimits().MaxChannels)
+	require.Nil(t, conn.OutboundThrottle(), "throttle requires a positive window")
+}

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -14,6 +14,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/turborg/turborg/internal/safe"
 )
 
 // ConnectorSpec describes one connector instance a tenant runs. Mirrors the
@@ -110,10 +112,10 @@ func (f *FileSource) Initial(_ context.Context) ([]TenantSpec, error) {
 // cancelled. Filesystem-watch-driven hot reload is a later milestone.
 func (f *FileSource) Watch(ctx context.Context) (<-chan TenantEvent, error) {
 	ch := make(chan TenantEvent)
-	go func() {
+	safe.Go("filesource-watch", func() {
 		<-ctx.Done()
 		close(ch)
-	}()
+	})
 	return ch, nil
 }
 
@@ -137,9 +139,9 @@ func (s *StaticSource) Watch(ctx context.Context) (<-chan TenantEvent, error) {
 		return s.Events, nil
 	}
 	ch := make(chan TenantEvent)
-	go func() {
+	safe.Go("staticsource-watch", func() {
 		<-ctx.Done()
 		close(ch)
-	}()
+	})
 	return ch, nil
 }

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -1,0 +1,132 @@
+// Package server hosts the multi-tenant ("pooled") turborg runtime: one
+// long-lived process that holds N tenants, each an isolated agent. It runs
+// alongside the existing single-tenant binary (cmd/turborg), which stays the
+// default for hobbyist/OSS env-driven deployments.
+//
+// M1 (this milestone) is lifecycle-only: the Server attaches and detaches
+// tenants from a TenantSource and supervises their goroutines. Real connector
+// behaviour, crash isolation, per-tenant limits, and the SNI bouncer router
+// land in later milestones (see accounts-api/dev/PLAN-multi-tenancy.md WS2).
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// ConnectorSpec describes one connector instance a tenant runs. Mirrors the
+// sidecar/accounts-api wire shape; Type matches turborg's connector names.
+type ConnectorSpec struct {
+	Type    string         `json:"type"`
+	Config  map[string]any `json:"config"`
+	Secrets map[string]any `json:"secrets"`
+}
+
+// TenantSpec is the desired state of a single tenant. Keyed by the logical
+// TurborgID — never a runtime identifier. Wire-compatible with the sidecar
+// TenantSpec so an HTTPSource (M5) can decode the same JSON.
+type TenantSpec struct {
+	TurborgID     string          `json:"turborg_id"`
+	ShardID       int             `json:"shard_id,omitempty"`
+	RuntimeMode   string          `json:"runtime_mode"`
+	UserUUID      string          `json:"user_uuid"`
+	PlanCode      string          `json:"plan_code"`
+	CommandPrefix string          `json:"command_prefix,omitempty"`
+	Connectors    []ConnectorSpec `json:"connectors"`
+}
+
+// TenantEventKind distinguishes an attach/update from a detach.
+type TenantEventKind int
+
+const (
+	// TenantUpserted creates the tenant if new, or updates it in place.
+	TenantUpserted TenantEventKind = iota
+	// TenantRemoved detaches the tenant identified by TurborgID.
+	TenantRemoved
+)
+
+// TenantEvent is a single change emitted by a TenantSource after the initial
+// snapshot. For TenantUpserted, Spec is populated. For TenantRemoved, only
+// TurborgID is meaningful.
+type TenantEvent struct {
+	Kind      TenantEventKind
+	Spec      TenantSpec
+	TurborgID string
+}
+
+// TenantSource feeds the Server its desired tenant set. Initial returns the
+// full snapshot at boot; Watch streams subsequent changes. Three
+// implementations are planned (plan WS1 F1): env (single tenant), file
+// (this package), and HTTP long-poll against accounts-api (M5).
+type TenantSource interface {
+	Initial(ctx context.Context) ([]TenantSpec, error)
+	Watch(ctx context.Context) (<-chan TenantEvent, error)
+}
+
+// fileDoc is the on-disk shape read by FileSource.
+type fileDoc struct {
+	Tenants []TenantSpec `json:"tenants"`
+}
+
+// FileSource loads tenants from a JSON file. M1 reads the snapshot once at
+// boot; live reload on file change lands in a later milestone (the Watch
+// channel simply stays open until ctx is cancelled for now).
+//
+// JSON rather than the plan's YAML to avoid promoting the indirect yaml.v3
+// dependency to a direct one without sign-off; the wire shape is identical.
+type FileSource struct {
+	Path string
+}
+
+// Initial reads and decodes the tenants file.
+func (f *FileSource) Initial(_ context.Context) ([]TenantSpec, error) {
+	raw, err := os.ReadFile(f.Path)
+	if err != nil {
+		return nil, fmt.Errorf("read tenants file %q: %w", f.Path, err)
+	}
+	var doc fileDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse tenants file %q: %w", f.Path, err)
+	}
+	return doc.Tenants, nil
+}
+
+// Watch returns a channel that yields no events and closes when ctx is
+// cancelled. Filesystem-watch-driven hot reload is a later milestone.
+func (f *FileSource) Watch(ctx context.Context) (<-chan TenantEvent, error) {
+	ch := make(chan TenantEvent)
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, nil
+}
+
+// StaticSource serves a fixed snapshot plus an optional caller-controlled
+// event channel. Primarily a test and embedding seam.
+type StaticSource struct {
+	Tenants []TenantSpec
+	// Events, when non-nil, is returned by Watch so callers can drive
+	// upsert/remove events. When nil, Watch yields nothing until ctx ends.
+	Events chan TenantEvent
+}
+
+// Initial returns the fixed snapshot.
+func (s *StaticSource) Initial(_ context.Context) ([]TenantSpec, error) {
+	return s.Tenants, nil
+}
+
+// Watch returns the caller-controlled channel, or a ctx-closed empty one.
+func (s *StaticSource) Watch(ctx context.Context) (<-chan TenantEvent, error) {
+	if s.Events != nil {
+		return s.Events, nil
+	}
+	ch := make(chan TenantEvent)
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, nil
+}

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -28,13 +28,26 @@ type ConnectorSpec struct {
 // TurborgID — never a runtime identifier. Wire-compatible with the sidecar
 // TenantSpec so an HTTPSource (M5) can decode the same JSON.
 type TenantSpec struct {
-	TurborgID     string          `json:"turborg_id"`
-	ShardID       int             `json:"shard_id,omitempty"`
-	RuntimeMode   string          `json:"runtime_mode"`
-	UserUUID      string          `json:"user_uuid"`
-	PlanCode      string          `json:"plan_code"`
-	CommandPrefix string          `json:"command_prefix,omitempty"`
-	Connectors    []ConnectorSpec `json:"connectors"`
+	TurborgID        string            `json:"turborg_id"`
+	ShardID          int               `json:"shard_id,omitempty"`
+	RuntimeMode      string            `json:"runtime_mode"`
+	UserUUID         string            `json:"user_uuid"`
+	PlanCode         string            `json:"plan_code"`
+	CommandPrefix    string            `json:"command_prefix,omitempty"`
+	Connectors       []ConnectorSpec   `json:"connectors"`
+	PlanCapabilities *PlanCapabilities `json:"plan_capabilities,omitempty"`
+}
+
+// PlanCapabilities is the subset of accounts-api's plan-tier caps the pooled
+// runtime enforces per tenant (M4). Mirrors the sidecar PlanCapabilities wire
+// shape; container mode delegates these to cgroups + the connector's env,
+// pooled mode enforces them in-process. 0 = unrestricted by convention.
+type PlanCapabilities struct {
+	NickLocked            bool `json:"nick_locked"`
+	RealnameLocked        bool `json:"realname_locked"`
+	MaxChannels           int  `json:"max_channels"`
+	OutboundMsgsPerWindow int  `json:"outbound_msgs_per_window"`
+	OutboundWindowSeconds int  `json:"outbound_window_seconds"`
 }
 
 // TenantEventKind distinguishes an attach/update from a detach.


### PR DESCRIPTION
The pooled multi-tenant runtime (WS2 in the multi-tenancy plan): one process
that holds N tenants as isolated agents, running **alongside** the existing
single-tenant `turborg` binary — which is untouched and stays the default for
env-driven hobbyist/OSS deployments.

Built incrementally; each milestone is its own commit.

## Done

- **M1 — lifecycle** (`internal/server`): `TenantSource` (Initial snapshot +
  Watch stream), `FileSource` (JSON `TURBORG_TENANTS_FILE`), `StaticSource`
  (test/embed seam), `Server` (reconciles running tenants against the source —
  boots the initial set, applies upsert/remove events, drains on shutdown),
  `Tenant` (cancellable per-tenant supervised goroutine). `cmd/turborg-server`
  entrypoint.
- **M2 — tenant-scoped IRC connector**: each tenant builds its own
  `agent.Agent` + `irc.Connector` from its spec; a two-tenant fakeirc test
  proves no cross-talk. Connector logic stays central in
  `internal/connector/irc` — both runtimes call the same `irc.New(...)`.
- **M3 — crash isolation + quarantine**: a panicking/erroring tenant is
  quarantined with exponential backoff and revived, never taking down the
  process or its neighbours. `Server.workFactory` seam; goleak-guarded.
- **M3/E4 — `internal/safe.Go`**: process-wide panic policy — single-tenant
  keeps crash+restart (ExitPolicy); `turborg-server` sets RecoverPolicy so one
  tenant's panic can't kill the pool.
- **M4 — per-tenant plan limits**: `applyPlanLimits` wires each tenant's plan
  caps into the same `irc.Connector.SetClientLimits` / `SetOutboundThrottle`
  the single-tenant runtime uses — one source of truth, sourced from the spec
  instead of env.
- **M5 — HTTP tenant source**: `HTTPSource` poll-and-diff against the hosted
  control plane's `/v1/internal/tenants?host_id=X` feed.
- **M7 — hot config reload** (conservative): a spec change restarts the
  tenant's run; an identical spec is a DeepEqual no-op.
- **M8 — load harness** (`cmd/loadgen`): standalone fake IRC sink + N synthetic
  tenants + heap/goroutine report. Local run: 1000 tenants ≈ 30.7 MB heap
  (~31 KB/tenant), ~7 goroutines/tenant.
- **Image** ships `turborg-server` alongside `turborg` (pooled supervisor, S3).

## Remaining

- **M6 — in-process SNI bouncer listener**: terminate TLS on the pool process,
  read the SNI ServerName, hand the connection to the matching tenant. Until
  this lands, pooled tenants connect **out** to IRC fine, but a client cannot
  attach **in** to a pooled turborg. Dedicated containers are unaffected — they
  own their own host port. This is the one outstanding pooled-engine milestone.
- **Pooled resource governance** (separate follow-up): the abuse caps a shared
  process needs but a dedicated container gets free from cgroups — inbound
  command rate limit, slow-consumer bound, per-tenant memory budget,
  connector-count cap, `GOMEMLIMIT`/pool watchdog.

The pooled runtime stays **gated off** in production (`TURBORG_POOLED_ENABLED`
in accounts-api) until M6 + governance land and a real-hardware load test
passes. The single-tenant `cmd/turborg` path is untouched throughout.

## Verification

- `go test ./...`, `go vet ./...`, `gofmt`, golangci-lint all clean.
- Coverage gate green (~94% total).
- `goleak` (`TestMain`) verifies attach/detach + shutdown leak no goroutines.
