### PR TITLE
feat(llm): token tracking + rolling-24h budget enforcement

### DIFF
--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -34,6 +34,7 @@ const (
 	EventWhoisResult    EventType = "WHOIS_RESULT"
 	EventListResult     EventType = "LIST_RESULT"
 	EventWhoResult      EventType = "WHO_RESULT"
+	EventLLMUsage       EventType = "LLM_USAGE"
 	EventError          EventType = "ERROR"
 	EventRaw            EventType = "RAW"
 )

--- a/internal/commands/builder.go
+++ b/internal/commands/builder.go
@@ -13,6 +13,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 
@@ -131,8 +132,11 @@ func llmHandler(d Definition, provider llm.Provider, log *slog.Logger) agent.Com
 		if model != "" {
 			opts = append(opts, llm.WithModel(model))
 		}
-		answer, err := provider.Ask(ctx, prompt, opts...)
+		answer, _, err := provider.Ask(ctx, prompt, opts...)
 		if err != nil {
+			if errors.Is(err, llm.ErrBudgetExhausted) {
+				return agent.ReplyTo(env, "Daily AI token budget spent. Resets on a rolling 24h window."), nil
+			}
 			log.Warn("llm command failed", "command", name, "err", err)
 			return agent.ReplyTo(env, "sorry, that broke: "+err.Error()), nil
 		}

--- a/internal/commands/builder_test.go
+++ b/internal/commands/builder_test.go
@@ -29,13 +29,13 @@ type recordingProvider struct {
 }
 
 func (p *recordingProvider) Model() string { return "rec" }
-func (p *recordingProvider) Ask(_ context.Context, prompt string, opts ...llm.CallOption) (string, error) {
+func (p *recordingProvider) Ask(_ context.Context, prompt string, opts ...llm.CallOption) (string, llm.Usage, error) {
 	co := llm.ApplyOptions(opts)
 	p.prompt = prompt
 	p.model = co.Model
 	p.system = co.System
 	p.maxTok = co.MaxTokens
-	return p.resp, p.err
+	return p.resp, llm.Usage{InputTokens: 10, OutputTokens: 5}, p.err
 }
 func (p *recordingProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
 	return func(func(string, error) bool) {}

--- a/internal/connector/irc/tb.go
+++ b/internal/connector/irc/tb.go
@@ -2,6 +2,7 @@ package irc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -90,8 +91,11 @@ func (h *tbHandler) tbSummarize(ctx context.Context, channel string, n int, cap 
 	ctx, cancel := context.WithTimeout(ctx, tbSummarizeTimeout)
 	defer cancel()
 
-	summary, err := provider.Ask(ctx, prompt, llm.WithSystem(tbSummarizeSystemPrompt), llm.WithMaxTokens(300))
+	summary, _, err := provider.Ask(ctx, prompt, llm.WithSystem(tbSummarizeSystemPrompt), llm.WithMaxTokens(300))
 	if err != nil {
+		if errors.Is(err, llm.ErrBudgetExhausted) {
+			return "", fmt.Errorf("daily AI token budget spent — resets on a rolling 24h window")
+		}
 		h.log.Warn("tb summarize LLM error", "channel", channel, "err", err)
 		return "", fmt.Errorf("LLM request failed: %w", err)
 	}

--- a/internal/connector/irc/tb_test.go
+++ b/internal/connector/irc/tb_test.go
@@ -21,8 +21,8 @@ type fakeLLM struct {
 }
 
 func (f *fakeLLM) Model() string { return "fake" }
-func (f *fakeLLM) Ask(_ context.Context, _ string, _ ...llm.CallOption) (string, error) {
-	return f.response, f.err
+func (f *fakeLLM) Ask(_ context.Context, _ string, _ ...llm.CallOption) (string, llm.Usage, error) {
+	return f.response, llm.Usage{}, f.err
 }
 func (f *fakeLLM) Stream(_ context.Context, _ string, _ ...llm.CallOption) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {}

--- a/internal/llm/anthropic/provider.go
+++ b/internal/llm/anthropic/provider.go
@@ -79,20 +79,24 @@ func (p *Provider) Model() string { return p.model }
 
 // Ask sends prompt to Claude and returns the assembled text response.
 // Streams under the hood so large outputs don't time out the request.
-func (p *Provider) Ask(ctx context.Context, prompt string, opts ...llm.CallOption) (string, error) {
+func (p *Provider) Ask(ctx context.Context, prompt string, opts ...llm.CallOption) (string, llm.Usage, error) {
 	params := p.buildParams(prompt, opts)
 	stream := p.client.Messages.NewStreaming(ctx, params)
 
 	var message sdk.Message
 	for stream.Next() {
 		if err := message.Accumulate(stream.Current()); err != nil {
-			return "", fmt.Errorf("anthropic accumulate: %w", err)
+			return "", llm.Usage{}, fmt.Errorf("anthropic accumulate: %w", err)
 		}
 	}
 	if err := stream.Err(); err != nil {
-		return "", fmt.Errorf("anthropic stream: %w", err)
+		return "", llm.Usage{}, fmt.Errorf("anthropic stream: %w", err)
 	}
-	return joinText(message), nil
+	usage := llm.Usage{
+		InputTokens:  int(message.Usage.InputTokens),
+		OutputTokens: int(message.Usage.OutputTokens),
+	}
+	return joinText(message), usage, nil
 }
 
 // Stream yields text deltas as iter.Seq2[string, error]. The error is

--- a/internal/llm/anthropic/provider_test.go
+++ b/internal/llm/anthropic/provider_test.go
@@ -91,7 +91,7 @@ func TestAskAccumulatesStreamedDeltas(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	got, err := p.Ask(context.Background(), "say hi")
+	got, _, err := p.Ask(context.Background(), "say hi")
 	require.NoError(t, err)
 	assert.Equal(t, "hello world.", got)
 }
@@ -104,7 +104,7 @@ func TestAskWrapsServerError(t *testing.T) {
 	defer srv.Close()
 
 	p, _ := anthropic.New(anthropic.Settings{APIKey: "test", BaseURL: srv.URL})
-	_, err := p.Ask(context.Background(), "x")
+	_, _, err := p.Ask(context.Background(), "x")
 	require.Error(t, err)
 }
 
@@ -161,7 +161,7 @@ func TestAskSendsSystemBlockWithCacheControl(t *testing.T) {
 		SystemPrompt:      "you are a helpful bot",
 		CacheSystemPrompt: true,
 	})
-	_, err := p.Ask(context.Background(), "say hi")
+	_, _, err := p.Ask(context.Background(), "say hi")
 	require.NoError(t, err)
 	require.NotNil(t, captured)
 
@@ -189,7 +189,7 @@ func TestAskOmitsCacheControlWhenDisabled(t *testing.T) {
 		SystemPrompt:      "short",
 		CacheSystemPrompt: false,
 	})
-	_, err := p.Ask(context.Background(), "x")
+	_, _, err := p.Ask(context.Background(), "x")
 	require.NoError(t, err)
 
 	system := captured["system"].([]any)
@@ -214,7 +214,7 @@ func TestAskRespectsPerCallOverrides(t *testing.T) {
 		Model:     "claude-sonnet-4-6",
 		MaxTokens: 100,
 	})
-	_, err := p.Ask(context.Background(), "x",
+	_, _, err := p.Ask(context.Background(), "x",
 		llm.WithSystem("override"),
 		llm.WithMaxTokens(50),
 		llm.WithModel("claude-opus-4-7"),
@@ -236,7 +236,7 @@ func TestAskOmitsSystemWhenEmpty(t *testing.T) {
 	defer srv.Close()
 
 	p, _ := anthropic.New(anthropic.Settings{APIKey: "test", BaseURL: srv.URL})
-	_, err := p.Ask(context.Background(), "x")
+	_, _, err := p.Ask(context.Background(), "x")
 	require.NoError(t, err)
 	_, ok := captured["system"]
 	assert.False(t, ok, "system field must be omitted when no system prompt is configured")
@@ -253,7 +253,7 @@ func TestAskSendsAPIKeyHeader(t *testing.T) {
 	defer srv.Close()
 
 	p, _ := anthropic.New(anthropic.Settings{APIKey: "sk-live-abc123", BaseURL: srv.URL})
-	_, err := p.Ask(context.Background(), "x")
+	_, _, err := p.Ask(context.Background(), "x")
 	require.NoError(t, err)
 	assert.Equal(t, "sk-live-abc123", key, "SDK must propagate APIKey via x-api-key header")
 }
@@ -356,7 +356,7 @@ func TestAskReturnsEmptyForBlankResponse(t *testing.T) {
 	defer srv.Close()
 
 	p, _ := anthropic.New(anthropic.Settings{APIKey: "test", BaseURL: srv.URL})
-	got, err := p.Ask(context.Background(), "x")
+	got, _, err := p.Ask(context.Background(), "x")
 	require.NoError(t, err)
 	assert.Equal(t, "", got, "joinText must return empty when the message has no text blocks")
 }
@@ -378,7 +378,7 @@ func TestNewDefaultsMaxTokensOnZero(t *testing.T) {
 		BaseURL:   srv.URL,
 		MaxTokens: 0,
 	})
-	_, err := p.Ask(context.Background(), "x")
+	_, _, err := p.Ask(context.Background(), "x")
 	require.NoError(t, err)
 	assert.Equal(t, float64(anthropic.DefaultMaxTokens), captured["max_tokens"],
 		"MaxTokens=0 must fall back to DefaultMaxTokens")

--- a/internal/llm/budget.go
+++ b/internal/llm/budget.go
@@ -1,0 +1,81 @@
+package llm
+
+import (
+	"sync"
+	"time"
+)
+
+const defaultWindow = 24 * time.Hour
+
+type tokenEntry struct {
+	ts     time.Time
+	input  int
+	output int
+}
+
+// TokenBudget tracks LLM token consumption in a rolling time window.
+// Goroutine-safe; entries older than the window are pruned on every
+// mutating call.
+type TokenBudget struct {
+	mu      sync.Mutex
+	entries []tokenEntry
+	window  time.Duration
+	now     func() time.Time // injectable clock for tests
+}
+
+func NewTokenBudget() *TokenBudget {
+	return &TokenBudget{
+		window: defaultWindow,
+		now:    time.Now,
+	}
+}
+
+// Record appends a token-consumption entry at the current time.
+func (b *TokenBudget) Record(input, output int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.prune()
+	b.entries = append(b.entries, tokenEntry{
+		ts:     b.now(),
+		input:  input,
+		output: output,
+	})
+}
+
+// Totals returns the sum of input and output tokens consumed within
+// the rolling window.
+func (b *TokenBudget) Totals() (input, output int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.prune()
+	for _, e := range b.entries {
+		input += e.input
+		output += e.output
+	}
+	return input, output
+}
+
+// Allow reports whether both input and output consumption are within
+// the given caps. A cap of 0 means unrestricted for that dimension.
+func (b *TokenBudget) Allow(inputCap, outputCap int) bool {
+	input, output := b.Totals()
+	if inputCap > 0 && input >= inputCap {
+		return false
+	}
+	if outputCap > 0 && output >= outputCap {
+		return false
+	}
+	return true
+}
+
+func (b *TokenBudget) prune() {
+	cutoff := b.now().Add(-b.window)
+	n := 0
+	for _, e := range b.entries {
+		if !e.ts.Before(cutoff) {
+			b.entries[n] = e
+			n++
+		}
+	}
+	b.entries = b.entries[:n]
+}

--- a/internal/llm/budget_test.go
+++ b/internal/llm/budget_test.go
@@ -1,0 +1,69 @@
+package llm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenBudgetRecordAndTotals(t *testing.T) {
+	b := NewTokenBudget()
+	b.Record(100, 50)
+	b.Record(200, 100)
+
+	in, out := b.Totals()
+	assert.Equal(t, 300, in)
+	assert.Equal(t, 150, out)
+}
+
+func TestTokenBudgetPrunesOldEntries(t *testing.T) {
+	b := NewTokenBudget()
+	b.window = time.Second
+
+	old := time.Now().Add(-2 * time.Second)
+	b.now = func() time.Time { return old }
+	b.Record(1000, 500)
+
+	b.now = time.Now
+	b.Record(10, 5)
+
+	in, out := b.Totals()
+	assert.Equal(t, 10, in)
+	assert.Equal(t, 5, out)
+}
+
+func TestTokenBudgetAllowRespectsInputCap(t *testing.T) {
+	b := NewTokenBudget()
+	b.Record(90, 10)
+
+	assert.True(t, b.Allow(100, 0))
+	b.Record(10, 0)
+	assert.False(t, b.Allow(100, 0))
+}
+
+func TestTokenBudgetAllowRespectsOutputCap(t *testing.T) {
+	b := NewTokenBudget()
+	b.Record(10, 90)
+
+	assert.True(t, b.Allow(0, 100))
+	b.Record(0, 10)
+	assert.False(t, b.Allow(0, 100))
+}
+
+func TestTokenBudgetAllowZeroCapMeansUnrestricted(t *testing.T) {
+	b := NewTokenBudget()
+	b.Record(999999, 999999)
+	assert.True(t, b.Allow(0, 0))
+}
+
+func TestTokenBudgetRollingWindow(t *testing.T) {
+	b := NewTokenBudget()
+	b.window = 100 * time.Millisecond
+
+	b.Record(100, 50)
+	assert.False(t, b.Allow(100, 0))
+
+	time.Sleep(150 * time.Millisecond)
+	assert.True(t, b.Allow(100, 0), "old entry should have expired")
+}

--- a/internal/llm/budgeted.go
+++ b/internal/llm/budgeted.go
@@ -1,0 +1,56 @@
+package llm
+
+import (
+	"context"
+	"iter"
+)
+
+// BudgetedProvider wraps a Provider with rolling-window token budget
+// enforcement. Before each Ask call it checks the budget; after a
+// successful call it records the consumption and fires the onUsage
+// callback for external reporting (EventBus, structured logging).
+type BudgetedProvider struct {
+	inner     Provider
+	budget    *TokenBudget
+	inputCap  int
+	outputCap int
+	onUsage   func(Usage)
+}
+
+func NewBudgetedProvider(inner Provider, budget *TokenBudget, inputCap, outputCap int, onUsage func(Usage)) *BudgetedProvider {
+	return &BudgetedProvider{
+		inner:     inner,
+		budget:    budget,
+		inputCap:  inputCap,
+		outputCap: outputCap,
+		onUsage:   onUsage,
+	}
+}
+
+func (p *BudgetedProvider) Model() string { return p.inner.Model() }
+
+func (p *BudgetedProvider) Ask(ctx context.Context, prompt string, opts ...CallOption) (string, Usage, error) {
+	if !p.budget.Allow(p.inputCap, p.outputCap) {
+		return "", Usage{}, ErrBudgetExhausted
+	}
+	text, usage, err := p.inner.Ask(ctx, prompt, opts...)
+	if err != nil {
+		return "", usage, err
+	}
+	p.budget.Record(usage.InputTokens, usage.OutputTokens)
+	if p.onUsage != nil {
+		p.onUsage(usage)
+	}
+	return text, usage, nil
+}
+
+func (p *BudgetedProvider) Stream(ctx context.Context, prompt string, opts ...CallOption) iter.Seq2[string, error] {
+	return p.inner.Stream(ctx, prompt, opts...)
+}
+
+// Budget returns the underlying TokenBudget so callers (e.g. the
+// gateway's /tb usage handler) can read live totals.
+func (p *BudgetedProvider) Budget() *TokenBudget { return p.budget }
+
+// Caps returns the configured per-day caps.
+func (p *BudgetedProvider) Caps() (inputCap, outputCap int) { return p.inputCap, p.outputCap }

--- a/internal/llm/budgeted_test.go
+++ b/internal/llm/budgeted_test.go
@@ -1,0 +1,86 @@
+package llm
+
+import (
+	"context"
+	"iter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProvider struct {
+	resp  string
+	usage Usage
+	err   error
+}
+
+func (f *fakeProvider) Model() string { return "fake" }
+func (f *fakeProvider) Ask(_ context.Context, _ string, _ ...CallOption) (string, Usage, error) {
+	return f.resp, f.usage, f.err
+}
+func (f *fakeProvider) Stream(_ context.Context, _ string, _ ...CallOption) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {}
+}
+
+func TestBudgetedProviderAllowsWithinBudget(t *testing.T) {
+	inner := &fakeProvider{resp: "ok", usage: Usage{InputTokens: 10, OutputTokens: 5}}
+	budget := NewTokenBudget()
+	var reported Usage
+	bp := NewBudgetedProvider(inner, budget, 100, 100, func(u Usage) { reported = u })
+
+	got, usage, err := bp.Ask(context.Background(), "hi")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", got)
+	assert.Equal(t, 10, usage.InputTokens)
+	assert.Equal(t, 5, usage.OutputTokens)
+	assert.Equal(t, 10, reported.InputTokens)
+
+	in, out := budget.Totals()
+	assert.Equal(t, 10, in)
+	assert.Equal(t, 5, out)
+}
+
+func TestBudgetedProviderRejectsWhenExhausted(t *testing.T) {
+	inner := &fakeProvider{resp: "ok", usage: Usage{InputTokens: 10, OutputTokens: 5}}
+	budget := NewTokenBudget()
+	budget.Record(100, 0)
+	bp := NewBudgetedProvider(inner, budget, 100, 100, nil)
+
+	_, _, err := bp.Ask(context.Background(), "hi")
+	require.ErrorIs(t, err, ErrBudgetExhausted)
+}
+
+func TestBudgetedProviderDoesNotRecordOnError(t *testing.T) {
+	inner := &fakeProvider{err: assert.AnError}
+	budget := NewTokenBudget()
+	bp := NewBudgetedProvider(inner, budget, 100, 100, nil)
+
+	_, _, err := bp.Ask(context.Background(), "hi")
+	require.Error(t, err)
+
+	in, out := budget.Totals()
+	assert.Equal(t, 0, in)
+	assert.Equal(t, 0, out)
+}
+
+func TestBudgetedProviderDelegatesModel(t *testing.T) {
+	inner := &fakeProvider{resp: "ok"}
+	bp := NewBudgetedProvider(inner, NewTokenBudget(), 0, 0, nil)
+	assert.Equal(t, "fake", bp.Model())
+}
+
+func TestBudgetedProviderStreamDelegates(t *testing.T) {
+	bp := NewBudgetedProvider(&fakeProvider{}, NewTokenBudget(), 0, 0, nil)
+	seq := bp.Stream(context.Background(), "hi")
+	assert.NotNil(t, seq)
+}
+
+func TestBudgetedProviderCapsAndBudgetAccessors(t *testing.T) {
+	budget := NewTokenBudget()
+	bp := NewBudgetedProvider(&fakeProvider{}, budget, 42, 21, nil)
+	assert.Equal(t, budget, bp.Budget())
+	inCap, outCap := bp.Caps()
+	assert.Equal(t, 42, inCap)
+	assert.Equal(t, 21, outCap)
+}

--- a/internal/llm/openaicompat/provider.go
+++ b/internal/llm/openaicompat/provider.go
@@ -108,6 +108,10 @@ type chatResponse struct {
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
 }
 
 func (p *Provider) buildRequest(prompt string, opts []llm.CallOption) chatRequest {
@@ -147,27 +151,32 @@ func (p *Provider) post(ctx context.Context, body chatRequest) (*http.Response, 
 }
 
 // Ask sends prompt and returns the assembled (non-streamed) text response.
-func (p *Provider) Ask(ctx context.Context, prompt string, opts ...llm.CallOption) (string, error) {
+func (p *Provider) Ask(ctx context.Context, prompt string, opts ...llm.CallOption) (string, llm.Usage, error) {
 	resp, err := p.post(ctx, p.buildRequest(prompt, opts))
 	if err != nil {
-		return "", err
+		return "", llm.Usage{}, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	var decoded chatResponse
 	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
-		return "", fmt.Errorf("openaicompat decode (status %d): %w", resp.StatusCode, err)
+		return "", llm.Usage{}, fmt.Errorf("openaicompat decode (status %d): %w", resp.StatusCode, err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		if decoded.Error != nil && decoded.Error.Message != "" {
-			return "", fmt.Errorf("openaicompat: %s (status %d)", decoded.Error.Message, resp.StatusCode)
+			return "", llm.Usage{}, fmt.Errorf("openaicompat: %s (status %d)", decoded.Error.Message, resp.StatusCode)
 		}
-		return "", fmt.Errorf("openaicompat: unexpected status %d", resp.StatusCode)
+		return "", llm.Usage{}, fmt.Errorf("openaicompat: unexpected status %d", resp.StatusCode)
 	}
 	if len(decoded.Choices) == 0 {
-		return "", fmt.Errorf("openaicompat: no choices in response")
+		return "", llm.Usage{}, fmt.Errorf("openaicompat: no choices in response")
 	}
-	return decoded.Choices[0].Message.Content, nil
+	var usage llm.Usage
+	if decoded.Usage != nil {
+		usage.InputTokens = decoded.Usage.PromptTokens
+		usage.OutputTokens = decoded.Usage.CompletionTokens
+	}
+	return decoded.Choices[0].Message.Content, usage, nil
 }
 
 // streamChunk is one server-sent delta in a streamed completion.

--- a/internal/llm/openaicompat/provider_test.go
+++ b/internal/llm/openaicompat/provider_test.go
@@ -46,7 +46,7 @@ func TestAskSendsModelAndSystemAndReturnsContent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "default-model", p.Model())
 
-	out, err := p.Ask(context.Background(), "ping",
+	out, _, err := p.Ask(context.Background(), "ping",
 		llm.WithModel("override-model"),
 		llm.WithSystem("be terse"),
 		llm.WithMaxTokens(123),
@@ -74,7 +74,7 @@ func TestAskSurfacesAPIError(t *testing.T) {
 	p, err := openaicompat.New(openaicompat.Settings{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
 	require.NoError(t, err)
 
-	_, err = p.Ask(context.Background(), "hi")
+	_, _, err = p.Ask(context.Background(), "hi")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rate limited")
 }
@@ -96,7 +96,7 @@ func TestAskWithoutSystemSendsSingleMessage(t *testing.T) {
 
 	p, err := openaicompat.New(openaicompat.Settings{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
 	require.NoError(t, err)
-	out, err := p.Ask(context.Background(), "hi")
+	out, _, err := p.Ask(context.Background(), "hi")
 	require.NoError(t, err)
 	assert.Equal(t, "ok", out)
 	msgs, _ := gotBody["messages"].([]any)
@@ -111,7 +111,7 @@ func TestAskErrorsOnEmptyChoices(t *testing.T) {
 
 	p, err := openaicompat.New(openaicompat.Settings{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
 	require.NoError(t, err)
-	_, err = p.Ask(context.Background(), "hi")
+	_, _, err = p.Ask(context.Background(), "hi")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no choices")
 }
@@ -125,7 +125,7 @@ func TestAskErrorsOnNon200WithoutErrorBody(t *testing.T) {
 
 	p, err := openaicompat.New(openaicompat.Settings{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
 	require.NoError(t, err)
-	_, err = p.Ask(context.Background(), "hi")
+	_, _, err = p.Ask(context.Background(), "hi")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected status 500")
 }
@@ -137,7 +137,7 @@ func TestAskErrorsOnConnectionFailure(t *testing.T) {
 
 	p, err := openaicompat.New(openaicompat.Settings{APIKey: "k", BaseURL: url})
 	require.NoError(t, err)
-	_, err = p.Ask(context.Background(), "hi")
+	_, _, err = p.Ask(context.Background(), "hi")
 	require.Error(t, err)
 }
 

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -7,20 +7,33 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"iter"
 )
 
+// Usage reports the token consumption of a single LLM call.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
+// ErrBudgetExhausted is returned by BudgetedProvider when the rolling
+// 24h token budget has been spent. Callers should render a user-friendly
+// message instead of treating it as an internal error.
+var ErrBudgetExhausted = errors.New("daily AI token budget exhausted")
+
 // Provider is the minimal surface every LLM backend exposes.
 //
-// Ask returns the assembled text response. Stream yields text deltas
-// as iter.Seq2[string, error] — the second value carries any error
-// encountered mid-stream; once non-nil, iteration ends.
+// Ask returns the assembled text response and the token usage for the
+// call. Stream yields text deltas as iter.Seq2[string, error] — the
+// second value carries any error encountered mid-stream; once non-nil,
+// iteration ends.
 //
 // Both methods accept per-call CallOptions to override defaults (max
 // tokens, system prompt, model) without rebuilding the provider.
 type Provider interface {
 	Model() string
-	Ask(ctx context.Context, prompt string, opts ...CallOption) (string, error)
+	Ask(ctx context.Context, prompt string, opts ...CallOption) (string, Usage, error)
 	Stream(ctx context.Context, prompt string, opts ...CallOption) iter.Seq2[string, error]
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -130,6 +130,8 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		OwnerDMNudgeEvery:         s.OwnerDMNudgeEvery,
 		BouncerWelcomeReplayDepth: ircCfg.BouncerWelcomeReplayDepth,
 		LLM:                       provider,
+		LLMInputCap:               s.LLMInputTokensPerDay,
+		LLMOutputCap:              s.LLMOutputTokensPerDay,
 		ActivityHook:              activityHook,
 		Store:                     store,
 	}, log); err != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -102,6 +102,12 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		activityHook = notifier.Hook
 	}
 
+	// Wrap the provider with budget enforcement once, here, so the same
+	// budget instance is shared by the connector/commands (via WireCommon)
+	// AND the web gateway (via buildGateway). WireCommon's own wrap is
+	// idempotent on an already-budgeted provider.
+	provider = BuildBudgetedProvider(a, provider, s.LLMInputTokensPerDay, s.LLMOutputTokensPerDay, log)
+
 	// The connector-agnostic, transport-independent wiring — builtins, owner
 	// guard, throttles, nudge, store submitters. The pooled runtime calls this
 	// same WireCommon from its tenant builder, so the two modes can't drift.

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -137,31 +137,9 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 
 	// Wrap the LLM provider with budget enforcement when caps are set.
 	// The wrapped provider is used everywhere: commands, /tb, gateway.
-	provider := p.LLM
-	if provider != nil && (p.LLMInputCap > 0 || p.LLMOutputCap > 0) {
-		budget := llm.NewTokenBudget()
-		provider = llm.NewBudgetedProvider(provider, budget, p.LLMInputCap, p.LLMOutputCap, func(u llm.Usage) {
-			inTotal, outTotal := budget.Totals()
-			log.Info("llm_usage",
-				"input_tokens", u.InputTokens,
-				"output_tokens", u.OutputTokens,
-				"input_total", inTotal,
-				"output_total", outTotal,
-			)
-			a.Events.Publish(context.Background(), &agent.Event{
-				Type: agent.EventLLMUsage,
-				Time: time.Now(),
-				Fields: map[string]any{
-					"input_tokens":  u.InputTokens,
-					"output_tokens": u.OutputTokens,
-					"input_total":   inTotal,
-					"output_total":  outTotal,
-					"input_cap":     p.LLMInputCap,
-					"output_cap":    p.LLMOutputCap,
-				},
-			})
-		})
-	}
+	// Idempotent — if the runtime already wrapped it (so the gateway can
+	// share the same budget instance), this is a no-op.
+	provider := BuildBudgetedProvider(a, p.LLM, p.LLMInputCap, p.LLMOutputCap, log)
 
 	if provider != nil {
 		ircConn.SetLLMProvider(provider)
@@ -188,6 +166,52 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	}, log)
 	a.Commands.ReplaceDynamic(built)
 	return nil
+}
+
+// BuildBudgetedProvider wraps an llm.Provider with rolling-24h budget
+// enforcement when caps are set. The onUsage callback emits the
+// structured llm_usage log (scraped by the sidecar) and publishes
+// EventLLMUsage on the agent's bus (broadcast to WS clients).
+//
+// Idempotent: a provider that is already a *llm.BudgetedProvider is
+// returned unchanged, so the runtime can build it once and share the
+// same budget instance between the gateway and WireCommon. nil in →
+// nil out; caps both 0 → unwrapped (no enforcement).
+func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outputCap int, log *slog.Logger) llm.Provider {
+	if provider == nil {
+		return nil
+	}
+	if _, ok := provider.(*llm.BudgetedProvider); ok {
+		return provider
+	}
+	if inputCap <= 0 && outputCap <= 0 {
+		return provider
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	budget := llm.NewTokenBudget()
+	return llm.NewBudgetedProvider(provider, budget, inputCap, outputCap, func(u llm.Usage) {
+		inTotal, outTotal := budget.Totals()
+		log.Info("llm_usage",
+			"input_tokens", u.InputTokens,
+			"output_tokens", u.OutputTokens,
+			"input_total", inTotal,
+			"output_total", outTotal,
+		)
+		a.Events.Publish(context.Background(), &agent.Event{
+			Type: agent.EventLLMUsage,
+			Time: time.Now(),
+			Fields: map[string]any{
+				"input_tokens":  u.InputTokens,
+				"output_tokens": u.OutputTokens,
+				"input_total":   inTotal,
+				"output_total":  outTotal,
+				"input_cap":     inputCap,
+				"output_cap":    outputCap,
+			},
+		})
+	})
 }
 
 // BuildLLMProvider mints an llm.Provider from a provider kind + endpoint +

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -55,6 +56,11 @@ type CommonParams struct {
 	// skipped at build time. Shared across pooled tenants (a stateless HTTP
 	// client) and per-process for dedicated.
 	LLM llm.Provider
+
+	// LLMInputCap / LLMOutputCap are the rolling-24h token budget caps.
+	// Both > 0 to enable enforcement via BudgetedProvider. 0 = unrestricted.
+	LLMInputCap  int
+	LLMOutputCap int
 
 	// ActivityHook fires on connector activity (bouncer attach, message
 	// traffic). Nil → activity hooks are not attached. Dedicated passes its
@@ -128,8 +134,37 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	if p.Store != nil {
 		ircConn.SetMessageStore(p.Store)
 	}
-	if p.LLM != nil {
-		ircConn.SetLLMProvider(p.LLM)
+
+	// Wrap the LLM provider with budget enforcement when caps are set.
+	// The wrapped provider is used everywhere: commands, /tb, gateway.
+	provider := p.LLM
+	if provider != nil && (p.LLMInputCap > 0 || p.LLMOutputCap > 0) {
+		budget := llm.NewTokenBudget()
+		provider = llm.NewBudgetedProvider(provider, budget, p.LLMInputCap, p.LLMOutputCap, func(u llm.Usage) {
+			inTotal, outTotal := budget.Totals()
+			log.Info("llm_usage",
+				"input_tokens", u.InputTokens,
+				"output_tokens", u.OutputTokens,
+				"input_total", inTotal,
+				"output_total", outTotal,
+			)
+			a.Events.Publish(context.Background(), &agent.Event{
+				Type: agent.EventLLMUsage,
+				Time: time.Now(),
+				Fields: map[string]any{
+					"input_tokens":  u.InputTokens,
+					"output_tokens": u.OutputTokens,
+					"input_total":   inTotal,
+					"output_total":  outTotal,
+					"input_cap":     p.LLMInputCap,
+					"output_cap":    p.LLMOutputCap,
+				},
+			})
+		})
+	}
+
+	if provider != nil {
+		ircConn.SetLLMProvider(provider)
 	}
 	ircConn.SetBouncerWelcomeReplayDepth(clampReplayDepth(p.BouncerWelcomeReplayDepth))
 
@@ -148,7 +183,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 
 	// Install the tenant's data-driven commands. The dynamic set is fully
 	// owned by ReplaceDynamic, so a later hot reload swaps it atomically.
-	built := commands.Build(p.Commands, p.LLM, func(d commands.Definition) agent.CommandGuard {
+	built := commands.Build(p.Commands, provider, func(d commands.Definition) agent.CommandGuard {
 		return PerCommandGuard(string(d.Access), d.Allowlist, p.Owner)
 	}, log)
 	a.Commands.ReplaceDynamic(built)

--- a/internal/runtime/wire_test.go
+++ b/internal/runtime/wire_test.go
@@ -18,8 +18,8 @@ import (
 type stubProvider struct{}
 
 func (stubProvider) Model() string { return "stub" }
-func (stubProvider) Ask(context.Context, string, ...llm.CallOption) (string, error) {
-	return "", nil
+func (stubProvider) Ask(context.Context, string, ...llm.CallOption) (string, llm.Usage, error) {
+	return "", llm.Usage{}, nil
 }
 func (stubProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
 	return func(func(string, error) bool) {}
@@ -122,4 +122,28 @@ func TestWireCommonAllowlistAccess(t *testing.T) {
 	other, err := a.Commands.Dispatch(context.Background(), &agent.InboundEnvelope{Text: "!team", Sender: "mallory"})
 	require.NoError(t, err)
 	require.Nil(t, other, "a non-owner non-allowlisted sender is denied")
+}
+
+func TestWireCommonWrapsLLMWithBudget(t *testing.T) {
+	a := newWiredAgent(t, runtime.CommonParams{
+		LLM:          stubProvider{},
+		LLMInputCap:  1000,
+		LLMOutputCap: 500,
+		Commands: []commands.Definition{
+			{Name: "ask", Type: commands.TypeLLM, Template: "hi", Access: commands.AccessEveryone},
+		},
+	})
+	require.Contains(t, a.Commands.Names(), "ask")
+}
+
+func TestWireCommonNoBudgetWhenCapsZero(t *testing.T) {
+	a := newWiredAgent(t, runtime.CommonParams{
+		LLM:          stubProvider{},
+		LLMInputCap:  0,
+		LLMOutputCap: 0,
+		Commands: []commands.Definition{
+			{Name: "ask", Type: commands.TypeLLM, Template: "hi", Access: commands.AccessEveryone},
+		},
+	})
+	require.Contains(t, a.Commands.Names(), "ask")
 }

--- a/internal/runtime/wire_test.go
+++ b/internal/runtime/wire_test.go
@@ -147,3 +147,62 @@ func TestWireCommonNoBudgetWhenCapsZero(t *testing.T) {
 	})
 	require.Contains(t, a.Commands.Names(), "ask")
 }
+
+func TestBuildBudgetedProviderNilReturnsNil(t *testing.T) {
+	a := agent.NewWithPrefix(nil, "!")
+	require.Nil(t, runtime.BuildBudgetedProvider(a, nil, 100, 100, nil))
+}
+
+func TestBuildBudgetedProviderNoCapsReturnsRaw(t *testing.T) {
+	a := agent.NewWithPrefix(nil, "!")
+	raw := stubProvider{}
+	got := runtime.BuildBudgetedProvider(a, raw, 0, 0, nil)
+	require.Equal(t, raw, got)
+}
+
+func TestBuildBudgetedProviderWrapsWhenCapsSet(t *testing.T) {
+	a := agent.NewWithPrefix(nil, "!")
+	got := runtime.BuildBudgetedProvider(a, stubProvider{}, 100, 50, nil)
+	_, ok := got.(*llm.BudgetedProvider)
+	require.True(t, ok, "expected a *llm.BudgetedProvider wrapper")
+}
+
+func TestBuildBudgetedProviderIdempotent(t *testing.T) {
+	a := agent.NewWithPrefix(nil, "!")
+	wrapped := runtime.BuildBudgetedProvider(a, stubProvider{}, 100, 50, nil)
+	again := runtime.BuildBudgetedProvider(a, wrapped, 100, 50, nil)
+	require.Same(t, wrapped, again, "re-wrapping must return the same instance")
+}
+
+func TestBuildBudgetedProviderPublishesUsageEvent(t *testing.T) {
+	a := agent.NewWithPrefix(nil, "!")
+	got := make(chan *agent.Event, 1)
+	a.Events.Subscribe(agent.EventLLMUsage, func(_ context.Context, ev *agent.Event) {
+		got <- ev
+	})
+	wrapped := runtime.BuildBudgetedProvider(a, &usageProvider{in: 30, out: 12}, 1000, 500, nil)
+	_, _, err := wrapped.Ask(context.Background(), "hi")
+	require.NoError(t, err)
+	select {
+	case ev := <-got:
+		require.Equal(t, 30, ev.Fields["input_tokens"])
+		require.Equal(t, 12, ev.Fields["output_tokens"])
+	default:
+		t.Fatal("expected an EventLLMUsage to be published")
+	}
+}
+
+// usageProvider reports fixed token usage so the budgeted wrapper records
+// and publishes a usage event.
+type usageProvider struct {
+	in  int
+	out int
+}
+
+func (usageProvider) Model() string { return "usage" }
+func (p *usageProvider) Ask(context.Context, string, ...llm.CallOption) (string, llm.Usage, error) {
+	return "ok", llm.Usage{InputTokens: p.in, OutputTokens: p.out}, nil
+}
+func (usageProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
+	return func(func(string, error) bool) {}
+}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -440,7 +440,7 @@ func (t *Tenant) applyTierSettings(s *irc.Settings, caps *PlanCapabilities) {
 // dedicated runtime does (from TURBORG_COMMANDS).
 func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick string, store messages.Store, ignoredNicks []string, cmds []commands.Definition) runtime.CommonParams {
 	var limits irc.ClientLimits
-	var outMax, outWin, nudge, cmdMax, cmdWin, customCmdMax int
+	var outMax, outWin, nudge, cmdMax, cmdWin, customCmdMax, llmInCap, llmOutCap int
 	if caps != nil {
 		limits = irc.ClientLimits{
 			NickLocked:             caps.NickLocked,
@@ -452,6 +452,7 @@ func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick 
 		nudge = caps.OwnerDMNudgeEvery
 		cmdMax, cmdWin = caps.CommandMaxPerWindow, caps.CommandWindowSeconds
 		customCmdMax = caps.CustomCommandsMax
+		llmInCap, llmOutCap = caps.LLMInputTokensPerDay, caps.LLMOutputTokensPerDay
 	}
 
 	// Activity hook: mark this tenant active in the pool's coalescing
@@ -481,6 +482,8 @@ func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick 
 		OwnerNick:             ownerNick,
 		OwnerDMNudgeEvery:     nudge,
 		LLM:                   t.llmProvider,
+		LLMInputCap:           llmInCap,
+		LLMOutputCap:          llmOutCap,
 		ActivityHook:          activityHook,
 		Store:                 store,
 	}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -359,7 +359,13 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// and message-store submitters, so the two modes can't drift. Owner-
 			// trust config travels in the connector config (the feed reuses the
 			// same connectorList() shape the dedicated spawn payload does).
-			if err := runtime.WireCommon(a, conn, t.commonParams(cs, caps, settings.Nick, store, ignoredNicks, cmds), t.log); err != nil {
+			// Build the budgeted provider once so the same budget instance is
+			// shared by the connector/commands (WireCommon) and the web gateway
+			// below. WireCommon's own wrap is idempotent on this.
+			cp := t.commonParams(cs, caps, settings.Nick, store, ignoredNicks, cmds)
+			budgetedProvider := runtime.BuildBudgetedProvider(a, cp.LLM, cp.LLMInputCap, cp.LLMOutputCap, t.log)
+			cp.LLM = budgetedProvider
+			if err := runtime.WireCommon(a, conn, cp, t.log); err != nil {
 				t.log.Error("skipping irc connector: wiring failed", "err", err)
 				continue
 			}
@@ -388,7 +394,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 				if caps != nil {
 					tbCap = caps.TBSummarizeMaxMessages
 				}
-				gw, err := buildTenantGateway(conn, gatewayToken, t.log, store, t.llmProvider, tbCap)
+				gw, err := buildTenantGateway(conn, gatewayToken, t.log, store, budgetedProvider, tbCap)
 				if err != nil {
 					t.log.Error("skipping web gateway", "err", err)
 					continue

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -96,6 +96,11 @@ type PlanCapabilities struct {
 	// subcommand can consume in a single invocation. 0 = feature disabled.
 	TBSummarizeMaxMessages int `json:"tb_summarize_max_messages"`
 
+	// LLMInputTokensPerDay / LLMOutputTokensPerDay are the rolling-24h
+	// token budget caps. 0 = unrestricted.
+	LLMInputTokensPerDay  int `json:"llm_input_tokens_per_day"`
+	LLMOutputTokensPerDay int `json:"llm_output_tokens_per_day"`
+
 	// LLM carries the OpenAI-compatible router config for LLM-type commands.
 	// Documentation-only on the turborg side: the pooled process builds one
 	// shared provider from its own env (the API key is a server-side secret,

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -198,6 +198,7 @@ func (g *Gateway) Subscribe(bus *agent.EventBus) {
 	bus.Subscribe(agent.EventListResult, g.onListResult)
 	bus.Subscribe(agent.EventWhoResult, g.onWhoResult)
 	bus.Subscribe(agent.EventJoinFailed, g.onJoinFailed)
+	bus.Subscribe(agent.EventLLMUsage, g.onLLMUsage)
 
 	if machine := g.bridge.UpstreamState(); machine != nil {
 		sub := machine.Subscribe(g.onUpstreamStateChange)
@@ -887,11 +888,15 @@ func (g *Gateway) handleTBSummarize(ctx context.Context, c *client, channel stri
 			fmt.Fprintf(&sb, "<%s> %s\n", m.Nick, m.Text)
 		}
 		prompt := fmt.Sprintf("Summarize these %d messages from %s:\n\n%s", len(msgs), channel, sb.String())
-		summary, err := provider.Ask(bgCtx, prompt,
+		summary, _, err := provider.Ask(bgCtx, prompt,
 			llm.WithSystem("Summarize the following IRC conversation concisely. Output a short, readable summary suitable for a single IRC message (max ~400 chars). No markdown."),
 			llm.WithMaxTokens(300))
 		if err != nil {
-			g.sendTo(bgCtx, c, map[string]any{"op": "tb_error", "message": "LLM request failed."})
+			msg := "LLM request failed."
+			if errors.Is(err, llm.ErrBudgetExhausted) {
+				msg = "Daily AI token budget spent. Resets on a rolling 24h window."
+			}
+			g.sendTo(bgCtx, c, map[string]any{"op": "tb_error", "message": msg})
 			return
 		}
 		trimmed := strings.TrimSpace(summary)
@@ -1098,6 +1103,18 @@ func (g *Gateway) onJoinFailed(_ context.Context, ev *agent.Event) {
 		"channel": ev.Fields["channel"],
 		"code":    ev.Fields["code"],
 		"reason":  reason,
+	})
+}
+
+func (g *Gateway) onLLMUsage(_ context.Context, ev *agent.Event) {
+	g.broadcast(map[string]any{
+		"op":            "llm_usage",
+		"input_tokens":  ev.Fields["input_tokens"],
+		"output_tokens": ev.Fields["output_tokens"],
+		"input_total":   ev.Fields["input_total"],
+		"output_total":  ev.Fields["output_total"],
+		"input_cap":     ev.Fields["input_cap"],
+		"output_cap":    ev.Fields["output_cap"],
 	})
 }
 

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -835,11 +835,29 @@ func (g *Gateway) handleTBOp(ctx context.Context, c *client, p map[string]any) {
 			n = int(v)
 		}
 		g.handleTBSummarize(ctx, c, channel, n)
+	case "usage":
+		g.handleTBUsage(ctx, c)
 	default:
 		g.sendTo(ctx, c, map[string]any{
-			"op": "tb_error", "message": "Unknown /tb subcommand. Available: summarize",
+			"op": "tb_error", "message": "Unknown /tb subcommand. Available: summarize, usage",
 		})
 	}
+}
+
+func (g *Gateway) handleTBUsage(ctx context.Context, c *client) {
+	var inputUsed, outputUsed, inputCap, outputCap int
+	if bp, ok := g.opts.LLMProvider.(*llm.BudgetedProvider); ok {
+		inputUsed, outputUsed = bp.Budget().Totals()
+		inputCap, outputCap = bp.Caps()
+	}
+	g.sendTo(ctx, c, map[string]any{
+		"op":          "tb_result",
+		"sub":         "usage",
+		"input_used":  inputUsed,
+		"output_used": outputUsed,
+		"input_cap":   inputCap,
+		"output_cap":  outputCap,
+	})
 }
 
 func (g *Gateway) handleTBSummarize(ctx context.Context, c *client, channel string, n int) {

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -95,8 +95,8 @@ type testLLM struct {
 }
 
 func (t *testLLM) Model() string { return "test" }
-func (t *testLLM) Ask(_ context.Context, _ string, _ ...llm.CallOption) (string, error) {
-	return t.response, nil
+func (t *testLLM) Ask(_ context.Context, _ string, _ ...llm.CallOption) (string, llm.Usage, error) {
+	return t.response, llm.Usage{}, nil
 }
 func (t *testLLM) Stream(_ context.Context, _ string, _ ...llm.CallOption) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {}
@@ -107,8 +107,8 @@ type testLLMErr struct {
 }
 
 func (t *testLLMErr) Model() string { return "test" }
-func (t *testLLMErr) Ask(_ context.Context, _ string, _ ...llm.CallOption) (string, error) {
-	return "", t.err
+func (t *testLLMErr) Ask(_ context.Context, _ string, _ ...llm.CallOption) (string, llm.Usage, error) {
+	return "", llm.Usage{}, t.err
 }
 func (t *testLLMErr) Stream(_ context.Context, _ string, _ ...llm.CallOption) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {}
@@ -404,6 +404,18 @@ func TestEveryEventBusHandlerBroadcastsAnOp(t *testing.T) {
 			agent.Event{Type: agent.EventMessageSent, Fields: map[string]any{"channel": "#x", "sender": "turborg", "text": "echo"}},
 			"message",
 			func(t *testing.T, got map[string]any) { assert.Equal(t, "echo", got["text"]) },
+		},
+		{"LLM_USAGE → llm_usage",
+			agent.Event{Type: agent.EventLLMUsage, Fields: map[string]any{
+				"input_tokens": 100, "output_tokens": 50,
+				"input_total": 200, "output_total": 100,
+				"input_cap": 4000, "output_cap": 1000,
+			}},
+			"llm_usage",
+			func(t *testing.T, got map[string]any) {
+				assert.Equal(t, float64(100), got["input_tokens"])
+				assert.Equal(t, float64(4000), got["input_cap"])
+			},
 		},
 	}
 	for _, tc := range cases {

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -1215,6 +1215,51 @@ func TestTBOpSummarizeZeroCap(t *testing.T) {
 	assert.Contains(t, got["message"], "not available on your plan")
 }
 
+func TestTBOpUsageReportsBudget(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	opts := newOptions(t, "p")
+	// A BudgetedProvider exposes Budget()/Caps() the usage handler reads.
+	budget := llm.NewTokenBudget()
+	budget.Record(120, 60)
+	opts.LLMProvider = llm.NewBudgetedProvider(&testLLM{response: "x"}, budget, 4000, 1000, nil)
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+
+	body, _ := json.Marshal(map[string]any{"op": "tb", "sub": "usage"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	got := readJSON(t, conn)
+	assert.Equal(t, "tb_result", got["op"])
+	assert.Equal(t, "usage", got["sub"])
+	assert.Equal(t, float64(120), got["input_used"])
+	assert.Equal(t, float64(60), got["output_used"])
+	assert.Equal(t, float64(4000), got["input_cap"])
+	assert.Equal(t, float64(1000), got["output_cap"])
+}
+
+func TestTBOpUsageZeroWithoutBudgetedProvider(t *testing.T) {
+	bridge := newFakeBridge("turborg")
+	opts := newOptions(t, "p")
+	opts.LLMProvider = &testLLM{response: "x"} // not budgeted
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+
+	body, _ := json.Marshal(map[string]any{"op": "tb", "sub": "usage"})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	got := readJSON(t, conn)
+	assert.Equal(t, "tb_result", got["op"])
+	assert.Equal(t, float64(0), got["input_used"])
+}
+
 func TestTBOpUnknownSubcommand(t *testing.T) {
 	bridge := newFakeBridge("turborg")
 	g, _, td := startGateway(t, newOptions(t, "p"), bridge, &fakeSender{})


### PR DESCRIPTION
## Summary

- Provider.Ask returns (string, Usage, error) — both Anthropic and OpenAI-compat providers now report per-call input/output token counts
- TokenBudget: goroutine-safe rolling-24h sliding window tracker
- BudgetedProvider: enforcement wrapper that checks budget before each Ask, records usage after, fires onUsage callback for EventBus + structured logging
- ErrBudgetExhausted renders user-friendly "daily AI budget spent" in commands and /tb summarize
- EventLLMUsage broadcasts real-time usage to WS clients; structured log msg:"llm_usage" for sidecar scraping
- Gateway /tb usage handler reads live budget state

Part of the cross-repo `feat/llm-token-tracking` initiative.