### PR TITLE
feat(server): full pooled parity — activity, durable history, nudge, throttle

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -93,6 +93,15 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	store, sink := buildMessageStore(s, log)
 	_ = sink // referenced for lifecycle parity; closing happens with the agent
 
+	// Dedicated activity transport: a per-event POST to the local sidecar via
+	// the Notifier. Only wired when configured; the pooled runtime supplies its
+	// own coalescing hook instead (per-event POSTs to the control plane don't
+	// scale across a pool).
+	var activityHook func(string)
+	if notifier.Enabled() {
+		activityHook = notifier.Hook
+	}
+
 	// The connector-agnostic, transport-independent wiring — builtins, owner
 	// guard, throttles, nudge, store submitters. The pooled runtime calls this
 	// same WireCommon from its tenant builder, so the two modes can't drift.
@@ -119,7 +128,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		OwnerDMNudgeEvery:         s.OwnerDMNudgeEvery,
 		BouncerWelcomeReplayDepth: ircCfg.BouncerWelcomeReplayDepth,
 		LLM:                       provider,
-		Activity:                  notifier,
+		ActivityHook:              activityHook,
 		Store:                     store,
 	}, log); err != nil {
 		return nil, err

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/turborg/turborg/internal/activity"
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/llm"
@@ -50,8 +49,12 @@ type CommonParams struct {
 	// pooled tenants (a stateless HTTP client) and per-process for dedicated.
 	LLM llm.Provider
 
-	// Activity notifier. Nil or disabled → activity hooks are not attached.
-	Activity *activity.Notifier
+	// ActivityHook fires on connector activity (bouncer attach, message
+	// traffic). Nil → activity hooks are not attached. Dedicated passes its
+	// Notifier.Hook (a per-event POST to the local sidecar); pooled passes a
+	// hook that marks the tenant active in the pool's coalescing aggregator
+	// (a per-event POST per tenant would hammer the control plane).
+	ActivityHook func(reason string)
 
 	// Store backs bouncer welcome replay + web-shell scrollback + CHATHISTORY.
 	// Nil → no store wiring (no submitters, connector keeps its zero value).
@@ -94,9 +97,9 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	a.Commands.SetMaxDynamic(p.CustomCommandsMax)
 	ircConn.SetClientLimits(p.Limits)
 
-	if p.Activity != nil && p.Activity.Enabled() {
-		ircConn.SetActivityHook(p.Activity.Hook)
-		ircConn.SetBouncerAttachHook(p.Activity.Hook)
+	if p.ActivityHook != nil {
+		ircConn.SetActivityHook(p.ActivityHook)
+		ircConn.SetBouncerAttachHook(p.ActivityHook)
 	}
 
 	if p.OutboundMaxPerWindow > 0 && p.OutboundWindowSeconds > 0 {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,11 @@ type Server struct {
 	// to each tenant's agent wiring. Nil → !ask is not registered.
 	llmProvider llm.Provider
 
+	// activity coalesces per-tenant activity into a coarse bulk heartbeat to the
+	// control plane so last_active_at refreshes and the idle reaper spares
+	// actively-used pooled tenants. Nil when no control plane is configured.
+	activity *activityAggregator
+
 	mu      sync.Mutex
 	tenants map[string]*Tenant
 }
@@ -63,6 +68,7 @@ func New(source TenantSource, log *slog.Logger) *Server {
 func (s *Server) SetControlPlane(url, token string) {
 	s.controlPlaneURL = url
 	s.controlPlaneToken = token
+	s.activity = newActivityAggregator(url, token, s.log)
 }
 
 // SetLLM installs the shared LLM provider that powers !ask for every tenant.
@@ -76,6 +82,10 @@ func (s *Server) SetLLM(p llm.Provider) {
 // streamed events until ctx is cancelled, at which point it drains all
 // tenants and returns ctx.Err().
 func (s *Server) Run(ctx context.Context) error {
+	// Pooled activity heartbeat flusher (no-op when no control plane). Exits
+	// when ctx is cancelled, alongside the tenants.
+	safe.Go("activity-flush", func() { s.activity.run(ctx) })
+
 	initial, err := s.source.Initial(ctx)
 	if err != nil {
 		return err
@@ -135,7 +145,7 @@ func (s *Server) upsert(ctx context.Context, spec TenantSpec) {
 		existing.update(spec)
 		return
 	}
-	s.tenants[spec.TurborgID] = startTenant(ctx, spec, s.log, s.quarantineBase, s.workFactory, s.controlPlaneURL, s.controlPlaneToken, s.llmProvider)
+	s.tenants[spec.TurborgID] = startTenant(ctx, spec, s.log, s.quarantineBase, s.workFactory, s.controlPlaneURL, s.controlPlaneToken, s.llmProvider, s.activity)
 }
 
 // remove detaches a tenant, draining its goroutine. No-op when absent.

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"reflect"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/messages"
+	"github.com/turborg/turborg/internal/messagesink"
 	"github.com/turborg/turborg/internal/runtime"
 	"github.com/turborg/turborg/internal/safe"
 	"github.com/turborg/turborg/internal/statepush"
@@ -103,13 +105,22 @@ type Tenant struct {
 	// llmProvider is the shared !ask provider handed down from the Server.
 	// Nil → !ask is not registered for this tenant.
 	llmProvider llm.Provider
+
+	// activity is the pool-wide aggregator this tenant marks itself active in
+	// (bouncer attach, message traffic). Nil when no control plane is set.
+	activity *activityAggregator
+
+	// messageSink is the durable-message writer for the current run, owning a
+	// background flush goroutine. Captured so defaultWork can Close it on run
+	// end (goleak-clean across restarts). nil between runs / no control plane.
+	messageSink *messagesink.Sink
 }
 
 // startTenant launches a self-supervising tenant under a child of parent.
 // workFactory builds the body to run (and re-run after a panic) from the
 // constructed Tenant; quarantineBase is the first backoff step (doubled per
 // consecutive failure, capped).
-func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger, quarantineBase time.Duration, workFactory func(*Tenant) func(context.Context) error, controlPlaneURL, controlPlaneToken string, llmProvider llm.Provider) *Tenant {
+func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger, quarantineBase time.Duration, workFactory func(*Tenant) func(context.Context) error, controlPlaneURL, controlPlaneToken string, llmProvider llm.Provider, activity *activityAggregator) *Tenant {
 	ctx, cancel := context.WithCancel(parent)
 	t := &Tenant{
 		ID:                spec.TurborgID,
@@ -123,6 +134,7 @@ func startTenant(parent context.Context, spec TenantSpec, log *slog.Logger, quar
 		controlPlaneURL:   controlPlaneURL,
 		controlPlaneToken: controlPlaneToken,
 		llmProvider:       llmProvider,
+		activity:          activity,
 	}
 	t.work = workFactory(t)
 	safe.Go("supervise/"+spec.TurborgID, func() { t.supervise(ctx) })
@@ -263,14 +275,23 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 		t.mu.Lock()
 		gw := t.gateway
 		em := t.stateEmitter
+		sink := t.messageSink
 		t.ircConn = nil
 		t.gateway = nil
 		t.stateEmitter = nil
+		t.messageSink = nil
 		t.mu.Unlock()
 		if gw != nil {
 			gw.Stop()
 		}
 		em.Stop() // safe on nil
+		if sink != nil {
+			// Drain + stop the sink's flush goroutine so restarts stay
+			// goleak-clean. Bounded so a slow control plane can't hang teardown.
+			closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			sink.Close(closeCtx)
+			cancel()
+		}
 		return err
 	}
 }
@@ -284,6 +305,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 	connectors := t.spec.Connectors
 	caps := t.spec.PlanCapabilities
 	gatewayToken := t.spec.GatewayToken
+	ignoredNicks := t.spec.IgnoredNicks
 	t.mu.Unlock()
 
 	for _, cs := range connectors {
@@ -305,14 +327,24 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// tenant resolution. Set before WireCommon adds the connector.
 			conn.SetBouncerListenerless(true)
 
+			// Durable message store (write-through to the control plane), so the
+			// bouncer welcome replay, web-shell scrollback, and the user's
+			// readable history survive a pool restart. Falls back to in-process
+			// when no control plane is configured. The sink owns a flush
+			// goroutine closed in defaultWork.
+			store, sink := t.buildMessageStore()
+			t.mu.Lock()
+			t.messageSink = sink
+			t.mu.Unlock()
+
 			// The shared, connector-agnostic wiring — identical to the dedicated
 			// runtime, which calls the same runtime.WireCommon. Gives pooled
 			// tenants builtins (!ping/!version/!ask), the owner command guard,
-			// plan limits + outbound throttle, and message-store submitters, so
-			// the two modes can't drift. Owner-trust config travels in the
-			// connector config (the feed reuses the same connectorList() shape
-			// the dedicated spawn payload does).
-			if err := runtime.WireCommon(a, conn, t.commonParams(cs, caps, settings.Nick), t.log); err != nil {
+			// plan limits + outbound throttle, owner nudge, activity reporting,
+			// and message-store submitters, so the two modes can't drift. Owner-
+			// trust config travels in the connector config (the feed reuses the
+			// same connectorList() shape the dedicated spawn payload does).
+			if err := runtime.WireCommon(a, conn, t.commonParams(cs, caps, settings.Nick, store, ignoredNicks), t.log); err != nil {
 				t.log.Error("skipping irc connector: wiring failed", "err", err)
 				continue
 			}
@@ -354,20 +386,18 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 }
 
 // commonParams maps a tenant's IRC connector spec + plan caps onto the
-// runtime.CommonParams the shared agent wiring consumes. Owner-trust fields
-// live in the connector config (the feed reuses the dedicated connectorList()
-// shape); identity limits + the outbound throttle come from the plan caps; the
-// LLM provider is the pool-process-wide shared one.
+// runtime.CommonParams the shared agent wiring consumes — the single place
+// pooled inputs become the same struct the dedicated runtime builds from env.
+// Owner-trust fields live in the connector config (the feed reuses the
+// dedicated connectorList() shape); identity limits, throttles, and the nudge
+// interval come from the plan caps; ignored nicks + the LLM provider + the
+// store + the activity hook are threaded from the tenant.
 //
-// Fields the pooled feed doesn't carry yet — custom-commands cap, per-sender
-// command throttle, owner-DM nudge interval, ignored nicks, and a durable
-// message store — default to their zero values here (builtins-only, no
-// throttle, no nudge, in-process MemoryStore). Phase 3 extends the feed +
-// control plane to fill them, at which point this is the single place to map
-// them through.
-func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick string) runtime.CommonParams {
+// The one field still unset is CustomCommandsMax: free (the only pooled tier)
+// has it at 0, so there's nothing to carry.
+func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick string, store messages.Store, ignoredNicks []string) runtime.CommonParams {
 	var limits irc.ClientLimits
-	var outMax, outWin int
+	var outMax, outWin, nudge, cmdMax, cmdWin int
 	if caps != nil {
 		limits = irc.ClientLimits{
 			NickLocked:     caps.NickLocked,
@@ -375,22 +405,56 @@ func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick 
 			MaxChannels:    caps.MaxChannels,
 		}
 		outMax, outWin = caps.OutboundMsgsPerWindow, caps.OutboundWindowSeconds
+		nudge = caps.OwnerDMNudgeEvery
+		cmdMax, cmdWin = caps.CommandMaxPerWindow, caps.CommandWindowSeconds
 	}
+
+	// Activity hook: mark this tenant active in the pool's coalescing
+	// aggregator. Nil when no control plane is configured.
+	var activityHook func(string)
+	if t.activity != nil {
+		activityHook = func(string) { t.activity.Mark(t.ID) }
+	}
+
+	ownerNick := stringField(cs.Config, "owner_nick")
 	return runtime.CommonParams{
 		Limits: limits,
 		Owner: runtime.GuardParams{
-			OwnerMode:     stringField(cs.Config, "owner_mode"),
-			OwnerNick:     stringField(cs.Config, "owner_nick"),
-			OwnerAccount:  stringField(cs.Config, "owner_account"),
-			OwnerHostmask: stringField(cs.Config, "owner_hostmask"),
-			BotNick:       botNick,
+			OwnerMode:            stringField(cs.Config, "owner_mode"),
+			OwnerNick:            ownerNick,
+			OwnerAccount:         stringField(cs.Config, "owner_account"),
+			OwnerHostmask:        stringField(cs.Config, "owner_hostmask"),
+			IgnoredNicks:         ignoredNicks,
+			BotNick:              botNick,
+			CommandMaxPerWindow:  cmdMax,
+			CommandWindowSeconds: cmdWin,
 		},
 		OutboundMaxPerWindow:  outMax,
 		OutboundWindowSeconds: outWin,
-		OwnerNick:             stringField(cs.Config, "owner_nick"),
+		OwnerNick:             ownerNick,
+		OwnerDMNudgeEvery:     nudge,
 		LLM:                   t.llmProvider,
-		Store:                 messages.NewMemoryStore(0),
+		ActivityHook:          activityHook,
+		Store:                 store,
 	}
+}
+
+// buildMessageStore builds this tenant's message store. With a control plane
+// configured it's a write-through HTTP store pointed at the per-tenant control-
+// plane endpoint (durable history that survives a pool restart + serves the
+// user's readable log window); the returned sink owns a flush goroutine the
+// caller must Close. Without a control plane it's an in-process MemoryStore
+// (and a nil sink) — the OSS/file-source path.
+func (t *Tenant) buildMessageStore() (messages.Store, *messagesink.Sink) {
+	if t.controlPlaneURL == "" {
+		return messages.NewMemoryStore(0), nil
+	}
+	base := strings.TrimRight(t.controlPlaneURL, "/") + "/turborgs/" + t.ID + "/messages"
+	sink := messagesink.New(base, t.controlPlaneToken, t.log)
+	if hs := messages.NewHTTPStore(base, t.controlPlaneToken, sink, t.log); hs != nil {
+		return hs, sink
+	}
+	return messages.NewMemoryStore(0), sink
 }
 
 // update applies a new desired spec to a running tenant (M7, conservative

--- a/internal/server/tenant_activity.go
+++ b/internal/server/tenant_activity.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// activityFlushInterval is how often the pool flushes its coalesced active-
+// tenant set to the control plane. Coarse on purpose: last_active_at only gates
+// the multi-day idle reaper, so minute granularity is ample and keeps the
+// control-plane write rate to one bulk POST per interval per pool — not one per
+// agent message across thousands of tenants.
+const activityFlushInterval = 60 * time.Second
+
+// activityHTTPTimeout bounds a single bulk-flush POST.
+const activityHTTPTimeout = 10 * time.Second
+
+// httpDoer is the slice of *http.Client the aggregator needs; swapped in tests.
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// activityAggregator coalesces per-tenant activity signals into a coarse
+// periodic bulk POST to the control plane's /turborgs/activity endpoint.
+//
+// Dedicated containers report activity to their host's sidecar (in-memory),
+// which accounts-api pulls onto last_active_at. Pooled tenants have no sidecar
+// hop, so the pool batches active tenant IDs here and flushes them on a timer.
+// Without it a pooled tenant's last_active_at would never refresh and the idle
+// reaper would kill an actively-used free tenant. Inert (Mark is a no-op, run
+// returns immediately) when no control plane is configured.
+type activityAggregator struct {
+	url    string
+	token  string
+	client httpDoer
+	log    *slog.Logger
+
+	mu     sync.Mutex
+	active map[string]struct{}
+}
+
+// newActivityAggregator returns an aggregator posting to
+// <controlPlaneURL>/turborgs/activity, or nil when no control plane is set
+// (the OSS/file-source path) so activity reporting is simply off.
+func newActivityAggregator(controlPlaneURL, token string, log *slog.Logger) *activityAggregator {
+	if controlPlaneURL == "" {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &activityAggregator{
+		url:    strings.TrimRight(controlPlaneURL, "/") + "/turborgs/activity",
+		token:  token,
+		client: &http.Client{Timeout: activityHTTPTimeout},
+		log:    log,
+		active: map[string]struct{}{},
+	}
+}
+
+// Mark records a tenant as active since the last flush. Safe on a nil receiver
+// (the no-control-plane path) and from many goroutines.
+func (a *activityAggregator) Mark(turborgID string) {
+	if a == nil || turborgID == "" {
+		return
+	}
+	a.mu.Lock()
+	a.active[turborgID] = struct{}{}
+	a.mu.Unlock()
+}
+
+// run flushes the active set on a ticker until ctx is cancelled. Nil receiver
+// returns immediately. The last sub-interval of activity is intentionally not
+// flushed on shutdown: last_active_at was bumped at most one interval ago, which
+// is irrelevant to the multi-day idle window, and skipping it keeps shutdown
+// from blocking on a network call.
+func (a *activityAggregator) run(ctx context.Context) {
+	if a == nil {
+		return
+	}
+	ticker := time.NewTicker(activityFlushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			a.flush(ctx)
+		}
+	}
+}
+
+// drain atomically swaps out the active set, returning the IDs to flush.
+func (a *activityAggregator) drain() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.active) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(a.active))
+	for id := range a.active {
+		ids = append(ids, id)
+	}
+	a.active = map[string]struct{}{}
+	return ids
+}
+
+func (a *activityAggregator) flush(ctx context.Context) {
+	ids := a.drain()
+	if len(ids) == 0 {
+		return
+	}
+	body, err := json.Marshal(map[string][]string{"turborg_ids": ids})
+	if err != nil {
+		a.log.Debug("activity marshal", "err", err)
+		return
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, activityHTTPTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, a.url, bytes.NewReader(body))
+	if err != nil {
+		a.log.Debug("activity request", "err", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if a.token != "" {
+		req.Header.Set("Authorization", "Bearer "+a.token)
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		a.log.Debug("activity flush", "err", err, "count", len(ids))
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		a.log.Debug("activity flush non-2xx", "status", resp.StatusCode, "count", len(ids))
+	}
+}

--- a/internal/server/tenant_activity_test.go
+++ b/internal/server/tenant_activity_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordedReq struct {
+	url  string
+	auth string
+	body string
+}
+
+type recordingDoer struct {
+	mu   sync.Mutex
+	reqs []recordedReq
+}
+
+func (d *recordingDoer) Do(req *http.Request) (*http.Response, error) {
+	body, _ := io.ReadAll(req.Body)
+	d.mu.Lock()
+	d.reqs = append(d.reqs, recordedReq{
+		url:  req.URL.String(),
+		auth: req.Header.Get("Authorization"),
+		body: string(body),
+	})
+	d.mu.Unlock()
+	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+}
+
+func (d *recordingDoer) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.reqs)
+}
+
+func TestNewActivityAggregatorNilWithoutControlPlane(t *testing.T) {
+	require.Nil(t, newActivityAggregator("", "tok", nil))
+}
+
+func TestActivityAggregatorBuildsTurborgsActivityURL(t *testing.T) {
+	agg := newActivityAggregator("https://cp.example/v1/internal/", "tok", nil)
+	require.NotNil(t, agg)
+	require.Equal(t, "https://cp.example/v1/internal/turborgs/activity", agg.url)
+}
+
+func TestActivityAggregatorFlushPostsDedupedBatch(t *testing.T) {
+	agg := newActivityAggregator("https://cp.example/v1/internal", "host-token", nil)
+	doer := &recordingDoer{}
+	agg.client = doer
+
+	agg.Mark("t1")
+	agg.Mark("t2")
+	agg.Mark("t1") // duplicate within the window — one entry
+	agg.flush(context.Background())
+
+	require.Equal(t, 1, doer.count())
+	require.Equal(t, "https://cp.example/v1/internal/turborgs/activity", doer.reqs[0].url)
+	require.Equal(t, "Bearer host-token", doer.reqs[0].auth)
+	require.Contains(t, doer.reqs[0].body, "t1")
+	require.Contains(t, doer.reqs[0].body, "t2")
+
+	// The set is drained on flush — a second flush with no new marks is a no-op.
+	agg.flush(context.Background())
+	require.Equal(t, 1, doer.count())
+}
+
+func TestActivityAggregatorEmptyFlushIsNoop(t *testing.T) {
+	agg := newActivityAggregator("https://cp.example", "tok", nil)
+	doer := &recordingDoer{}
+	agg.client = doer
+
+	agg.flush(context.Background())
+	require.Equal(t, 0, doer.count())
+}
+
+func TestActivityAggregatorNilReceiverSafe(t *testing.T) {
+	var agg *activityAggregator
+	require.NotPanics(t, func() {
+		agg.Mark("x")
+		agg.run(context.Background()) // returns immediately on nil
+	})
+}
+
+func TestActivityAggregatorRunExitsOnCancel(t *testing.T) {
+	agg := newActivityAggregator("https://cp.example", "tok", nil)
+	agg.client = &recordingDoer{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { agg.run(ctx); close(done) }()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("run did not exit on context cancellation")
+	}
+}

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -39,6 +39,10 @@ type TenantSpec struct {
 	Connectors       []ConnectorSpec   `json:"connectors"`
 	PlanCapabilities *PlanCapabilities `json:"plan_capabilities,omitempty"`
 
+	// IgnoredNicks is the owner's per-user ignore list: the command guard drops
+	// !commands from these nicks. Mirrors the dedicated spawn payload's field.
+	IgnoredNicks []string `json:"ignored_nicks,omitempty"`
+
 	// GatewayToken authorizes the per-tenant web shell (the appui `/ws`
 	// surface). It's the turborg's existing container_token, threaded through
 	// by accounts-api; an empty token means "no web shell for this tenant" and
@@ -57,6 +61,13 @@ type PlanCapabilities struct {
 	MaxChannels           int  `json:"max_channels"`
 	OutboundMsgsPerWindow int  `json:"outbound_msgs_per_window"`
 	OutboundWindowSeconds int  `json:"outbound_window_seconds"`
+	// OwnerDMNudgeEvery: DM the owner every N outbound PRIVMSGs with a usage
+	// summary (free=100). Fires only when an owner nick is configured.
+	OwnerDMNudgeEvery int `json:"owner_dm_nudge_every"`
+	// CommandMaxPerWindow/WindowSeconds: per-sender !command throttle (free=3
+	// per 30s). 0 = unthrottled by convention.
+	CommandMaxPerWindow  int `json:"command_max_per_window"`
+	CommandWindowSeconds int `json:"command_window_seconds"`
 }
 
 // TenantEventKind distinguishes an attach/update from a detach.

--- a/internal/server/tenant_wire_test.go
+++ b/internal/server/tenant_wire_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/messages"
 )
 
 // newIRCTenant builds a Tenant whose spec carries one IRC connector with the
@@ -79,7 +80,8 @@ func TestBuildConnectorsOwnerGuardDefaultDenies(t *testing.T) {
 }
 
 // TestCommonParamsMapsCapsAndOwner locks the spec→CommonParams mapping: owner
-// fields come from the connector config, identity/throttle limits from caps.
+// fields + ignored nicks from the spec, identity/throttle/nudge limits from
+// caps, and the store threaded in.
 func TestCommonParamsMapsCapsAndOwner(t *testing.T) {
 	tn := newIRCTenant(nil, nil)
 	cs := ConnectorSpec{Config: map[string]any{
@@ -94,16 +96,24 @@ func TestCommonParamsMapsCapsAndOwner(t *testing.T) {
 		MaxChannels:           5,
 		OutboundMsgsPerWindow: 7,
 		OutboundWindowSeconds: 30,
+		OwnerDMNudgeEvery:     100,
+		CommandMaxPerWindow:   3,
+		CommandWindowSeconds:  30,
 	}
+	store := messages.NewMemoryStore(0)
 
-	p := tn.commonParams(cs, caps, "bot")
+	p := tn.commonParams(cs, caps, "bot", store, []string{"spammer", "troll"})
 
 	require.Equal(t, "external", p.Owner.OwnerMode)
 	require.Equal(t, "alice", p.Owner.OwnerNick)
 	require.Equal(t, "aliceacct", p.Owner.OwnerAccount)
 	require.Equal(t, "*!*@trusted.host", p.Owner.OwnerHostmask)
 	require.Equal(t, "bot", p.Owner.BotNick)
+	require.Equal(t, []string{"spammer", "troll"}, p.Owner.IgnoredNicks)
+	require.Equal(t, 3, p.Owner.CommandMaxPerWindow)
+	require.Equal(t, 30, p.Owner.CommandWindowSeconds)
 	require.Equal(t, "alice", p.OwnerNick)
+	require.Equal(t, 100, p.OwnerDMNudgeEvery)
 
 	require.True(t, p.Limits.NickLocked)
 	require.True(t, p.Limits.RealnameLocked)
@@ -111,5 +121,33 @@ func TestCommonParamsMapsCapsAndOwner(t *testing.T) {
 	require.Equal(t, 7, p.OutboundMaxPerWindow)
 	require.Equal(t, 30, p.OutboundWindowSeconds)
 
-	require.NotNil(t, p.Store, "pooled tenants get an in-process store for scrollback (Phase 1)")
+	require.Equal(t, store, p.Store, "the store is threaded straight through")
+	require.Nil(t, p.ActivityHook, "no aggregator on a directly-built tenant → no activity hook")
+}
+
+// TestBuildMessageStoreMemoryWithoutControlPlane: the OSS/file-source path with
+// no control plane gets an in-process store and no sink (nothing to close).
+func TestBuildMessageStoreMemoryWithoutControlPlane(t *testing.T) {
+	tn := &Tenant{ID: "t1", log: slog.Default()}
+	store, sink := tn.buildMessageStore()
+	require.NotNil(t, store)
+	require.Nil(t, sink)
+}
+
+// TestBuildMessageStoreHTTPWithControlPlane: with a control plane the store is
+// the write-through HTTP store pointed at the per-tenant endpoint, and a sink
+// (owning a flush goroutine) is returned for the caller to Close.
+func TestBuildMessageStoreHTTPWithControlPlane(t *testing.T) {
+	tn := &Tenant{
+		ID:                "t1",
+		log:               slog.Default(),
+		controlPlaneURL:   "https://cp.example/v1/internal",
+		controlPlaneToken: "host-token",
+	}
+	store, sink := tn.buildMessageStore()
+	require.NotNil(t, store)
+	require.NotNil(t, sink, "control plane configured → durable sink with a flush goroutine")
+
+	// Close the sink so its goroutine doesn't leak past the test.
+	sink.Close(context.Background())
 }


### PR DESCRIPTION
## Summary
Closes the remaining pooled-vs-dedicated gaps by feeding the shared `WireCommon` (from the unify PR #54) the inputs pooled wasn't supplying yet:

- **Activity reporting** — a pool-level `activityAggregator` coalesces per-tenant activity (bouncer attach, message traffic) and flushes a coarse bulk batch to the control plane's `POST /turborgs/activity` every minute. Each tenant marks itself active via `WireCommon`'s new `ActivityHook` (generalized from `*activity.Notifier` → `func(string)` so both modes share the wiring but keep their own transport). Without this, a pooled tenant's `last_active_at` never refreshed and the idle reaper would kill an actively-used free tenant.
- **Durable message store** — pooled builds a write-through HTTP store + sink at the per-tenant control-plane `/messages` endpoint, so bouncer welcome replay, web-shell scrollback, and the user's readable history survive a pool restart (was in-process `MemoryStore`, lost on restart + invisible to the messages API). The sink's flush goroutine is `Close`d on tenant run-end (goleak-clean across restarts).
- **Owner-DM nudge, per-sender command throttle, ignored nicks** — read from the extended tenant feed (`plan_capabilities` + top-level `ignored_nicks`) into the command guard / connector, matching dedicated.

Pairs with the accounts-api feed changes (activity endpoint, `owner_dm_nudge_every`, command throttle, `ignored_nicks`).

## Test plan
- [x] activity aggregator: deduped bulk POST shape + bearer; drains on flush; empty = no-op; nil-safe; `run` exits on ctx cancel
- [x] `buildMessageStore`: MemoryStore w/o control plane (nil sink), HTTP store + sink with it
- [x] `commonParams` maps nudge / command throttle / ignored nicks / store / (no) activity hook
- [x] `go test -race`, `make cover-gate` 94.1% (server 92.0%, runtime 94.5%), lint clean
- [ ] Post-merge: release + bump staging `pool_image`; verify active tenant not reaped + history survives a pool restart