### PR TITLE
fix(irc): data race in NOTICE web test (red main from #32)

### DIFF
--- a/internal/connector/irc/notice_web_test.go
+++ b/internal/connector/irc/notice_web_test.go
@@ -42,7 +42,7 @@ func TestServiceNoticeReachesGatewayButCTCPDoesNot(t *testing.T) {
 			}
 		}
 		return false
-	}, 2*time.Second, 10*time.Millisecond, "service NOTICE should reach the gateway with sender; got %v", notices)
+	}, 2*time.Second, 10*time.Millisecond, "service NOTICE should reach the gateway with sender")
 
 	mu.Lock()
 	before := len(notices)


### PR DESCRIPTION
## Why

The post-merge CI run for #32 went **red on `main`** (Go 1.25.x race-detector leg). #32's own PR run was green — the race is timing-dependent and didn't trip there, nor on the Go 1.26.x leg.

## What

`TestServiceNoticeReachesGatewayButCTCPDoesNot` passed the live `notices` slice as a printf arg to `require.Eventually`. That arg is read (slice header) **without the mutex** at call time, while the connector's publish goroutine is still appending to `notices` under the lock → data race.

Fix: drop the live slice from the failure message. The assertion body already reads `notices` under `mu`.

## Verification

- `go test -race -count=20` on the test: clean (was failing ~1/5 before).
- No production code touched; test-only.