### PR TITLE
fix(irc): bound the upstream dial with DialTimeout

### DIFF
--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -533,7 +533,18 @@ func (c *Connector) bringUp(ctx context.Context) error {
 	)
 	c.machine.Transition(UpstreamStateConnecting)
 
-	cli, err := Dial(ctx, c.settings.Hostname, c.settings.Port, c.settings.UseTLS)
+	// Bound the dial so a node that accepts the TCP connection then stalls
+	// the TLS handshake can't hang the connect forever; on timeout it errors
+	// into the supervisor's backoff + DNS-re-resolve reconnect loop, which
+	// rotates to a healthy node. HandshakeTimeout covers only the post-connect
+	// registration reads, so the dial needs its own deadline.
+	dialTimeout := c.settings.DialTimeout
+	if dialTimeout <= 0 {
+		dialTimeout = 20 * time.Second
+	}
+	dctx, cancel := context.WithTimeout(ctx, dialTimeout)
+	cli, err := Dial(dctx, c.settings.Hostname, c.settings.Port, c.settings.UseTLS)
+	cancel()
 	if err != nil {
 		c.classifyFallback(err)
 		return err

--- a/internal/connector/irc/connector_dial_timeout_test.go
+++ b/internal/connector/irc/connector_dial_timeout_test.go
@@ -1,0 +1,51 @@
+package irc_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// TestBringUpDialTimeoutDoesNotHang covers the libera-throttle failure mode:
+// a node accepts the TCP connection but never completes the TLS handshake
+// (it zero-windows us mid-ClientHello). Without a dial deadline the connect
+// blocks indefinitely on DialContext; with DialTimeout it must error promptly
+// so the supervisor's backoff/re-resolve loop can rotate to a healthy node.
+func TestBringUpDialTimeoutDoesNotHang(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	// Accept and hold connections open, never responding — the stall.
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer func() { _ = c.Close() }()
+		}
+	}()
+
+	conn := irc.New(&irc.Settings{
+		Hostname:    "127.0.0.1",
+		Port:        ln.Addr().(*net.TCPAddr).Port,
+		UseTLS:      true,
+		Nick:        "turborg",
+		DialTimeout: 200 * time.Millisecond,
+	}, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+
+	start := time.Now()
+	err = conn.Start(context.Background())
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a stalled TLS dial must error, not hang")
+	require.Less(t, elapsed, 3*time.Second,
+		"dial must abort at the ~200ms deadline, not block indefinitely (took %s)", elapsed)
+}

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -40,6 +40,12 @@ type Settings struct {
 
 	Channels []string `env:"CHANNELS" envSeparator:","`
 
+	// DialTimeout bounds the TCP+TLS connect itself. HandshakeTimeout
+	// covers the post-connect registration reads, not the dial, so a node
+	// that accepts the TCP connection then stalls the TLS handshake (e.g.
+	// a server zero-windowing us under connection throttling) needs this
+	// separate bound or the connect hangs indefinitely.
+	DialTimeout        time.Duration `env:"DIAL_TIMEOUT"         envDefault:"20s"`
 	HandshakeTimeout   time.Duration `env:"HANDSHAKE_TIMEOUT"    envDefault:"30s"`
 	ReadIdleTimeout    time.Duration `env:"READ_IDLE_TIMEOUT"    envDefault:"300s"`
 	ClientPingInterval time.Duration `env:"CLIENT_PING_INTERVAL" envDefault:"120s"`


### PR DESCRIPTION
## Problem

`bringUp` passed the connector's **lifetime** context straight to `Dial`, so the TCP+TLS connect had **no deadline**. A node that accepts the TCP connection then stalls the TLS handshake — e.g. a server zero-windowing us under connection throttling (observed against Libera from a shared dev IP) — hangs the connect **indefinitely**, stuck in `connecting` with no error. `HandshakeTimeout` only bounds the *post-connect* registration reads, not the dial itself.

## Fix

- Add `Settings.DialTimeout` (`DIAL_TIMEOUT`, default **20s**).
- Wrap the dial in `bringUp` with a per-attempt `context.WithTimeout`.

On timeout the dial errors into the **existing** supervisor machinery — exponential backoff with ±20% jitter (capped 60s) and DNS re-resolve on each attempt — so it rotates to a healthy node instead of wedging on a bad one. No change to the reconnect/backoff logic, which was already solid.

## Test

`TestBringUpDialTimeoutDoesNotHang`: a listener that accepts TCP but never completes the TLS handshake; `Start` must error at the ~200ms deadline rather than block. Without the fix this test hangs.

go test / vet / gofmt / golangci-lint clean.