### PR TITLE
fix(irc): per-client WHOIS/WHO + surface bot's own CTCP replies

### DIFF
--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -433,7 +433,31 @@ func (c *Connector) SendRaw(line string) error {
 	if cli == nil {
 		return errors.New("irc: not connected")
 	}
+	// WHOIS/WHO sent through SendRaw are WEB-originated (the gateway forwards
+	// client ops here). Register the target so the reply numerics are
+	// accumulated + published as EventWhois/WhoResult for the web UI. Bouncer
+	// clients' queries bypass SendRaw (their own upstream closure, see
+	// AttachUpstream), so they fan out to the IRC client but never pop a web
+	// modal — they're per-client request/response, not shared state.
+	c.registerWebQuery(line)
 	return cli.WriteLine(line)
+}
+
+// registerWebQuery marks a WHOIS/WHO target as web-requested so its reply is
+// surfaced to the web UI. No-op for any other command.
+func (c *Connector) registerWebQuery(line string) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return
+	}
+	switch strings.ToUpper(fields[0]) {
+	case CmdWhois:
+		// WHOIS [server] target — the queried nick is the last field.
+		c.markWhoisRequested(fields[len(fields)-1])
+	case CmdWho:
+		// WHO target [flags] — the target/mask is the first arg.
+		c.markWhoRequested(fields[1])
+	}
 }
 
 func (c *Connector) Send(env *agent.OutboundEnvelope) error {
@@ -1682,6 +1706,11 @@ func (c *Connector) handlePrivmsg(ctx context.Context, msg Message, raw string) 
 		if c.settings.CTCPAutoReply && c.ctcp != nil && c.ctcp.Allow(strings.ToLower(sender)) {
 			if reply := ctcpReply(text); reply != "" {
 				_ = c.client.WriteLine(fmt.Sprintf("%s %s :\x01%s\x01", CmdNotice, sender, reply))
+				// Surface our own reply in the web UI. Otherwise the bot
+				// answers silently and the user only sees it from an attached
+				// IRC client (the reply is outbound, so nothing else publishes
+				// it). Mirrors how incoming CTCP notices are shown.
+				c.publishServerNotice(ctx, "notice", fmt.Sprintf("[CTCP] replied to %s: %s", sender, reply))
 			}
 		}
 		return
@@ -1962,10 +1991,26 @@ func (c *Connector) handleWhoisNumeric(ctx context.Context, msg Message) {
 		return
 	}
 	targetNick := msg.Params[1]
-	b := c.whoisBuilderFor(targetNick)
+	b, ok := c.whoisBuilderLookup(targetNick)
+	if !ok {
+		// No web-originated WHOIS for this nick — bouncer-forwarded or
+		// unsolicited. The numerics already fanned out to bouncer clients;
+		// don't pop a web modal.
+		return
+	}
 	if b.nick == "" {
 		b.nick = targetNick
 	}
+	if applyWhoisNumeric(b, msg) {
+		// RPL_ENDOFWHOIS — the response is complete; snapshot + publish.
+		c.publishWhoisResult(ctx, targetNick, b, "")
+	}
+}
+
+// applyWhoisNumeric folds one WHOIS numeric into the builder. Returns true on
+// RPL_ENDOFWHOIS (318), telling the caller to publish + clear. Pure (no IO) —
+// extracted so handleWhoisNumeric stays under the cyclomatic-complexity gate.
+func applyWhoisNumeric(b *whoisBuilder, msg Message) bool {
 	switch msg.Command {
 	case RplWhoisUser:
 		// 311 mynick target user host * :realname
@@ -2008,8 +2053,9 @@ func (c *Connector) handleWhoisNumeric(ctx context.Context, msg Message) {
 	case RplWhoisSecure:
 		b.secure = true
 	case RplEndOfWhois:
-		c.publishWhoisResult(ctx, targetNick, b, "")
+		return true
 	}
+	return false
 }
 
 // handleWhoisNoSuchNick finalises an in-flight whois with an error and
@@ -2025,22 +2071,30 @@ func (c *Connector) handleWhoisNoSuchNick(ctx context.Context, targetNick, reaso
 	c.publishWhoisResult(ctx, targetNick, b, reason)
 }
 
-// whoisBuilderFor returns (creating if needed) the in-flight builder
-// for the target nick. Concurrent /whois calls on different nicks are
-// safely isolated by the map.
-func (c *Connector) whoisBuilderFor(targetNick string) *whoisBuilder {
+// markWhoisRequested registers an in-flight WHOIS for a web-originated query,
+// so handleWhoisNumeric accumulates + publishes its reply. Bouncer-forwarded
+// WHOIS are intentionally NOT registered. Concurrent /whois on different nicks
+// are isolated by the map.
+func (c *Connector) markWhoisRequested(targetNick string) {
 	key := strings.ToLower(targetNick)
 	c.whoisMu.Lock()
 	defer c.whoisMu.Unlock()
 	if c.whoisInFlight == nil {
 		c.whoisInFlight = make(map[string]*whoisBuilder)
 	}
-	b, ok := c.whoisInFlight[key]
-	if !ok {
-		b = &whoisBuilder{}
-		c.whoisInFlight[key] = b
+	if _, ok := c.whoisInFlight[key]; !ok {
+		c.whoisInFlight[key] = &whoisBuilder{}
 	}
-	return b
+}
+
+// whoisBuilderLookup returns the in-flight builder for a target, or (nil,
+// false) when no web-originated WHOIS registered it (so the reply is ignored
+// for web emission).
+func (c *Connector) whoisBuilderLookup(targetNick string) (*whoisBuilder, bool) {
+	c.whoisMu.Lock()
+	defer c.whoisMu.Unlock()
+	b, ok := c.whoisInFlight[strings.ToLower(targetNick)]
+	return b, ok
 }
 
 func (c *Connector) publishWhoisResult(ctx context.Context, targetNick string, b *whoisBuilder, errReason string) {
@@ -2170,7 +2224,11 @@ func (c *Connector) handleWhoNumeric(ctx context.Context, msg Message) {
 				entry.realName = msg.Trailing
 			}
 		}
-		b := c.whoBuilderFor(target)
+		b, ok := c.whoBuilderLookup(target)
+		if !ok {
+			// bouncer-forwarded WHO — no web emission.
+			return
+		}
 		b.users = append(b.users, entry)
 	case RplEndOfWho:
 		// 315 mynick target :End of /WHO list
@@ -2185,7 +2243,8 @@ func (c *Connector) handleWhoNumeric(ctx context.Context, msg Message) {
 		}
 		c.whoMu.Unlock()
 		if !ok {
-			b = &whoBuilder{target: target}
+			// bouncer-forwarded WHO — no web emission.
+			return
 		}
 		users := make([]map[string]any, 0, len(b.users))
 		for _, u := range b.users {
@@ -2215,19 +2274,28 @@ func (c *Connector) handleWhoNumeric(ctx context.Context, msg Message) {
 	}
 }
 
-func (c *Connector) whoBuilderFor(target string) *whoBuilder {
+// markWhoRequested registers an in-flight WHO for a web-originated query. As
+// with WHOIS, bouncer-forwarded WHO are NOT registered, so handleWhoNumeric
+// ignores their replies for web emission.
+func (c *Connector) markWhoRequested(target string) {
 	key := strings.ToLower(target)
 	c.whoMu.Lock()
 	defer c.whoMu.Unlock()
 	if c.whoInFlight == nil {
 		c.whoInFlight = make(map[string]*whoBuilder)
 	}
-	b, ok := c.whoInFlight[key]
-	if !ok {
-		b = &whoBuilder{target: target}
-		c.whoInFlight[key] = b
+	if _, ok := c.whoInFlight[key]; !ok {
+		c.whoInFlight[key] = &whoBuilder{target: target}
 	}
-	return b
+}
+
+// whoBuilderLookup returns the in-flight builder for a target, or (nil, false)
+// when no web-originated WHO registered it.
+func (c *Connector) whoBuilderLookup(target string) (*whoBuilder, bool) {
+	c.whoMu.Lock()
+	defer c.whoMu.Unlock()
+	b, ok := c.whoInFlight[strings.ToLower(target)]
+	return b, ok
 }
 
 func (c *Connector) handleTopic(ctx context.Context, msg Message) {

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -186,6 +186,7 @@ func connectorWithBus(t *testing.T, eventType agent.EventType) (*Connector, <-ch
 func TestHandleWhoisNumericAccumulatesAndFlushesOnEnd(t *testing.T) {
 	c, ch := connectorWithBus(t, agent.EventWhoisResult)
 	ctx := context.Background()
+	c.markWhoisRequested("alice") // web-originated WHOIS registers; bouncer ones don't
 
 	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisUser, Params: []string{"me", "alice", "~uid", "host.tld", "*"}, Trailing: "Alice Wonderland"})
 	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisServer, Params: []string{"me", "alice", "ergo.test"}, Trailing: "Test Server"})
@@ -230,11 +231,11 @@ func TestHandleWhoisNumericAccumulatesAndFlushesOnEnd(t *testing.T) {
 func TestHandleWhoisNoSuchNick(t *testing.T) {
 	c, ch := connectorWithBus(t, agent.EventWhoisResult)
 	ctx := context.Background()
+	c.markWhoisRequested("phantom") // web-originated WHOIS registers intent
 
-	// Open a whois that the server will fail. The handler buffers
-	// nothing until at least one numeric arrives; simulate a 401
-	// straight away — common when the user types /whois on a nick
-	// the server has never seen.
+	// Open a whois that the server will fail. Simulate a 401 straight
+	// away — common when the user types /whois on a nick the server has
+	// never seen.
 	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisUser, Params: []string{"me", "phantom", "~u", "h", "*"}, Trailing: "P"})
 	c.handleWhoisNoSuchNick(ctx, "phantom", "No such nick/channel")
 
@@ -278,9 +279,28 @@ func TestHandleListNumericAggregatesAcrossBatch(t *testing.T) {
 	assert.Equal(t, 12, channels[2]["users"])
 }
 
+func TestHandleWhoisNumericIgnoresUnregisteredTarget(t *testing.T) {
+	// A bouncer-forwarded WHOIS bypasses SendRaw, so it never registers intent.
+	// Its reply numerics must NOT publish EventWhoisResult (no web modal) — they
+	// only fan out to bouncer clients via the separate Broadcast path.
+	c, ch := connectorWithBus(t, agent.EventWhoisResult)
+	ctx := context.Background()
+	// Deliberately NO markWhoisRequested("mallory").
+
+	c.handleWhoisNumeric(ctx, Message{Command: RplWhoisUser, Params: []string{"me", "mallory", "~m", "h.tld", "*"}, Trailing: "M"})
+	c.handleWhoisNumeric(ctx, Message{Command: RplEndOfWhois, Params: []string{"me", "mallory"}, Trailing: "End of /WHOIS list"})
+
+	select {
+	case ev := <-ch:
+		t.Fatalf("unregistered (bouncer) WHOIS must not emit to web: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestHandleWhoNumericAggregatesPerTarget(t *testing.T) {
 	c, ch := connectorWithBus(t, agent.EventWhoResult)
 	ctx := context.Background()
+	c.markWhoRequested("#test")
 
 	// /who #test
 	c.handleWhoNumeric(ctx, Message{
@@ -313,6 +333,8 @@ func TestHandleWhoNumericTwoTargetsInFlight(t *testing.T) {
 	// member lists into each other.
 	c, ch := connectorWithBus(t, agent.EventWhoResult)
 	ctx := context.Background()
+	c.markWhoRequested("#a")
+	c.markWhoRequested("#b")
 
 	c.handleWhoNumeric(ctx, Message{Command: RplWhoReply, Params: []string{"me", "#a", "~a", "h", "s", "alice", "H"}, Trailing: "0 A"})
 	c.handleWhoNumeric(ctx, Message{Command: RplWhoReply, Params: []string{"me", "#b", "~b", "h", "s", "bob", "H"}, Trailing: "0 B"})


### PR DESCRIPTION
Two web-UX fixes in the IRC connector.

## 1. WHOIS/WHO are per-client again
Issuing `/whois` (or `/who`) from a **bouncer** client (HexChat) was popping a WHOIS modal in the **web UI** too. Cause: `whoisBuilderFor` lazily built a result for *any* reply numeric, so `EventWhoisResult` fired regardless of who asked.

Fix: web-originated queries flow through `SendRaw`, which now **registers intent** (`markWhoisRequested`/`markWhoRequested`). `handleWhoisNumeric`/`handleWhoNumeric` only accumulate + publish for registered targets. Bouncer queries bypass `SendRaw` (their own `AttachUpstream` closure), so they fan out to the IRC client via Broadcast but never emit a web event.

## 2. The bot's own CTCP replies show in the web
turborg's CTCP auto-reply (e.g. `VERSION turborg 0.2.1`) was sent outbound via `WriteLine` and never surfaced, so the web user only saw it from an attached client. It now publishes a notice, mirroring how incoming CTCP notices are shown.

`handleWhoisNumeric`'s switch is extracted into a pure `applyWhoisNumeric` helper to stay under gocyclo.

## Tests
- New `TestHandleWhoisNumericIgnoresUnregisteredTarget` (bouncer-style whois → no web emission).
- Existing whois/who tests register intent first. `go test ./internal/connector/irc ./internal/web` green; vet + gofmt + golangci-lint clean.