### PR TITLE
feat: pooled resource governance (GOMEMLIMIT, watchdog, slow-consumer) + M6 coverage

### DIFF
--- a/cmd/turborg-server/main.go
+++ b/cmd/turborg-server/main.go
@@ -14,7 +14,10 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"runtime/debug"
+	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
@@ -77,6 +80,11 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	// (and every other tenant in it). Recover + log instead of exiting.
 	safe.SetPanicPolicy(safe.RecoverPolicy)
 
+	// Soft memory limit so GC defends the pool under pressure rather than
+	// letting one tenant push the shared process to an OOM kill that drops
+	// every tenant. The watchdog (server) observes; this bounds.
+	applyMemoryLimit(log)
+
 	source, desc := selectSource(log)
 	log.Info("turborg-server starting", "version", version.Version, "source", desc)
 
@@ -101,11 +109,40 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 		})
 	}
 
+	// Pool watchdog: periodic heap/goroutine/tenant sampling for observability
+	// and early warning (escalates to Warn above TURBORG_HEAP_WARN_BYTES). 0
+	// interval disables it.
+	if interval := envIntOr("TURBORG_WATCHDOG_INTERVAL_SECONDS", 60); interval > 0 {
+		heapWarn := envUint64Or("TURBORG_HEAP_WARN_BYTES", 0)
+		safe.Go("watchdog", func() {
+			srv.RunWatchdog(ctx, time.Duration(interval)*time.Second, heapWarn)
+		})
+	}
+
 	if err := srv.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("pooled server: %w", err)
 	}
 	log.Info("turborg-server exited cleanly")
 	return nil
+}
+
+// applyMemoryLimit sets the Go soft memory limit (GOMEMLIMIT) from
+// TURBORG_GOMEMLIMIT_BYTES when present. The sidecar derives it from the pool
+// container's memory allocation so GC works harder near the ceiling instead of
+// the kernel OOM-killing a process that holds every pooled tenant. Unset keeps
+// Go's default (the runtime still honours a natively-set GOMEMLIMIT env).
+func applyMemoryLimit(log *slog.Logger) {
+	v := os.Getenv("TURBORG_GOMEMLIMIT_BYTES")
+	if v == "" {
+		return
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n <= 0 {
+		log.Warn("ignoring invalid TURBORG_GOMEMLIMIT_BYTES", "value", v)
+		return
+	}
+	debug.SetMemoryLimit(n)
+	log.Info("GOMEMLIMIT applied", "bytes", n)
 }
 
 // selectSource picks the tenant source from the environment. When
@@ -129,4 +166,32 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// envIntOr reads a non-negative integer env var, falling back to def when
+// unset, empty, or unparseable.
+func envIntOr(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}
+
+// envUint64Or reads an unsigned integer env var (e.g. a byte count), falling
+// back to def when unset, empty, or unparseable.
+func envUint64Or(key string, def uint64) uint64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return def
+	}
+	return n
 }

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -35,6 +35,11 @@ const (
 	// connection. The read loop reaps a client that sends nothing (not even a
 	// PONG) for pingInterval+pongGrace.
 	defaultClientPongGrace = 30 * time.Second
+	// clientWriteTimeout bounds a single write to an attached client. A client
+	// that stops reading must not pin the writing goroutine — critical in the
+	// pooled runtime, where one shared goroutine fans an upstream line out to
+	// every attached client. On timeout the write errors and the client drops.
+	clientWriteTimeout = 30 * time.Second
 )
 
 // forwardable is the set of commands that bouncer clients are allowed to
@@ -199,7 +204,19 @@ func (b *BouncerClient) sendLine(line string) error {
 	}
 	b.wmu.Lock()
 	defer b.wmu.Unlock()
-	_, err := b.conn.Write([]byte(strings.TrimRight(line, "\r\n") + "\r\n"))
+	return writeWithTimeout(b.conn, []byte(strings.TrimRight(line, "\r\n")+"\r\n"), clientWriteTimeout)
+}
+
+// writeWithTimeout writes data with a bounded deadline — the slow-consumer
+// guard. A client that stops reading fills the socket buffer and would
+// otherwise pin the writing goroutine indefinitely; in the pooled runtime that
+// goroutine is often a shared fan-out delivering one upstream line to every
+// attached client, so one stalled consumer must not stall the rest. On timeout
+// the write errors and the caller drops the client.
+func writeWithTimeout(conn net.Conn, data []byte, timeout time.Duration) error {
+	_ = conn.SetWriteDeadline(time.Now().Add(timeout))
+	_, err := conn.Write(data)
+	_ = conn.SetWriteDeadline(time.Time{})
 	return err
 }
 

--- a/internal/connector/irc/bouncer_serveconn_test.go
+++ b/internal/connector/irc/bouncer_serveconn_test.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/tests/fixtures/fakeirc"
 )
 
 // TestBouncerListenerlessServeConn is the pooled-runtime seam: a bouncer
@@ -54,6 +56,62 @@ func TestBouncerListenerlessServeConn(t *testing.T) {
 		}
 	}
 	assert.True(t, got001, "PASS over a served connection must reach the 001 welcome")
+}
+
+// TestConnectorListenerlessBouncerServesRoutedConn is the end-to-end pooled
+// path: a connector started in listenerless mode binds no bouncer port, yet a
+// connection delivered through ServeBouncerConn (as the pool router would,
+// after PROXY-v2 tenant resolution) gets the live bouncer's handshake.
+func TestConnectorListenerlessBouncerServesRoutedConn(t *testing.T) {
+	fs := fakeirc.New(t)
+	defer fs.Close()
+
+	conn := irc.New(&irc.Settings{
+		Hostname:        "127.0.0.1",
+		Port:            fs.Port(),
+		Nick:            "turborg",
+		Username:        "turborg",
+		RealName:        "turborg",
+		Channels:        []string{"#test"},
+		BouncerPassword: "hunter2",
+	}, nil, nil)
+	conn.SetBouncerListenerless(true)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = a.Run(ctx) }()
+
+	require.True(t, fs.WaitFor(containsPrefix("JOIN #test"), 2*time.Second),
+		"connector did not register; received: %v", fs.Received())
+
+	srv, cli := net.Pipe()
+	t.Cleanup(func() { _ = cli.Close() })
+	go conn.ServeBouncerConn(srv) // ServeConn blocks on the client read loop
+
+	r := bufio.NewReader(cli)
+	_ = cli.SetReadDeadline(time.Now().Add(2 * time.Second))
+	notice, err := r.ReadString('\n')
+	require.NoError(t, err)
+	assert.Contains(t, notice, "NOTICE AUTH",
+		"a listenerless connector's bouncer must serve a routed connection end-to-end")
+}
+
+// TestConnectorServeBouncerConnBeforeStartCloses: the connector's pooled
+// entry point closes a routed connection when its bouncer isn't up yet (router
+// raced connector start), rather than leaking it or panicking.
+func TestConnectorServeBouncerConnBeforeStartCloses(t *testing.T) {
+	conn := irc.New(&irc.Settings{BouncerPassword: "hunter2"}, nil, nil)
+	conn.SetBouncerListenerless(true) // pooled mode; still not Started, so bouncer is nil
+
+	srv, cli := net.Pipe()
+	t.Cleanup(func() { _ = cli.Close() })
+	conn.ServeBouncerConn(srv)
+
+	_ = cli.SetReadDeadline(time.Now().Add(time.Second))
+	_, err := cli.Read(make([]byte, 1))
+	assert.Error(t, err, "ServeBouncerConn before the bouncer is up must close the conn")
 }
 
 // TestBouncerServeConnAfterStopClosesConn: a connection handed to a stopped

--- a/internal/connector/irc/bouncer_slowconsumer_test.go
+++ b/internal/connector/irc/bouncer_slowconsumer_test.go
@@ -1,0 +1,43 @@
+package irc
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestWriteWithTimeoutErrorsOnStalledConsumer: a client that never reads must
+// not pin the writing goroutine. On net.Pipe a write blocks until the peer
+// reads, so with no reader the bounded deadline fires and the write returns a
+// timeout error — the signal the bouncer uses to drop a slow consumer instead
+// of stalling the shared pooled fan-out.
+func TestWriteWithTimeoutErrorsOnStalledConsumer(t *testing.T) {
+	srv, cli := net.Pipe()
+	defer func() { _ = srv.Close(); _ = cli.Close() }() // cli never reads
+
+	err := writeWithTimeout(srv, []byte("PING :x\r\n"), 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("write to a non-reading peer must time out, not block forever")
+	}
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("expected a deadline-exceeded error, got %v", err)
+	}
+}
+
+// TestWriteWithTimeoutSucceedsWhenConsumerReads: the happy path — a reading
+// peer gets the bytes and the write returns nil.
+func TestWriteWithTimeoutSucceedsWhenConsumerReads(t *testing.T) {
+	srv, cli := net.Pipe()
+	defer func() { _ = srv.Close(); _ = cli.Close() }()
+
+	go func() {
+		buf := make([]byte, 64)
+		_, _ = cli.Read(buf)
+	}()
+
+	if err := writeWithTimeout(srv, []byte("PING :x\r\n"), 2*time.Second); err != nil {
+		t.Fatalf("write to a reading peer should succeed, got %v", err)
+	}
+}

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -875,11 +875,12 @@ type brokenConn struct {
 	closeErr error
 }
 
-func (b *brokenConn) Write(_ []byte) (int, error) { return 0, errBrokenWrite }
-func (b *brokenConn) Read(p []byte) (int, error)  { return 0, errBrokenWrite }
-func (b *brokenConn) Close() error                { return b.closeErr }
-func (b *brokenConn) RemoteAddr() net.Addr        { return fakeAddr{} }
-func (b *brokenConn) LocalAddr() net.Addr         { return fakeAddr{} }
+func (b *brokenConn) Write(_ []byte) (int, error)        { return 0, errBrokenWrite }
+func (b *brokenConn) Read(p []byte) (int, error)         { return 0, errBrokenWrite }
+func (b *brokenConn) Close() error                       { return b.closeErr }
+func (b *brokenConn) RemoteAddr() net.Addr               { return fakeAddr{} }
+func (b *brokenConn) LocalAddr() net.Addr                { return fakeAddr{} }
+func (b *brokenConn) SetWriteDeadline(_ time.Time) error { return nil }
 
 type fakeAddr struct{}
 

--- a/internal/server/bouncer_router_test.go
+++ b/internal/server/bouncer_router_test.go
@@ -37,6 +37,68 @@ func TestTurborgIDFromAuthority(t *testing.T) {
 
 	_, err = turborgIDFromAuthority(authorityHeader(""))
 	require.Error(t, err, "a header with no AUTHORITY TLV is an error, not a silent empty id")
+
+	_, err = turborgIDFromAuthority(authorityHeader(".bouncer.irc.staging.xshellz.com"))
+	require.Error(t, err, "an authority with an empty leading label has no turborg_id")
+}
+
+// TestRouteBouncerConnNonProxyConnCloses: a connection that isn't a
+// *proxyproto.Conn (no header to read) is closed rather than leaked.
+func TestRouteBouncerConnNonProxyConnCloses(t *testing.T) {
+	s := New(nil, slog.Default())
+	srv, cli := net.Pipe()
+	t.Cleanup(func() { _ = cli.Close() })
+
+	s.routeBouncerConn(srv)
+
+	_ = cli.SetReadDeadline(time.Now().Add(time.Second))
+	_, err := cli.Read(make([]byte, 1))
+	assert.Error(t, err, "a non-PROXY connection must be closed")
+}
+
+// TestBouncerRouterNoAuthorityClosesConn drives the accept path with a valid
+// PROXY v2 header that carries no AUTHORITY TLV: the router can't resolve a
+// tenant and closes the connection.
+func TestBouncerRouterNoAuthorityClosesConn(t *testing.T) {
+	s := New(nil, slog.Default())
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.serveBouncerRouter(ctx, ln) }()
+
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	_, err = authorityHeader("").WriteTo(conn) // valid v2 header, no AUTHORITY TLV
+	require.NoError(t, err)
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, err = conn.Read(make([]byte, 1))
+	assert.Error(t, err, "a header with no authority resolves to no tenant and is closed")
+}
+
+// TestServeBouncerRouterBindsAndStops covers the bind+delegate wrapper and a
+// clean shutdown on context cancel.
+func TestServeBouncerRouterBindsAndStops(t *testing.T) {
+	s := New(nil, slog.Default())
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errc := make(chan error, 1)
+	go func() { errc <- s.ServeBouncerRouter(ctx, "127.0.0.1:0") }()
+
+	time.Sleep(50 * time.Millisecond) // let the listener bind
+	cancel()
+
+	select {
+	case err := <-errc:
+		assert.ErrorIs(t, err, context.Canceled, "router returns ctx.Err() on cancel")
+	case <-time.After(2 * time.Second):
+		t.Fatal("router did not stop on context cancel")
+	}
 }
 
 func TestRouteBouncerConnLookup(t *testing.T) {

--- a/internal/server/watchdog.go
+++ b/internal/server/watchdog.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"time"
+)
+
+// watchdogLevel decides the log level for a resource sample: Warn once heap
+// crosses the configured threshold (>0), else Info. Split out so the decision
+// is unit-tested without driving a real heap to the limit.
+func watchdogLevel(heapAlloc, heapWarnBytes uint64) slog.Level {
+	if heapWarnBytes > 0 && heapAlloc >= heapWarnBytes {
+		return slog.LevelWarn
+	}
+	return slog.LevelInfo
+}
+
+// RunWatchdog periodically samples pool-wide resource usage — heap, goroutine
+// count, attached tenants — and logs it, escalating to Warn when heap crosses
+// heapWarnBytes. This is observability + early warning; the hard memory defense
+// is GOMEMLIMIT (GC backpressure) and per-tenant quarantine. A non-positive
+// interval disables it. Blocks until ctx is cancelled.
+func (s *Server) RunWatchdog(ctx context.Context, interval time.Duration, heapWarnBytes uint64) {
+	if interval <= 0 {
+		return
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sampleResources(heapWarnBytes)
+		}
+	}
+}
+
+// sampleResources reads one resource snapshot and logs it at the
+// threshold-appropriate level.
+func (s *Server) sampleResources(heapWarnBytes uint64) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	s.log.Log(context.Background(), watchdogLevel(m.HeapAlloc, heapWarnBytes), "pool watchdog",
+		"heap_bytes", m.HeapAlloc,
+		"goroutines", runtime.NumGoroutine(),
+		"tenants", s.Count(),
+		"heap_warn_bytes", heapWarnBytes,
+	)
+}

--- a/internal/server/watchdog_test.go
+++ b/internal/server/watchdog_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchdogLevel(t *testing.T) {
+	assert.Equal(t, slog.LevelInfo, watchdogLevel(100, 0), "no threshold → never warn")
+	assert.Equal(t, slog.LevelInfo, watchdogLevel(50, 100), "under threshold → info")
+	assert.Equal(t, slog.LevelWarn, watchdogLevel(100, 100), "at threshold → warn")
+	assert.Equal(t, slog.LevelWarn, watchdogLevel(150, 100), "over threshold → warn")
+}
+
+// countingHandler is a minimal slog.Handler that counts "pool watchdog"
+// records so the test can confirm the watchdog actually sampled.
+type countingHandler struct{ n *atomic.Int64 }
+
+func (h countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h countingHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Message == "pool watchdog" {
+		h.n.Add(1)
+	}
+	return nil
+}
+func (h countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h countingHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestRunWatchdogSamplesAndStops(t *testing.T) {
+	var n atomic.Int64
+	s := New(nil, slog.New(countingHandler{n: &n}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { s.RunWatchdog(ctx, 10*time.Millisecond, 0); close(done) }()
+
+	require.Eventually(t, func() bool { return n.Load() >= 1 }, 2*time.Second, 5*time.Millisecond,
+		"watchdog must emit at least one sample")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not stop on context cancel")
+	}
+}
+
+func TestRunWatchdogDisabledWithZeroInterval(t *testing.T) {
+	s := New(nil, slog.Default())
+	// Returns immediately (no ticker) — a non-positive interval disables it.
+	s.RunWatchdog(context.Background(), 0, 0)
+}


### PR DESCRIPTION
## What

Adds the **pooled resource governance** a shared process needs that a dedicated container gets for free from cgroups (plan PR2), and backfills the M6 coverage from #41.

- **GOMEMLIMIT** (`cmd/turborg-server`) — soft memory limit from `TURBORG_GOMEMLIMIT_BYTES`, so GC backpressures under load instead of letting one tenant push the shared process to an OOM kill that drops *every* tenant.
- **Pool watchdog** (`server`) — periodic heap / goroutine / tenant sampling, escalating to Warn above `TURBORG_HEAP_WARN_BYTES`. Observability + early warning; the hard memory defense stays GOMEMLIMIT + per-tenant quarantine. `TURBORG_WATCHDOG_INTERVAL_SECONDS` (default 60; 0 disables).
- **Slow-consumer guard** (`irc` bouncer) — a bounded write deadline (`writeWithTimeout`) so a client that stops reading can't pin the writing goroutine. Critical in pooled mode, where one shared fan-out goroutine delivers an upstream line to every attached client — one stalled consumer must not stall the rest.

## Coverage

Backfills tests for the M6 bouncer ingress from #41 (the gate was admin-merged with a gap): router resolve/close paths, `ServeBouncerRouter` lifecycle, an **end-to-end listenerless-connector** test, and a `SetWriteDeadline` on the `brokenConn` mock. Gate green again: file 70 / package 90 / **total 94.3%**.

## Tests

`watchdog_test.go` (level decision + sample/stop + disabled), `bouncer_slowconsumer_test.go` (timeout on a stalled consumer + happy path), plus the M6 backfill. Full module passes `-race`; `golangci-lint` clean.

## Follow-up

Reconnect-storm quarantine — the 4th governance item — is deferred: it touches the reconnect supervisor and overlaps WS4 H2 (abuse detection). Next in the roadmap is **PR3 (sidecar)**: replace the pooled `501` with a pool client + `poolmgr` supervising `turborg-server`.