### PR TITLE
fix(irc): surface service/user NOTICEs in the web UI

### DIFF
--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1481,15 +1481,25 @@ func (c *Connector) dispatchLine(ctx context.Context, line string) {
 		// sees the reason in the chat surface too.
 		c.publishServerNotice(ctx, "error", serverNoticeText(msg))
 	case CmdNotice:
-		// Server-originated NOTICE (no `!user@host` in the prefix) —
-		// pre-registration "NOTICE AUTH :*** Looking up your
-		// hostname" lines, services bot greetings, etc. — flow into
-		// the server tab. Client-originated NOTICEs (with a user
-		// hostmask prefix) are intentionally left unhandled here:
-		// the bot has no PRIVMSG-equivalent path for NOTICE today,
-		// and silently dropping matches the pre-existing behaviour.
-		if isServerPrefix(msg.Prefix) {
+		// NOTICEs surface in the status/server tab so the web UI shows them
+		// like an attached IRC client does:
+		//   - server-prefixed (no `!user@host`): pre-reg "Looking up your
+		//     hostname", server/services info lines.
+		//   - service/user-prefixed (NickServ, ChanServ, a user's /notice):
+		//     real messages the user expects to see — prefix with the sender.
+		// CTCP notices (\x01..\x01) are machine replies to VERSION/PING/TIME,
+		// not chat, so they're skipped.
+		switch {
+		case isServerPrefix(msg.Prefix):
 			c.publishServerNotice(ctx, "notice", serverNoticeText(msg))
+		case isCTCP(msg.Trailing):
+			// machine metadata, not chat — drop
+		default:
+			body := serverNoticeText(msg)
+			if sender := Nick(msg.Prefix); sender != "" {
+				body = sender + ": " + body
+			}
+			c.publishServerNotice(ctx, "notice", body)
 		}
 	case CmdPrivmsg:
 		c.handlePrivmsg(ctx, msg, line)

--- a/internal/connector/irc/notice_web_test.go
+++ b/internal/connector/irc/notice_web_test.go
@@ -1,0 +1,58 @@
+package irc_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// Service/user NOTICEs (NickServ replies, ChanServ, a user's /notice) must
+// reach the web gateway so the web UI shows them — an attached IRC client
+// (the bouncer path) already does. CTCP notices stay filtered: they're
+// machine replies (VERSION/PING/TIME), not chat.
+func TestServiceNoticeReachesGatewayButCTCPDoesNot(t *testing.T) {
+	fs, _, a, td := driveConnector(t, &irc.Settings{})
+	defer td()
+
+	var mu sync.Mutex
+	var notices []string
+	a.Events.Subscribe(agent.EventServerNotice, func(_ context.Context, ev *agent.Event) {
+		if ev.Fields["kind"] != "notice" {
+			return
+		}
+		text, _ := ev.Fields["text"].(string)
+		mu.Lock()
+		notices = append(notices, text)
+		mu.Unlock()
+	})
+
+	// NickServ reply — service hostmask prefix → must surface, with sender.
+	require.NoError(t, fs.SendLine(":NickServ!NickServ@services.libera.chat NOTICE turborg :This nickname is registered."))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, n := range notices {
+			if n == "NickServ: This nickname is registered." {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond, "service NOTICE should reach the gateway with sender; got %v", notices)
+
+	mu.Lock()
+	before := len(notices)
+	mu.Unlock()
+
+	// CTCP notice (machine reply) → must NOT surface as chat.
+	require.NoError(t, fs.SendLine(":bob!u@h NOTICE turborg :\x01VERSION turbo 1.0\x01"))
+	require.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(notices) > before
+	}, 250*time.Millisecond, 25*time.Millisecond, "CTCP notice must not surface as chat")
+}


### PR DESCRIPTION
## Problem

Inbound NOTICEs were only published to the web gateway when **server-prefixed** (`isServerPrefix`). Service/user-prefixed NOTICEs — NickServ/ChanServ replies, a user's `/notice` — have a `nick!user@host` prefix, so they fell through and were silently dropped. The original comment flagged this as a conservative stub ('no PRIVMSG-equivalent path… matches pre-existing behaviour'), not a deliberate hide.

Symptom: an attached IRC client (HexChat, via the bouncer) shows e.g. `/msg nickserv help` replies, but the **web UI does not** — the bouncer forwards all NOTICEs, the gateway path dropped these.

## Fix

In the `CmdNotice` dispatch:
- **server-prefixed** → status tab (unchanged).
- **service/user-prefixed** → status tab, prefixed with the sender (`NickServ: …`) so it's clear who sent it. Uses the existing `EventServerNotice` path the web gateway + appui already render — no appui change.
- **CTCP notices** (`\x01…\x01` — VERSION/PING/TIME machine replies) stay filtered; they're protocol metadata, not chat.

## Test

`TestServiceNoticeReachesGatewayButCTCPDoesNot`: a NickServ NOTICE reaches the gateway with the sender folded in; a CTCP NOTICE does not surface. go test / vet / gofmt / golangci-lint clean.