### PR TITLE
feat: pooled bouncer ingress (M6 — SNI/PROXY-v2 routing)

### DIFF
--- a/cmd/turborg-server/main.go
+++ b/cmd/turborg-server/main.go
@@ -80,10 +80,27 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	source, desc := selectSource(log)
 	log.Info("turborg-server starting", "version", version.Version, "source", desc)
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+	ctx, cancel := context.WithCancel(sigCtx)
+	defer cancel()
 
 	srv := server.New(source, log)
+
+	// Pooled bouncer ingress: one PROXY-v2 router fronts every tenant (HAProxy
+	// terminates TLS and forwards the SNI as the PROXY authority). Runs
+	// alongside the tenant supervisor; a bind failure cancels the process so we
+	// fail fast rather than serve tenants nobody can attach to. Empty addr
+	// disables it (e.g. a file-source self-host that doesn't expose a bouncer).
+	if routerAddr := os.Getenv("TURBORG_BOUNCER_ROUTER_ADDR"); routerAddr != "" {
+		safe.Go("bouncer-router", func() {
+			if err := srv.ServeBouncerRouter(ctx, routerAddr); err != nil && !errors.Is(err, context.Canceled) {
+				log.Error("bouncer router stopped", "err", err)
+				cancel()
+			}
+		})
+	}
+
 	if err := srv.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("pooled server: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/oklog/ulid/v2 v2.1.1
+	github.com/pires/go-proxyproto v0.12.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
+github.com/pires/go-proxyproto v0.12.0 h1:TTCxD66dU898tahivkqc3hoceZp7P44FnorWyo9d5vM=
+github.com/pires/go-proxyproto v0.12.0/go.mod h1:qUvfqUMEoX7T8g0q7TQLDnhMjdTrxnG0hvpMn+7ePNI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -240,7 +240,12 @@ type Bouncer struct {
 	clients  map[*BouncerClient]struct{}
 	listener net.Listener
 	cancel   context.CancelFunc
-	wg       sync.WaitGroup
+	// runCtx is the cancelable context every client handler runs under,
+	// captured at Start/StartListenerless and cleared at Stop. The listener
+	// path passes it to acceptLoop; the listenerless path hands it to each
+	// ServeConn so injected connections share the same lifecycle.
+	runCtx context.Context
+	wg     sync.WaitGroup
 
 	upstreamMu    sync.RWMutex
 	upstreamNick  string
@@ -517,18 +522,39 @@ func (b *Bouncer) upstreamPrefix() string {
 // listener is ready (so callers can race a client connect against
 // Start). Stop must be called to release resources.
 func (b *Bouncer) Start(ctx context.Context) error {
-	addr := fmt.Sprintf("%s:%d", b.host, b.port)
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("bouncer listen %s: %w", addr, err)
+	return b.start(ctx, true)
+}
+
+// StartListenerless brings the bouncer up without binding a TCP listener:
+// connections are delivered by the caller via ServeConn instead of an accept
+// loop. This is the pooled-runtime path — one turborg-server process fronts
+// every tenant behind a single SNI/PROXY-v2 router, so per-tenant bouncers
+// must not each bind a port. Dedicated mode still uses Start (own host port).
+// Everything past the listener — auth, replay, state surfacing, keepalive —
+// is identical across both, so the bouncer behaviour is one source of truth.
+func (b *Bouncer) StartListenerless(ctx context.Context) error {
+	return b.start(ctx, false)
+}
+
+func (b *Bouncer) start(ctx context.Context, listen bool) error {
+	var l net.Listener
+	if listen {
+		addr := fmt.Sprintf("%s:%d", b.host, b.port)
+		var err error
+		l, err = net.Listen("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("bouncer listen %s: %w", addr, err)
+		}
 	}
-	b.mu.Lock()
-	b.listener = l
-	machine := b.machine
-	b.mu.Unlock()
 
 	bctx, cancel := context.WithCancel(ctx)
+
+	b.mu.Lock()
+	b.listener = l
 	b.cancel = cancel
+	b.runCtx = bctx
+	machine := b.machine
+	b.mu.Unlock()
 
 	if machine != nil {
 		sub := machine.Subscribe(b.onUpstreamStateChange)
@@ -537,11 +563,39 @@ func (b *Bouncer) Start(ctx context.Context) error {
 		b.mu.Unlock()
 	}
 
-	b.wg.Add(1)
-	go b.acceptLoop(bctx, l)
-
-	b.log.Info("bouncer listening", "host", b.host, "port", b.port)
+	if listen {
+		b.wg.Add(1)
+		go b.acceptLoop(bctx, l)
+		b.log.Info("bouncer listening", "host", b.host, "port", b.port)
+	} else {
+		b.log.Info("bouncer ready (listenerless; served via ServeConn)")
+	}
 	return nil
+}
+
+// ServeConn handles one already-accepted client connection instead of one
+// taken from the bouncer's own listener — the pooled router calls this after
+// reading the PROXY-v2 header and resolving which tenant the connection is
+// for. The bouncer must have been brought up first (Start or
+// StartListenerless). Blocks until the client disconnects, so callers run it
+// per-connection in their own goroutine. A nil run context (never started, or
+// already stopped) closes the connection rather than leaking it.
+func (b *Bouncer) ServeConn(conn net.Conn) {
+	b.mu.Lock()
+	ctx := b.runCtx
+	b.mu.Unlock()
+	if ctx == nil {
+		_ = conn.Close()
+		return
+	}
+
+	client := newBouncerClient(conn, b.log)
+	b.mu.Lock()
+	b.clients[client] = struct{}{}
+	b.mu.Unlock()
+
+	b.wg.Add(1)
+	b.handleClient(ctx, client)
 }
 
 // Stop closes every active client, the listener, and waits for in-flight
@@ -559,6 +613,7 @@ func (b *Bouncer) Stop() error {
 	b.clients = map[*BouncerClient]struct{}{}
 	b.listener = nil
 	b.cancel = nil
+	b.runCtx = nil
 	b.stateSub = nil
 	b.mu.Unlock()
 

--- a/internal/connector/irc/bouncer_serveconn_test.go
+++ b/internal/connector/irc/bouncer_serveconn_test.go
@@ -1,0 +1,85 @@
+package irc_test
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// TestBouncerListenerlessServeConn is the pooled-runtime seam: a bouncer
+// brought up with StartListenerless binds no port, and a connection handed to
+// ServeConn gets a fully-functional bouncer session — same pre-auth hint and
+// PASS→001 handshake a listened connection would. This is what lets the
+// pooled SNI/PROXY-v2 router front per-tenant bouncers without per-tenant
+// ports, while the bouncer logic stays one source of truth across modes.
+func TestBouncerListenerlessServeConn(t *testing.T) {
+	b, err := irc.NewBouncer("hunter2", "127.0.0.1", 0, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, b.StartListenerless(context.Background()))
+	t.Cleanup(func() { _ = b.Stop() })
+
+	assert.Empty(t, b.Addr(), "listenerless bouncer must not bind a TCP listener")
+
+	srv, cli := net.Pipe()
+	t.Cleanup(func() { _ = cli.Close() })
+	go b.ServeConn(srv)
+
+	r := bufio.NewReader(cli)
+	_ = cli.SetReadDeadline(time.Now().Add(2 * time.Second))
+	notice, err := r.ReadString('\n')
+	require.NoError(t, err)
+	assert.Contains(t, notice, "NOTICE AUTH",
+		"a served connection gets the same pre-auth hint as a listened one")
+
+	_, err = cli.Write([]byte("PASS hunter2\r\n"))
+	require.NoError(t, err)
+
+	got001 := false
+	for i := 0; i < 50; i++ {
+		_ = cli.SetReadDeadline(time.Now().Add(2 * time.Second))
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if strings.Contains(line, " 001 ") {
+			got001 = true
+			break
+		}
+	}
+	assert.True(t, got001, "PASS over a served connection must reach the 001 welcome")
+}
+
+// TestBouncerServeConnAfterStopClosesConn: a connection handed to a stopped
+// (or never-started) bouncer is closed, not leaked — runCtx is nil so there's
+// no lifecycle to attach it to.
+func TestBouncerServeConnAfterStopClosesConn(t *testing.T) {
+	b, err := irc.NewBouncer("hunter2", "127.0.0.1", 0, nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, b.StartListenerless(context.Background()))
+	require.NoError(t, b.Stop())
+
+	srv, cli := net.Pipe()
+	defer func() { _ = cli.Close() }()
+	done := make(chan struct{})
+	go func() { b.ServeConn(srv); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ServeConn on a stopped bouncer must return promptly")
+	}
+
+	// The server end is closed, so a read from the client end ends in error
+	// rather than hanging.
+	_ = cli.SetReadDeadline(time.Now().Add(time.Second))
+	buf := make([]byte, 1)
+	_, err = cli.Read(buf)
+	require.Error(t, err, "connection should be closed by ServeConn")
+}

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -65,7 +65,11 @@ type Connector struct {
 
 	state   *ChannelState
 	bouncer *Bouncer
-	ctcp    *Throttle
+	// bouncerListenerless brings the bouncer up without its own TCP listener
+	// (pooled runtime): the pool's SNI/PROXY-v2 router feeds connections in via
+	// ServeBouncerConn. Default false = dedicated mode (bouncer binds a port).
+	bouncerListenerless bool
+	ctcp                *Throttle
 
 	// wanted is the "channels I want to be in" set the reconnect
 	// supervisor replays JOINs from. Seeded at construction from the
@@ -322,6 +326,26 @@ func (c *Connector) SetMessageStore(s messages.Store) { c.messageStore = s }
 // Forwarded to the bouncer at startBouncer time. Pass 0 to leave the
 // default in place.
 func (c *Connector) SetBouncerWelcomeReplayDepth(n int) { c.bouncerWelcomeReplayDepth = n }
+
+// SetBouncerListenerless selects the pooled-runtime bouncer path: the bouncer
+// comes up without binding a TCP port and is fed connections by the pool's
+// SNI/PROXY-v2 router via ServeBouncerConn, instead of its own accept loop.
+// Must be called before Start. Default (false) keeps dedicated mode, where the
+// bouncer binds its own host port.
+func (c *Connector) SetBouncerListenerless(v bool) { c.bouncerListenerless = v }
+
+// ServeBouncerConn hands one already-accepted client connection to this
+// connector's bouncer — the pooled router's entry point once it has resolved
+// which tenant a connection belongs to. Closes the connection if the bouncer
+// isn't up yet (router raced connector start); the router retries on the
+// client's reconnect.
+func (c *Connector) ServeBouncerConn(conn net.Conn) {
+	if b := c.bouncer; b != nil {
+		b.ServeConn(conn)
+		return
+	}
+	_ = conn.Close()
+}
 
 // SetUpstreamWarnHook installs the callback the escalation watchdog
 // fires when a transient outage persists past UpstreamWarnAfter. Pass
@@ -730,7 +754,12 @@ func (c *Connector) startBouncer(ctx context.Context) error {
 			})
 		})
 	}
-	if err := b.Start(ctx); err != nil {
+	start := b.Start
+	if c.bouncerListenerless {
+		// Pooled: no own port; the pool router feeds conns via ServeBouncerConn.
+		start = b.StartListenerless
+	}
+	if err := start(ctx); err != nil {
 		return err
 	}
 	c.bouncer = b

--- a/internal/server/bouncer_router.go
+++ b/internal/server/bouncer_router.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	proxyproto "github.com/pires/go-proxyproto"
+
+	"github.com/turborg/turborg/internal/safe"
+)
+
+// proxyHeaderReadTimeout bounds how long the router waits for the PROXY v2
+// header on a freshly accepted connection. A slow or non-HAProxy peer must not
+// pin a goroutine waiting for bytes that never come.
+const proxyHeaderReadTimeout = 5 * time.Second
+
+// ServeBouncerRouter accepts bouncer connections the edge HAProxy forwards to
+// the pool and routes each to the tenant it belongs to. HAProxy terminates the
+// wildcard TLS and sends a PROXY v2 header whose AUTHORITY TLV carries the
+// original TLS SNI (`<turborg_id>.bouncer.<domain>`); the connection payload is
+// plaintext IRC from there on. This is the pooled counterpart to a dedicated
+// container's own bouncer port — one listener fronts every pooled tenant, so
+// the runtime doesn't reintroduce a per-tenant port pool.
+//
+// Blocks until ctx is cancelled or the listener fails.
+func (s *Server) ServeBouncerRouter(ctx context.Context, addr string) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("bouncer router listen %s: %w", addr, err)
+	}
+	return s.serveBouncerRouter(ctx, ln)
+}
+
+// serveBouncerRouter wraps an already-bound listener in the PROXY-protocol
+// reader and runs the accept loop. Split from ServeBouncerRouter so tests can
+// drive it with a listener on an ephemeral port.
+func (s *Server) serveBouncerRouter(ctx context.Context, ln net.Listener) error {
+	pl := &proxyproto.Listener{
+		Listener: ln,
+		// REQUIRE: only the edge proxy (which always sends a PROXY header) may
+		// reach the router. A direct connection has no header and is rejected,
+		// so nobody can bypass tenant resolution by dialing the pool port.
+		ConnPolicy: func(proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+			return proxyproto.REQUIRE, nil
+		},
+	}
+	defer func() { _ = pl.Close() }()
+
+	go func() {
+		<-ctx.Done()
+		_ = pl.Close()
+	}()
+
+	s.log.Info("bouncer router listening", "addr", ln.Addr().String())
+	for {
+		conn, err := pl.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			s.log.Debug("bouncer router accept", "err", err)
+			continue
+		}
+		safe.Go("bouncer-route", func() { s.routeBouncerConn(conn) })
+	}
+}
+
+// routeBouncerConn resolves the tenant from the connection's PROXY v2 authority
+// and hands it off. Any failure — missing/!proxy header, no authority TLV,
+// unknown tenant — closes the connection so nothing leaks.
+func (s *Server) routeBouncerConn(conn net.Conn) {
+	pc, ok := conn.(*proxyproto.Conn)
+	if !ok {
+		s.log.Warn("bouncer router: non-proxy connection", "remote", conn.RemoteAddr())
+		_ = conn.Close()
+		return
+	}
+
+	// Bound the header read; clear the deadline before handoff so the bouncer
+	// manages its own (keepalive) deadlines on the same conn.
+	_ = pc.SetReadDeadline(time.Now().Add(proxyHeaderReadTimeout))
+	header := pc.ProxyHeader()
+	_ = pc.SetReadDeadline(time.Time{})
+	if header == nil {
+		s.log.Warn("bouncer router: missing proxy header", "remote", conn.RemoteAddr())
+		_ = conn.Close()
+		return
+	}
+
+	id, err := turborgIDFromAuthority(header)
+	if err != nil {
+		s.log.Warn("bouncer router: cannot resolve tenant", "err", err, "remote", conn.RemoteAddr())
+		_ = conn.Close()
+		return
+	}
+
+	if !s.RouteBouncerConn(id, conn) {
+		s.log.Info("bouncer router: no such tenant", "turborg_id", id)
+		_ = conn.Close()
+	}
+}
+
+// turborgIDFromAuthority reads the PROXY v2 AUTHORITY TLV (the TLS SNI HAProxy
+// forwarded) and returns its first DNS label — the turborg_id in
+// `<turborg_id>.bouncer.<domain>`.
+func turborgIDFromAuthority(header *proxyproto.Header) (string, error) {
+	tlvs, err := header.TLVs()
+	if err != nil {
+		return "", fmt.Errorf("parse tlvs: %w", err)
+	}
+	for _, tlv := range tlvs {
+		if tlv.Type != proxyproto.PP2_TYPE_AUTHORITY {
+			continue
+		}
+		authority := string(tlv.Value)
+		label, _, _ := strings.Cut(authority, ".")
+		if label == "" {
+			return "", fmt.Errorf("empty turborg_id label in authority %q", authority)
+		}
+		return label, nil
+	}
+	return "", errors.New("no authority tlv in proxy header")
+}

--- a/internal/server/bouncer_router_test.go
+++ b/internal/server/bouncer_router_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	proxyproto "github.com/pires/go-proxyproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func authorityHeader(authority string) *proxyproto.Header {
+	h := &proxyproto.Header{
+		Version:           2,
+		Command:           proxyproto.PROXY,
+		TransportProtocol: proxyproto.TCPv4,
+		SourceAddr:        &net.TCPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 12345},
+		DestinationAddr:   &net.TCPAddr{IP: net.IPv4(5, 6, 7, 8), Port: 7900},
+	}
+	if authority != "" {
+		_ = h.SetTLVs([]proxyproto.TLV{{Type: proxyproto.PP2_TYPE_AUTHORITY, Value: []byte(authority)}})
+	}
+	return h
+}
+
+func TestTurborgIDFromAuthority(t *testing.T) {
+	id, err := turborgIDFromAuthority(authorityHeader("alice-7f3b.bouncer.irc.staging.xshellz.com"))
+	require.NoError(t, err)
+	assert.Equal(t, "alice-7f3b", id, "turborg_id is the first DNS label of the SNI authority")
+
+	id, err = turborgIDFromAuthority(authorityHeader("bareid"))
+	require.NoError(t, err)
+	assert.Equal(t, "bareid", id, "an authority with no dot is the whole label")
+
+	_, err = turborgIDFromAuthority(authorityHeader(""))
+	require.Error(t, err, "a header with no AUTHORITY TLV is an error, not a silent empty id")
+}
+
+func TestRouteBouncerConnLookup(t *testing.T) {
+	s := New(nil, slog.Default())
+	s.tenants["known"] = &Tenant{ID: "known", log: slog.Default()} // no live ircConn
+
+	// Unknown tenant: false, and the conn is left for the caller to close.
+	c1, c1peer := net.Pipe()
+	t.Cleanup(func() { _ = c1.Close(); _ = c1peer.Close() })
+	assert.False(t, s.RouteBouncerConn("missing", c1), "missing tenant routes false")
+
+	// Known tenant with no running connector: true, and the tenant closes the
+	// routed conn (nothing to attach to between runs).
+	srv, cli := net.Pipe()
+	t.Cleanup(func() { _ = cli.Close() })
+	assert.True(t, s.RouteBouncerConn("known", srv), "attached tenant routes true")
+	_ = cli.SetReadDeadline(time.Now().Add(time.Second))
+	_, err := cli.Read(make([]byte, 1))
+	assert.Error(t, err, "tenant with no live connector closes the routed conn")
+}
+
+// TestBouncerRouterUnknownTenantClosesConn drives the full accept path: a real
+// PROXY v2 header is written to the router, which parses the authority,
+// resolves no tenant, and closes the connection.
+func TestBouncerRouterUnknownTenantClosesConn(t *testing.T) {
+	s := New(nil, slog.Default())
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.serveBouncerRouter(ctx, ln) }()
+
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = authorityHeader("ghost-tenant.bouncer.irc.staging.xshellz.com").WriteTo(conn)
+	require.NoError(t, err)
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, err = conn.Read(make([]byte, 1))
+	assert.Error(t, err, "router must close a conn whose authority resolves to no tenant")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"sort"
 	"sync"
 	"time"
@@ -157,6 +158,21 @@ func (s *Server) Has(id string) bool {
 	defer s.mu.Unlock()
 	_, ok := s.tenants[id]
 	return ok
+}
+
+// RouteBouncerConn hands one accepted client connection to the named tenant's
+// bouncer. Returns false (and does not touch the conn) when no such tenant is
+// attached, so the router can close it with an explanatory log. The actual
+// bouncer delivery (and closing on a between-runs tenant) is the tenant's job.
+func (s *Server) RouteBouncerConn(turborgID string, conn net.Conn) bool {
+	s.mu.Lock()
+	t, ok := s.tenants[turborgID]
+	s.mu.Unlock()
+	if !ok {
+		return false
+	}
+	t.ServeBouncerConn(conn)
+	return true
 }
 
 // Status returns a tenant's supervision phase, and whether it is attached.

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"reflect"
 	"runtime/debug"
 	"sync"
@@ -71,6 +72,11 @@ type Tenant struct {
 	quarantineUntil time.Time
 	// runCancel cancels the in-flight work run so update() can restart it.
 	runCancel context.CancelFunc
+	// ircConn is the live IRC connector for the current run, captured in
+	// buildConnectors and cleared when the run ends. The bouncer router reaches
+	// it via ServeBouncerConn to deliver an attached client to this tenant. nil
+	// between runs (quarantined / restarting) → an inbound conn is closed.
+	ircConn *irc.Connector
 }
 
 // startTenant launches a self-supervising tenant under a child of parent.
@@ -215,7 +221,14 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 		a := agent.New(t.log)
 		t.buildConnectors(a)
 		t.log.Info("tenant attached", "connectors", t.connectorTypes())
-		return a.Run(ctx)
+		err := a.Run(ctx)
+		// Run ended (ctx cancelled / restart) — the connector's bouncer is
+		// stopping, so drop the routing handle. A late inbound conn then closes
+		// cleanly instead of hitting a torn-down bouncer.
+		t.mu.Lock()
+		t.ircConn = nil
+		t.mu.Unlock()
+		return err
 	}
 }
 
@@ -242,7 +255,14 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 				t.log.Error("skipping irc connector: invalid plan limits", "err", err)
 				continue
 			}
+			// Pooled runtime: the bouncer must not bind its own port — the pool
+			// router feeds it connections via ServeBouncerConn after PROXY-v2
+			// tenant resolution.
+			conn.SetBouncerListenerless(true)
 			a.AddConnector(conn)
+			t.mu.Lock()
+			t.ircConn = conn
+			t.mu.Unlock()
 		default:
 			t.log.Warn("connector type not supported in pooled mode yet", "type", cs.Type)
 		}
@@ -285,6 +305,22 @@ func (t *Tenant) update(spec TenantSpec) {
 func (t *Tenant) stop() {
 	t.cancel()
 	<-t.done
+}
+
+// ServeBouncerConn delivers one already-accepted client connection to this
+// tenant's live IRC bouncer (the pooled router calls it after resolving the
+// tenant from the PROXY-v2 authority). Closes the connection when the tenant
+// has no running IRC connector (between runs / quarantined / no IRC connector
+// configured); the client reconnects and the router retries.
+func (t *Tenant) ServeBouncerConn(conn net.Conn) {
+	t.mu.Lock()
+	c := t.ircConn
+	t.mu.Unlock()
+	if c == nil {
+		_ = conn.Close()
+		return
+	}
+	c.ServeBouncerConn(conn)
 }
 
 // connectorTypes lists the configured connector types, for logging.


### PR DESCRIPTION
## What

Lands turborg **M6** from `PLAN-multi-tenancy.md`: a pooled tenant can now be **attached to** by an IRC client, not just dial out. This is the functional blocker for "one box, both runtimes."

Two parts:

**1. Listenerless bouncer seam (irc).** The bouncer stays one source of truth across dedicated and pooled — only the connection source differs.
- `Bouncer.StartListenerless` + `Bouncer.ServeConn(conn)` — bring the bouncer up without binding a port and handle an externally-accepted conn through the same auth / replay / state-surfacing / keepalive path.
- `Connector.SetBouncerListenerless` + `Connector.ServeBouncerConn` to drive it. **Dedicated mode untouched** (still `Start` + own host port).

**2. PROXY-v2 router (server).** The pooled counterpart to a dedicated container's bouncer port — one listener fronts every tenant, no per-tenant port pool.
- `Server.ServeBouncerRouter`: a `proxyproto.Listener` (REQUIRE policy — a direct header-less dial can't bypass tenant resolution). HAProxy terminates the wildcard TLS at the edge and forwards a PROXY v2 header whose **AUTHORITY TLV** carries the SNI (`<turborg_id>.bouncer.<domain>`); the router reads the first label as the `turborg_id`.
- `Server.RouteBouncerConn` + `Tenant.ServeBouncerConn`: lookup + handoff. The tenant captures its live IRC connector in `buildConnectors` (listenerless) and drops the handle when a run ends, so a between-runs conn closes cleanly.
- `cmd/turborg-server` starts the router (`TURBORG_BOUNCER_ROUTER_ADDR`; empty disables); a bind failure cancels the process.
- Adds `github.com/pires/go-proxyproto` (de-facto Go PROXY-protocol lib).

## Safe to merge

Additive and dormant: the router only runs when `TURBORG_BOUNCER_ROUTER_ADDR` is set, and `turborg-server` only runs in pooled mode — which the sidecar still answers `501` to until the next PR. The dedicated path is unchanged.

## Tests

`bouncer_serveconn_test.go` (served-conn handshake + stopped-bouncer close) and `bouncer_router_test.go` (authority→turborg_id parse, lookup hit/miss + between-runs close, full accept path closing an unknown-tenant conn). Full module suite passes with `-race`; `golangci-lint` clean.

## Follow-ups (per the plan)

- PR2 governance: `GOMEMLIMIT` + pool watchdog + slow-consumer + reconnect-storm quarantine.
- PR3 sidecar: replace pooled `501` with a pool client; `poolmgr` boots/supervises turborg-server.
- PR4 infra: HAProxy `send-proxy-v2 proxy-v2-options authority` on the pooled backend.