### PR TITLE
fix(release): ship /turborg-server in the published image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,24 @@ builds:
       - amd64
       - arm64
 
+  # The pooled multi-tenant runtime, shipped in the SAME image as /turborg
+  # (the sidecar PoolManager runs it via an entrypoint override). Without this
+  # build the published image only has /turborg and pooled hosts can't boot.
+  - id: turborg-server
+    main: ./cmd/turborg-server
+    binary: turborg-server
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/turborg/turborg/internal/version.Version={{.Version}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
 archives:
   - id: default
     formats:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,6 +7,10 @@ LABEL org.opencontainers.image.source="https://github.com/turborg/turborg"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY turborg /turborg
+# Pooled multi-tenant runtime — same image, started via an entrypoint override
+# by the sidecar PoolManager. GoReleaser stages both build binaries into the
+# docker context.
+COPY turborg-server /turborg-server
 
 EXPOSE 8765
 


### PR DESCRIPTION
## Bug

The released `ghcr.io/turborg/turborg:<v>` image **only contains `/turborg`** — a pooled host booting it dies with `exec: "/turborg-server": no such file or directory`. Found while enabling pooled locally.

Cause: the image is built by **GoReleaser**, whose `builds:` had only `id: turborg` (`./cmd/turborg`) and whose `Dockerfile.goreleaser` only `COPY turborg /turborg`. The repo `Dockerfile` (used by local `make docker`) *does* build both, which masked the gap — but that Dockerfile isn't what ships.

## Fix

- `.goreleaser.yml`: add a `turborg-server` build (`./cmd/turborg-server`, same flags/ldflags, linux amd64+arm64).
- `Dockerfile.goreleaser`: `COPY turborg-server /turborg-server` (GoReleaser stages both build binaries into the docker context).

One artifact, two entrypoints: `/turborg` (single-tenant) + `/turborg-server` (pool, run via the sidecar's entrypoint override).

## After merge

`0.3.0` was already cut **without** the server binary, so it can't run the pool. Merging this → release-please cuts **0.3.1** → its image ships `/turborg-server` → set `pool_image`/`SIDECAR_POOL_IMAGE` to `…:0.3.1`. (Verified `cmd/turborg-server` builds; goreleaser config is a standard build stanza, validated at release.)