### PR TITLE
feat(irc): Settings.ApplyDefaults — shared defaults for hand-built (pooled) settings

### DIFF
--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -139,6 +139,52 @@ func parseChannelList(raw string) []string {
 	return out
 }
 
+// ApplyDefaults fills the operational fields a HAND-BUILT Settings leaves at
+// their zero value with the same defaults the env loader applies — so a Settings
+// built from a spec (the pooled runtime's settingsFromConnectorSpec) behaves
+// identically to the env-loaded dedicated path (CTCP auto-reply on, liveness
+// probing, reconnect escalation, …). The values mirror the `envDefault` tags
+// above; this is the single place the hand-built path picks them up.
+//
+// It must NOT be called on an env-loaded Settings: the true-default bools below
+// are forced on, which would clobber an operator's explicit `CTCP_AUTO_REPLY=false`
+// (the env layer preserves that; a fill-zero defaulter can't tell "unset" from
+// "explicit false"). The connector spec doesn't express these fields, so forcing
+// the defaults is correct for the hand-built path.
+func (s *Settings) ApplyDefaults() {
+	setIfZero(&s.Port, 6697)
+	setIfZero(&s.RealName, "turborg agent")
+	setIfZero(&s.QuitMessage, "bye from turborg")
+	setIfZero(&s.DialTimeout, 20*time.Second)
+	setIfZero(&s.HandshakeTimeout, 30*time.Second)
+	setIfZero(&s.ReadIdleTimeout, 300*time.Second)
+	setIfZero(&s.ClientPingInterval, 120*time.Second)
+	setIfZero(&s.PongTimeout, 30*time.Second)
+	setIfZero(&s.UpstreamWarnAfter, 10*time.Minute)
+	setIfZero(&s.UpstreamPauseAfter, time.Hour)
+	setIfZero(&s.CTCPMaxPerWindow, 3)
+	setIfZero(&s.CTCPWindowSeconds, 30)
+	setIfZero(&s.BouncerHost, "127.0.0.1")
+	setIfZero(&s.BouncerPort, 31337)
+	setIfZero(&s.BouncerMaxFailedAttempts, 5)
+	setIfZero(&s.BouncerFailureWindowSeconds, 60)
+	setIfZero(&s.BouncerLockoutSeconds, 300)
+	setIfZero(&s.BouncerWelcomeReplayDepth, 200)
+	// true-default bools: a hand-built (spec) Settings leaves these false and the
+	// spec doesn't carry them, so default them on to match env.
+	s.CTCPAutoReply = true
+	s.BouncerRatelimitEnabled = true
+}
+
+// setIfZero assigns def to *p only when *p is the zero value. Lets ApplyDefaults
+// read as a flat default table instead of N if-blocks.
+func setIfZero[T comparable](p *T, def T) {
+	var zero T
+	if *p == zero {
+		*p = def
+	}
+}
+
 // NormalizedChannels returns Channels with a '#' prefix added where the
 // caller omitted one. Channels already starting with #/&/+/! are passed
 // through unchanged.

--- a/internal/connector/irc/settings_test.go
+++ b/internal/connector/irc/settings_test.go
@@ -62,6 +62,41 @@ func TestLoadSettingsDefaults(t *testing.T) {
 	assert.Equal(t, "bye from turborg", s.EffectiveQuitMessage())
 }
 
+func TestApplyDefaultsFillsHandBuiltSettings(t *testing.T) {
+	// A spec-built Settings (only the required + spec fields set) gets the same
+	// operational defaults the env loader applies.
+	s := &irc.Settings{Hostname: "irc.example", Nick: "bot", UseTLS: false}
+	s.ApplyDefaults()
+
+	assert.Equal(t, 6697, s.Port)
+	assert.Equal(t, "turborg agent", s.RealName)
+	assert.True(t, s.CTCPAutoReply, "CTCP auto-reply defaults on")
+	assert.Equal(t, 3, s.CTCPMaxPerWindow)
+	assert.Equal(t, 20*time.Second, s.DialTimeout)
+	assert.Equal(t, 300*time.Second, s.ReadIdleTimeout)
+	assert.Equal(t, 120*time.Second, s.ClientPingInterval)
+	assert.Equal(t, 30*time.Second, s.PongTimeout)
+	assert.Equal(t, 10*time.Minute, s.UpstreamWarnAfter)
+	assert.Equal(t, 200, s.BouncerWelcomeReplayDepth)
+	assert.NoError(t, s.Validate(), "defaulted settings satisfy cross-field validation")
+}
+
+func TestApplyDefaultsPreservesSetValues(t *testing.T) {
+	// Non-zero fields the builder already set are left alone (the bools are the
+	// documented exception — forced on for the spec path).
+	s := &irc.Settings{
+		Hostname: "irc.example", Nick: "bot",
+		Port: 6667, RealName: "custom", DialTimeout: 5 * time.Second,
+		CTCPMaxPerWindow: 9,
+	}
+	s.ApplyDefaults()
+
+	assert.Equal(t, 6667, s.Port)
+	assert.Equal(t, "custom", s.RealName)
+	assert.Equal(t, 5*time.Second, s.DialTimeout)
+	assert.Equal(t, 9, s.CTCPMaxPerWindow)
+}
+
 func TestEffectiveQuitMessageFallsBackWhenEmpty(t *testing.T) {
 	// Tests that build Settings by hand (bypassing LoadSettings + envDefault)
 	// still get a sensible fallback rather than an empty trailing parameter.

--- a/internal/server/connector_irc.go
+++ b/internal/server/connector_irc.go
@@ -42,6 +42,11 @@ func settingsFromConnectorSpec(cs ConnectorSpec) (*irc.Settings, error) {
 		ServerPassword:   stringField(cs.Secrets, "server_password"),
 	}
 
+	// Apply the same operational defaults the env loader gives the dedicated
+	// path, so pooled tenants get CTCP auto-reply, liveness probing, reconnect
+	// escalation, etc. — not the Go zero values a spec-built struct starts with.
+	s.ApplyDefaults()
+
 	if err := s.Validate(); err != nil {
 		return nil, fmt.Errorf("irc settings: %w", err)
 	}

--- a/internal/server/connector_irc_test.go
+++ b/internal/server/connector_irc_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -46,6 +47,24 @@ func TestSettingsRealNameDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "turborg agent", s.RealName)
 	require.True(t, s.UseTLS, "use_tls defaults true when absent")
+}
+
+// TestSettingsAppliesOperationalDefaults: a spec-built Settings gets the same
+// env-defaulted operational fields the dedicated path does — chiefly CTCP
+// auto-reply (the pooled `/ctcp <bot> version` drift), plus liveness probing
+// and reconnect escalation. UseTLS=false above proves ApplyDefaults doesn't
+// clobber spec-set fields.
+func TestSettingsAppliesOperationalDefaults(t *testing.T) {
+	s, err := settingsFromConnectorSpec(ircConfig(nil))
+	require.NoError(t, err)
+	require.True(t, s.CTCPAutoReply, "CTCP auto-reply must default on for pooled too")
+	require.Equal(t, 3, s.CTCPMaxPerWindow)
+	require.Equal(t, 30, s.CTCPWindowSeconds)
+	require.Equal(t, 20*time.Second, s.DialTimeout)
+	require.Equal(t, 300*time.Second, s.ReadIdleTimeout)
+	require.Equal(t, 120*time.Second, s.ClientPingInterval)
+	require.Equal(t, 30*time.Second, s.PongTimeout)
+	require.Equal(t, 200, s.BouncerWelcomeReplayDepth)
 }
 
 func TestSettingsBareHostDefaultsPort(t *testing.T) {


### PR DESCRIPTION
## Summary

Stage 1 of unifying pooled/dedicated composition (`accounts-api/dev/PLAN-unify-runtime-composition.md`). Fixes the concrete drift: `/ctcp <bot> version` got no reply on pooled but worked on dedicated.

Pooled builds `irc.Settings` from the tenant spec (`settingsFromConnectorSpec`), leaving every env-defaulted operational field at its Go zero value → `CTCPAutoReply=false`, no liveness probing, no reconnect escalation. Dedicated got these from the `envDefault` tags via `LoadSettings`.

- **`Settings.ApplyDefaults()`** (via a generic `setIfZero` helper) — the single place the hand-built path applies the same defaults: CTCP auto-reply + throttle, dial/handshake/read-idle/ping/pong timeouts, upstream warn/pause, bouncer welcome depth, quit message.
- `settingsFromConnectorSpec` calls it before `Validate`.
- **Not** called on env-loaded settings — the forced true-default bools would clobber an operator's explicit `CTCP_AUTO_REPLY=false` (env preserves it; a fill-zero defaulter can't tell unset from explicit-false).

## Test plan
- [x] `go test -race ./...` green; `make cover-gate` green (irc 93.7%, server 92.5%, total 94.2%)
- [x] Tests: spec-built settings get CTCP on + timeouts; `ApplyDefaults` fills a hand-built struct + preserves already-set values; the existing `use_tls:false` test proves it doesn't clobber spec-set fields.

Does **not** re-roll staging — main still carries the pooled state-sync (#48) feedback loop (staging pool is on 0.4.0). Re-roll waits for the loop decouple (next stage) so we don't ship the loop again.