### PR TITLE
feat(irc): reconnect-storm circuit breaker

### DIFF
--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -78,6 +78,11 @@ type Connector struct {
 	// JOIN/PART commands routed through the bouncer.
 	wanted *WantedChannels
 
+	// storm is the reconnect circuit breaker: after too many reconnects in a
+	// window it forces a long cooldown so a flapping tenant can't keep
+	// hammering the upstream network / shared egress IP. See reconnect_storm.go.
+	storm *reconnectStorm
+
 	// clientLimits is the operator-policy struct the bouncer consults
 	// before forwarding client-originated commands upstream. Held here
 	// so runtime.Build can hand it to the connector before Start; it
@@ -237,7 +242,19 @@ func New(s *Settings, log *slog.Logger, events *agent.EventBus) *Connector {
 		machine:     NewUpstreamStateMachine(log),
 		wanted:      NewWantedChannels(s.NormalizedChannels()),
 		currentNick: s.Nick,
+		storm: newReconnectStorm(
+			defaultReconnectStormWindow,
+			defaultReconnectStormMax,
+			defaultReconnectStormCooldown,
+		),
 	}
+}
+
+// SetReconnectStorm overrides the reconnect-storm circuit-breaker thresholds.
+// A non-positive maxAttempts disables it (the supervisor uses plain backoff).
+// Must be called before Run; tests use it to trip the breaker on tight timings.
+func (c *Connector) SetReconnectStorm(window time.Duration, maxAttempts int, cooldown time.Duration) {
+	c.storm = newReconnectStorm(window, maxAttempts, cooldown)
 }
 
 // WantedChannels returns the connector's wanted-channels set. Used by
@@ -1101,8 +1118,10 @@ func (c *Connector) Run(ctx context.Context) error {
 
 		// Recoverable: sleep with backoff, then bring upstream back up.
 		// runCtx cancels mid-sleep when the watchdog transitions to
-		// paused_idle — that surfaces as runCtx.Done.
-		delay := backoff.Next()
+		// paused_idle — that surfaces as runCtx.Done. The storm breaker swaps
+		// in a long cooldown once reconnects pile up in its window, so a
+		// persistent flapper stops hammering the network / egress IP.
+		delay := c.storm.nextDelay(time.Now(), backoff.Next(), c.log)
 		c.log.Info("irc reconnecting", "state", c.machine.State(), "after", delay, "err", err)
 		select {
 		case <-runCtx.Done():

--- a/internal/connector/irc/reconnect_storm.go
+++ b/internal/connector/irc/reconnect_storm.go
@@ -1,0 +1,73 @@
+package irc
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	// Reconnect-storm circuit-breaker defaults. A flapping upstream — a session
+	// that drops before the 30s stable window, so the backoff never resets —
+	// reconnects at the 60s backoff cap, ~1/min, indefinitely. After
+	// defaultReconnectStormMax reconnects within the window, force the longer
+	// cooldown so one broken tenant can't keep hammering the IRC network and,
+	// in the pooled runtime, the shared egress IP (sustained reconnect floods
+	// are a classic K-line trigger that would take down every tenant on that
+	// IP). At ~1/min a genuine flapper trips in ~6 min; a healthy connector
+	// never approaches it.
+	defaultReconnectStormWindow   = 10 * time.Minute
+	defaultReconnectStormMax      = 6
+	defaultReconnectStormCooldown = 15 * time.Minute
+)
+
+// reconnectStorm is a sliding-window circuit breaker over the supervisor's
+// reconnect loop. It complements the per-attempt backoff (which caps the
+// delay) with a hard cooldown once the *rate* of reconnects over a window
+// crosses a threshold — turning sustained flapping into long quiet periods.
+type reconnectStorm struct {
+	window      time.Duration
+	maxAttempts int
+	cooldown    time.Duration
+
+	mu       sync.Mutex
+	attempts []time.Time
+}
+
+func newReconnectStorm(window time.Duration, maxAttempts int, cooldown time.Duration) *reconnectStorm {
+	return &reconnectStorm{window: window, maxAttempts: maxAttempts, cooldown: cooldown}
+}
+
+// record logs a reconnect attempt at now, prunes attempts older than the
+// window, and reports whether the count within the window now exceeds the
+// threshold. A non-positive maxAttempts disables the breaker.
+func (r *reconnectStorm) record(now time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.maxAttempts <= 0 {
+		return false
+	}
+	cutoff := now.Add(-r.window)
+	kept := r.attempts[:0]
+	for _, t := range r.attempts {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	r.attempts = append(kept, now)
+	return len(r.attempts) > r.maxAttempts
+}
+
+// nextDelay records a reconnect attempt and returns how long to wait before
+// it: the normal backoff delay, or the longer cooldown when the reconnect rate
+// has crossed the storm threshold. Logs a warning on the storm path.
+func (r *reconnectStorm) nextDelay(now time.Time, backoff time.Duration, log *slog.Logger) time.Duration {
+	if r.record(now) {
+		if log != nil {
+			log.Warn("irc reconnect storm; cooling down to protect the upstream + egress IP",
+				"window", r.window, "max_attempts", r.maxAttempts, "cooldown", r.cooldown)
+		}
+		return r.cooldown
+	}
+	return backoff
+}

--- a/internal/connector/irc/reconnect_storm_test.go
+++ b/internal/connector/irc/reconnect_storm_test.go
@@ -1,0 +1,65 @@
+package irc
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestReconnectStormTripsOverThreshold(t *testing.T) {
+	s := newReconnectStorm(10*time.Minute, 3, 15*time.Minute)
+	base := time.Now()
+	// Up to the threshold (3) within the window: no storm yet.
+	if s.record(base) || s.record(base.Add(time.Second)) || s.record(base.Add(2*time.Second)) {
+		t.Fatal("must not trip at or below the threshold")
+	}
+	// The one that pushes the window count past the threshold trips it.
+	if !s.record(base.Add(3 * time.Second)) {
+		t.Fatal("a reconnect that pushes the count over the threshold must trip the storm")
+	}
+}
+
+func TestReconnectStormPrunesOldAttempts(t *testing.T) {
+	s := newReconnectStorm(5*time.Minute, 2, time.Hour)
+	base := time.Now()
+	s.record(base)
+	s.record(base.Add(time.Minute))
+	// Well past the window: the two old attempts age out, so a lone reconnect
+	// is not a storm — the breaker only fires on a sustained *rate*.
+	if s.record(base.Add(6 * time.Minute)) {
+		t.Fatal("attempts older than the window must prune, not accumulate into a storm")
+	}
+}
+
+func TestReconnectStormDisabled(t *testing.T) {
+	s := newReconnectStorm(time.Minute, 0, time.Hour) // maxAttempts <= 0 disables
+	now := time.Now()
+	for i := 0; i < 50; i++ {
+		if s.record(now.Add(time.Duration(i) * time.Millisecond)) {
+			t.Fatal("a non-positive maxAttempts must disable the breaker")
+		}
+	}
+}
+
+func TestReconnectStormNextDelay(t *testing.T) {
+	s := newReconnectStorm(10*time.Minute, 2, 15*time.Minute)
+	now := time.Now()
+	backoff := 5 * time.Second
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	if d := s.nextDelay(now, backoff, log); d != backoff {
+		t.Fatalf("under threshold: want backoff %v, got %v", backoff, d)
+	}
+	if d := s.nextDelay(now.Add(time.Second), backoff, log); d != backoff {
+		t.Fatalf("under threshold: want backoff %v, got %v", backoff, d)
+	}
+	// Over threshold (> 2) → the long cooldown, regardless of the backoff.
+	if d := s.nextDelay(now.Add(2*time.Second), backoff, log); d != 15*time.Minute {
+		t.Fatalf("over threshold: want cooldown 15m, got %v", d)
+	}
+	// nil logger on the storm path must not panic.
+	if d := s.nextDelay(now.Add(3*time.Second), backoff, nil); d != 15*time.Minute {
+		t.Fatalf("over threshold (nil log): want cooldown 15m, got %v", d)
+	}
+}


### PR DESCRIPTION
## What

The last governance item (deferred from PR2). The supervisor's per-attempt backoff caps the reconnect delay at 60s, and the 30s stable-window gate stops it resetting on a flapper — so a session that connects and immediately drops reconnects **~once a minute forever**. In the pooled runtime that one broken tenant keeps hammering the IRC network and the **shared egress IP** — a classic K-line trigger that would take down *every* pooled tenant on that IP.

Add a sliding-window circuit breaker over the reconnect loop (`reconnect_storm.go`): after `maxAttempts` reconnects within `window` (default **6 / 10m**), the supervisor swaps the normal backoff for a long **cooldown** (default **15m**), turning sustained flapping into long quiet periods. A genuine flapper at the 60s cap trips in ~6 min; a healthy connector never approaches it.

- One-line integration in `Run`: `delay := c.storm.nextDelay(time.Now(), backoff.Next(), c.log)`.
- `SetReconnectStorm(window, max, cooldown)` to tune; non-positive `maxAttempts` disables it.
- Applies to **dedicated + pooled** alike (connector-level) — most valuable for pooled's shared egress IP.

## Tests

`reconnect_storm_test.go`: threshold trip, window pruning (rate-based, not cumulative), disabled mode, and `nextDelay` both paths incl. the nil-logger storm path. Full `irc` suite passes with `-race`; `golangci-lint` clean; coverage gate **94.2%**.

## Closes the governance set

With this, PR2's four governance items are all in: GOMEMLIMIT, pool watchdog, slow-consumer, **reconnect-storm**. Pooled multi-tenancy is fully ready behind the gate.