### PR TITLE
fix(server): wire bouncer password for pooled tenants

### DIFF
--- a/internal/server/connector_irc.go
+++ b/internal/server/connector_irc.go
@@ -13,9 +13,11 @@ import (
 // Pure — no IO. The single-tenant binary derives the same struct from env via
 // irc.LoadSettings; this is the pooled-mode equivalent sourced from a spec.
 //
-// The per-tenant bouncer is intentionally NOT wired here: N tenants in one
-// process can't each bind a host bouncer port. Pooled bouncer attach is the
-// SNI-router milestone (M6); until then pooled tenants run upstream-only.
+// The bouncer is wired listenerless: it never binds a host port (N tenants in
+// one process can't), and the pool's PROXY-v2 SNI router (M6) feeds it accepted
+// connections via ServeBouncerConn. BouncerPassword (from the spec secrets) is
+// what ENABLES the bouncer — without it the connector runs upstream-only and a
+// routed client connection is closed.
 func settingsFromConnectorSpec(cs ConnectorSpec) (*irc.Settings, error) {
 	host, port, err := splitNetwork(stringField(cs.Config, "network"))
 	if err != nil {
@@ -40,6 +42,8 @@ func settingsFromConnectorSpec(cs ConnectorSpec) (*irc.Settings, error) {
 		SASLPassword:     stringField(cs.Secrets, "sasl_password"),
 		NickServPassword: stringField(cs.Secrets, "nickserv_password"),
 		ServerPassword:   stringField(cs.Secrets, "server_password"),
+		// Enables the (listenerless) bouncer the pool's SNI router feeds.
+		BouncerPassword: stringField(cs.Secrets, "bouncer_password"),
 	}
 
 	// Apply the same operational defaults the env loader gives the dedicated

--- a/internal/server/connector_irc_test.go
+++ b/internal/server/connector_irc_test.go
@@ -42,6 +42,24 @@ func TestSettingsFromConnectorSpec(t *testing.T) {
 	require.Equal(t, "p", s.SASLPassword)
 }
 
+func TestSettingsWiresBouncerPasswordFromSecrets(t *testing.T) {
+	// The spec carries bouncer_password in secrets; settingsFromConnectorSpec
+	// must read it so the (listenerless) bouncer the SNI router feeds is enabled.
+	cs := ircConfig(nil)
+	cs.Secrets = map[string]any{"bouncer_password": "bnc-pass"}
+
+	s, err := settingsFromConnectorSpec(cs)
+	require.NoError(t, err)
+	require.Equal(t, "bnc-pass", s.BouncerPassword)
+	require.True(t, s.BouncerEnabled(), "bouncer enables when the spec carries a password")
+}
+
+func TestSettingsBouncerDisabledWithoutPassword(t *testing.T) {
+	s, err := settingsFromConnectorSpec(ircConfig(nil)) // no bouncer_password secret
+	require.NoError(t, err)
+	require.False(t, s.BouncerEnabled(), "no password → bouncer stays off (upstream-only)")
+}
+
 func TestSettingsRealNameDefaults(t *testing.T) {
 	s, err := settingsFromConnectorSpec(ircConfig(nil))
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- The pooled SNI bouncer **edge** (HAProxy `:7900`) and **router** (`:7901` PROXY-v2) are built and route a client connection to the correct tenant — but `settingsFromConnectorSpec` never read `bouncer_password` from the spec secrets, so `BouncerEnabled()` was always `false`. The router delivered the connection to a tenant with no running bouncer → socket closed immediately after login (`Connected. Now logging in. Disconnected`).
- Read `bouncer_password` from the spec secrets so the (listenerless) bouncer the router feeds is enabled. `buildConnectors` already calls `SetBouncerListenerless(true)`, and the accounts-api tenant feed already ships `bouncer_password` — this was the one missing link.

This is the last pooled-connector parity gap of the same class as the earlier CTCP / state-sync drift: pooled re-implements a subset of the dedicated connector wiring and missed a field. The systematic fix (a shared `BuildAgent` composition) is tracked separately.

## Test plan
- [x] `TestSettingsWiresBouncerPasswordFromSecrets` — spec carries `bouncer_password` → `s.BouncerPassword` set + `BouncerEnabled()` true
- [x] `TestSettingsBouncerDisabledWithoutPassword` — no password → bouncer stays off (upstream-only)
- [x] `go test ./internal/server/... ./internal/connector/irc/...` green
- [ ] Post-merge: cut release, bump pool_image on staging, re-roll, verify a client can attach to `*.bouncer.irc.staging.xshellz.com`