### PR TITLE
test(server): deterministically cover the activity aggregator

### DIFF
--- a/internal/server/tenant_activity.go
+++ b/internal/server/tenant_activity.go
@@ -3,9 +3,9 @@ package server
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,10 +36,11 @@ type httpDoer interface {
 // reaper would kill an actively-used free tenant. Inert (Mark is a no-op, run
 // returns immediately) when no control plane is configured.
 type activityAggregator struct {
-	url    string
-	token  string
-	client httpDoer
-	log    *slog.Logger
+	url      string
+	token    string
+	client   httpDoer
+	interval time.Duration
+	log      *slog.Logger
 
 	mu     sync.Mutex
 	active map[string]struct{}
@@ -56,11 +57,12 @@ func newActivityAggregator(controlPlaneURL, token string, log *slog.Logger) *act
 		log = slog.Default()
 	}
 	return &activityAggregator{
-		url:    strings.TrimRight(controlPlaneURL, "/") + "/turborgs/activity",
-		token:  token,
-		client: &http.Client{Timeout: activityHTTPTimeout},
-		log:    log,
-		active: map[string]struct{}{},
+		url:      strings.TrimRight(controlPlaneURL, "/") + "/turborgs/activity",
+		token:    token,
+		client:   &http.Client{Timeout: activityHTTPTimeout},
+		interval: activityFlushInterval,
+		log:      log,
+		active:   map[string]struct{}{},
 	}
 }
 
@@ -84,7 +86,7 @@ func (a *activityAggregator) run(ctx context.Context) {
 	if a == nil {
 		return
 	}
-	ticker := time.NewTicker(activityFlushInterval)
+	ticker := time.NewTicker(a.interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -116,11 +118,16 @@ func (a *activityAggregator) flush(ctx context.Context) {
 	if len(ids) == 0 {
 		return
 	}
-	body, err := json.Marshal(map[string][]string{"turborg_ids": ids})
-	if err != nil {
-		a.log.Debug("activity marshal", "err", err)
-		return
+	// Build the fixed-shape body directly (mirrors activity.Notifier.fire):
+	// marshaling {"turborg_ids":[...]} can't fail, so skipping json.Marshal
+	// removes an unreachable error branch. IDs are control-plane UUIDs but
+	// quoted defensively.
+	quoted := make([]string, len(ids))
+	for i, id := range ids {
+		quoted[i] = strconv.Quote(id)
 	}
+	body := []byte(`{"turborg_ids":[` + strings.Join(quoted, ",") + `]}`)
+
 	reqCtx, cancel := context.WithTimeout(ctx, activityHTTPTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, a.url, bytes.NewReader(body))

--- a/internal/server/tenant_activity_test.go
+++ b/internal/server/tenant_activity_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -19,8 +20,10 @@ type recordedReq struct {
 }
 
 type recordingDoer struct {
-	mu   sync.Mutex
-	reqs []recordedReq
+	mu     sync.Mutex
+	reqs   []recordedReq
+	status int   // 0 → 200
+	err    error // when set, Do returns it (records the attempt first)
 }
 
 func (d *recordingDoer) Do(req *http.Request) (*http.Response, error) {
@@ -31,8 +34,16 @@ func (d *recordingDoer) Do(req *http.Request) (*http.Response, error) {
 		auth: req.Header.Get("Authorization"),
 		body: string(body),
 	})
+	err := d.err
+	status := d.status
 	d.mu.Unlock()
-	return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("{}"))}, nil
+	if err != nil {
+		return nil, err
+	}
+	if status == 0 {
+		status = http.StatusOK
+	}
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader("{}"))}, nil
 }
 
 func (d *recordingDoer) count() int {
@@ -103,4 +114,38 @@ func TestActivityAggregatorRunExitsOnCancel(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("run did not exit on context cancellation")
 	}
+}
+
+func TestActivityAggregatorRunFlushesOnTick(t *testing.T) {
+	agg := newActivityAggregator("https://cp.example", "tok", nil)
+	doer := &recordingDoer{}
+	agg.client = doer
+	agg.interval = 5 * time.Millisecond // tick fast so the ticker branch runs
+	agg.Mark("t1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { agg.run(ctx); close(done) }()
+
+	require.Eventually(t, func() bool { return doer.count() >= 1 }, time.Second, 2*time.Millisecond,
+		"the ticker should drive at least one flush")
+	cancel()
+	<-done
+}
+
+func TestActivityAggregatorFlushToleratesClientError(t *testing.T) {
+	agg := newActivityAggregator("https://cp.example", "tok", nil)
+	agg.client = &recordingDoer{err: errors.New("connection refused")}
+	agg.Mark("t1")
+
+	require.NotPanics(t, func() { agg.flush(context.Background()) })
+}
+
+func TestActivityAggregatorFlushToleratesNon2xx(t *testing.T) {
+	agg := newActivityAggregator("https://cp.example", "tok", nil)
+	agg.client = &recordingDoer{status: http.StatusInternalServerError}
+	agg.Mark("t1")
+
+	require.NotPanics(t, func() { agg.flush(context.Background()) })
 }


### PR DESCRIPTION
## Summary
The cover-gate is boundary-sensitive (94% total threshold). The new `activityAggregator` (PR #55) left its ticker-driven flush and transport error branches uncovered, so the total flaked just under on CI (93.9%) while passing locally (94.1%) — the release PR #53's cover-gate failed on it.

- Make the flush interval injectable so a fast-tick test deterministically exercises the ticker branch (was timing-dependent).
- Add client-error + non-2xx flush tests.
- Build the request body directly (mirrors `activity.Notifier.fire`) to drop the unreachable `json.Marshal` error branch.

Total back to **94.3%** with margin; lint clean.

## Test plan
- [x] `make cover-gate` → 94.3% (was 93.9% on CI)
- [x] aggregator tests pass under `-race`