### PR TITLE
fix(llm): seed rolling-window budget with prior usage so the cap survives restarts

### DIFF
--- a/internal/budgetrefresh/refresh.go
+++ b/internal/budgetrefresh/refresh.go
@@ -1,0 +1,153 @@
+// Package budgetrefresh keeps an LLM token budget's account baseline current
+// for a single long-lived agent process.
+//
+// The in-process TokenBudget counts exactly what THIS process consumes, but
+// the cap is meant to hold across the whole account/window — including sibling
+// agents and this agent's own pre-restart usage. Those live in the control
+// plane, not in memory. This package polls the control plane (via the local
+// sidecar, the same transport the message store uses) and pushes the latest
+// "everyone else" total into the budget as its baseline.
+//
+// Wire contract the operator must serve at the configured URL:
+//
+//	GET <url>?since=<unix_seconds>
+//	  Authorization: Bearer <token>
+//	  Status: 200 on success.
+//	  Body: {"input_used": int, "output_used": int}
+//	  - The response MUST exclude this agent's own usage recorded at or after
+//	    `since` (this process's start), because that half is counted locally —
+//	    so the two never double-count. Usage before `since` (prior incarnations
+//	    of the same agent) stays included, which is what keeps a restart from
+//	    resetting the window.
+//
+// Failures are non-fatal: the budget keeps its last baseline and the loop
+// retries on the next tick. The baseline is a conservative seed, never the
+// only thing standing between the agent and a runaway bill within a single
+// process (local counting still applies), so a brief stale baseline is safe.
+package budgetrefresh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// baselineSetter is the slice of *llm.TokenBudget this package needs. Kept as
+// an interface so the package doesn't import llm and stays trivially testable.
+type baselineSetter interface {
+	SetBaseline(input, output int)
+}
+
+const (
+	defaultInterval = 15 * time.Second
+	minInterval     = 2 * time.Second
+	requestTimeout  = 10 * time.Second
+)
+
+// Refresher periodically pulls the account baseline and applies it to a budget.
+type Refresher struct {
+	endpoint string
+	token    string
+	interval time.Duration
+	since    time.Time
+	budget   baselineSetter
+	client   *http.Client
+	log      *slog.Logger
+}
+
+// New returns nil when refresh is not configured (no endpoint/token or no
+// budget) — so the caller can plug the result straight into an optional field
+// and a single non-nil check gates the whole feature. `since` is this
+// process's start; it's sent on every request so the control plane can exclude
+// usage this process counts locally. intervalSeconds <= 0 uses the default;
+// values below the floor are clamped up.
+func New(endpoint, token string, intervalSeconds int, since time.Time, budget baselineSetter, log *slog.Logger) *Refresher {
+	if endpoint == "" || token == "" || budget == nil {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	interval := time.Duration(intervalSeconds) * time.Second
+	switch {
+	case intervalSeconds <= 0:
+		interval = defaultInterval
+	case interval < minInterval:
+		interval = minInterval
+	}
+	return &Refresher{
+		endpoint: endpoint,
+		token:    token,
+		interval: interval,
+		since:    since,
+		budget:   budget,
+		client:   &http.Client{Timeout: requestTimeout},
+		log:      log.With("component", "budget-refresh"),
+	}
+}
+
+// Run refreshes once immediately, then on every interval tick, until ctx is
+// cancelled. Always returns nil (cancellation is the normal exit); the error
+// return exists for symmetry with the other runnables the runtime supervises.
+func (r *Refresher) Run(ctx context.Context) error {
+	r.refreshOnce(ctx) // tighten accuracy at boot rather than wait a full tick
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			r.refreshOnce(ctx)
+		}
+	}
+}
+
+func (r *Refresher) refreshOnce(ctx context.Context) {
+	in, out, err := r.fetch(ctx)
+	if err != nil {
+		// Keep the last baseline; local counting still bounds this process.
+		r.log.Debug("budget baseline refresh failed; keeping last value", "err", err)
+		return
+	}
+	r.budget.SetBaseline(in, out)
+}
+
+func (r *Refresher) fetch(ctx context.Context) (input, output int, err error) {
+	u, err := url.Parse(r.endpoint)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse endpoint: %w", err)
+	}
+	q := u.Query()
+	q.Set("since", strconv.FormatInt(r.since.Unix(), 10))
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.token)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return 0, 0, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		InputUsed  int `json:"input_used"`
+		OutputUsed int `json:"output_used"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return 0, 0, fmt.Errorf("decode body: %w", err)
+	}
+	return body.InputUsed, body.OutputUsed, nil
+}

--- a/internal/budgetrefresh/refresh_test.go
+++ b/internal/budgetrefresh/refresh_test.go
@@ -1,0 +1,167 @@
+package budgetrefresh
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+type spyBudget struct {
+	mu       sync.Mutex
+	input    int
+	output   int
+	setCalls int
+}
+
+func (s *spyBudget) SetBaseline(input, output int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.input, s.output = input, output
+	s.setCalls++
+}
+
+func (s *spyBudget) snapshot() (int, int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.input, s.output, s.setCalls
+}
+
+func TestNewReturnsNilWhenUnconfigured(t *testing.T) {
+	b := &spyBudget{}
+	assert.Nil(t, New("", "tok", 0, time.Now(), b, nil), "no endpoint → nil")
+	assert.Nil(t, New("http://x", "", 0, time.Now(), b, nil), "no token → nil")
+	assert.Nil(t, New("http://x", "tok", 0, time.Now(), nil, nil), "no budget → nil")
+	assert.NotNil(t, New("http://x", "tok", 0, time.Now(), b, nil))
+}
+
+func TestRefreshAppliesBaselineAndSendsSinceAndAuth(t *testing.T) {
+	var gotSince atomic.Value
+	var gotAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSince.Store(r.URL.Query().Get("since"))
+		gotAuth.Store(r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"input_used": 1200, "output_used": 300}`))
+	}))
+	defer srv.Close()
+
+	b := &spyBudget{}
+	since := time.Unix(1_700_000_000, 0)
+	r := New(srv.URL, "secret-tok", 1, since, b, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	in, out, calls := b.snapshot()
+	assert.Equal(t, 1200, in)
+	assert.Equal(t, 300, out)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "1700000000", gotSince.Load())
+	assert.Equal(t, "Bearer secret-tok", gotAuth.Load())
+}
+
+func TestRefreshKeepsLastBaselineOnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	b := &spyBudget{}
+	r := New(srv.URL, "tok", 1, time.Now(), b, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	_, _, calls := b.snapshot()
+	assert.Equal(t, 0, calls, "a non-200 must not push a baseline (keeps the last value)")
+}
+
+func TestRunRefreshesImmediatelyAndStopsOnContextCancel(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"input_used": 5, "output_used": 1}`))
+	}))
+	defer srv.Close()
+
+	b := &spyBudget{}
+	r := New(srv.URL, "tok", 0, time.Now(), b, nil) // default interval; immediate first refresh
+	require.NotNil(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return hits.Load() >= 1 }, time.Second, 10*time.Millisecond,
+		"Run must refresh once immediately, not wait a full interval")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestRefreshKeepsLastBaselineOnMalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	b := &spyBudget{}
+	r := New(srv.URL, "tok", 1, time.Now(), b, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	_, _, calls := b.snapshot()
+	assert.Equal(t, 0, calls, "a body that fails to decode must not push a baseline")
+}
+
+func TestRunRefreshesOnTick(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"input_used": 1, "output_used": 0}`))
+	}))
+	defer srv.Close()
+
+	b := &spyBudget{}
+	r := New(srv.URL, "tok", 2, time.Now(), b, nil) // clamped to the 2s floor
+	require.NotNil(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	// One immediate refresh + at least one ticked refresh.
+	require.Eventually(t, func() bool { return hits.Load() >= 2 }, 5*time.Second, 50*time.Millisecond,
+		"Run must keep refreshing on each tick")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestNewClampsSubFloorInterval(t *testing.T) {
+	b := &spyBudget{}
+	r := New("http://x", "tok", 1, time.Now(), b, nil) // 1s < floor
+	require.NotNil(t, r)
+	assert.Equal(t, minInterval, r.interval)
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -136,6 +136,22 @@ type Settings struct {
 	LLMInputTokensUsed  int `env:"LLM_INPUT_TOKENS_USED"`
 	LLMOutputTokensUsed int `env:"LLM_OUTPUT_TOKENS_USED"`
 
+	// LLMBudgetURL is an optional endpoint the agent polls to keep the token
+	// budget's account baseline current while it runs (the boot seed above is
+	// only a point-in-time value). SaaS deployments point it at the sidecar's
+	// per-container budget handler, which forwards to the control plane; the
+	// agent sends its start time as `?since=` so the response can exclude what
+	// it counts locally. Empty = no live refresh (the boot seed is all there
+	// is, which is correct for self-host single-agent installs).
+	LLMBudgetURL string `env:"LLM_BUDGET_URL"`
+	// LLMBudgetToken is the bearer sent on every budget poll. Defaults to
+	// MessageSinkToken via normalize() when unset — both terminate at the same
+	// per-container endpoint with the same bearer.
+	LLMBudgetToken string `env:"LLM_BUDGET_TOKEN"`
+	// LLMBudgetRefreshSeconds is the poll interval. 0 uses the package default
+	// (15s); values below the floor are clamped up by the refresher.
+	LLMBudgetRefreshSeconds int `env:"LLM_BUDGET_REFRESH_SECONDS"`
+
 	// CustomCommandsMax caps the dynamic-command registry. 0 = no
 	// commands, -1 = unrestricted. Bounds the command set loaded from
 	// TURBORG_COMMANDS (and any later runtime registrations).
@@ -279,6 +295,11 @@ func (s *Settings) normalize() error {
 	// for read vs. write set MESSAGE_STORE_TOKEN explicitly.
 	if s.MessageStoreToken == "" {
 		s.MessageStoreToken = s.MessageSinkToken
+	}
+	// The budget-refresh poll terminates at the same per-container endpoint as
+	// the message sink, so it reuses that bearer unless overridden.
+	if s.LLMBudgetToken == "" {
+		s.LLMBudgetToken = s.MessageSinkToken
 	}
 	return nil
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -128,6 +128,14 @@ type Settings struct {
 	LLMOutputTokensPerDay int      `env:"LLM_OUTPUT_TOKENS_PER_DAY"`
 	AllowedLLMModels      []string `env:"ALLOWED_LLM_MODELS" envSeparator:","`
 
+	// LLMInputTokensUsed / LLMOutputTokensUsed seed the rolling-window budget
+	// with consumption already reported across the account for the current
+	// window (sibling agents and previously-destroyed ones), supplied by the
+	// operator at boot. They make the cap enforce per account/window instead of
+	// resetting to zero on every restart/recreate. 0 = fresh window.
+	LLMInputTokensUsed  int `env:"LLM_INPUT_TOKENS_USED"`
+	LLMOutputTokensUsed int `env:"LLM_OUTPUT_TOKENS_USED"`
+
 	// CustomCommandsMax caps the dynamic-command registry. 0 = no
 	// commands, -1 = unrestricted. Bounds the command set loaded from
 	// TURBORG_COMMANDS (and any later runtime registrations).
@@ -308,6 +316,12 @@ func (s *Settings) validatePolicyBounds() error {
 	}
 	if s.LLMOutputTokensPerDay < 0 {
 		return errors.New("config: LLM_OUTPUT_TOKENS_PER_DAY must be >= 0 (0 = unrestricted)")
+	}
+	if s.LLMInputTokensUsed < 0 {
+		return errors.New("config: LLM_INPUT_TOKENS_USED must be >= 0 (0 = fresh window)")
+	}
+	if s.LLMOutputTokensUsed < 0 {
+		return errors.New("config: LLM_OUTPUT_TOKENS_USED must be >= 0 (0 = fresh window)")
 	}
 	if s.MaxChannels < 0 {
 		return errors.New("config: MAX_CHANNELS must be >= 0 (0 = unrestricted)")

--- a/internal/llm/budget.go
+++ b/internal/llm/budget.go
@@ -16,11 +16,27 @@ type tokenEntry struct {
 // TokenBudget tracks LLM token consumption in a rolling time window.
 // Goroutine-safe; entries older than the window are pruned on every
 // mutating call.
+//
+// Enforcement is the sum of two parts:
+//
+//   - locally recorded entries — what THIS process has consumed since it
+//     started (exact, in-memory).
+//   - a baseline — consumption attributed to the rest of the account for the
+//     same window (other agents, and this agent's own pre-restart usage),
+//     supplied by an external authority and refreshed live via SetBaseline.
+//
+// Splitting the two is what makes the cap hold per account/window rather than
+// per process: a fresh process starts with locals at zero but inherits the
+// account baseline, so it can't reset the window by restarting or being
+// recreated. The baseline is a replaceable snapshot (not pruned) — the
+// authority recomputes it over the rolling window on each refresh.
 type TokenBudget struct {
-	mu      sync.Mutex
-	entries []tokenEntry
-	window  time.Duration
-	now     func() time.Time // injectable clock for tests
+	mu             sync.Mutex
+	entries        []tokenEntry
+	baselineInput  int
+	baselineOutput int
+	window         time.Duration
+	now            func() time.Time // injectable clock for tests
 }
 
 func NewTokenBudget() *TokenBudget {
@@ -42,37 +58,28 @@ func (b *TokenBudget) Record(input, output int) {
 	})
 }
 
-// Seed pre-loads consumption that happened before this budget existed — the
-// totals an external authority (the control plane) reports for the rolling
-// window across the whole account, including sibling and previously-destroyed
-// agents. Without it, the window resets to zero every time an agent restarts
-// or is recreated, so the cap would be enforced per agent-instance rather than
-// per account/window: an operator could reset the budget at will by recreating
-// the agent. Seeding closes that.
+// SetBaseline replaces the account baseline — consumption attributed to the
+// rest of the account (other agents + this agent's pre-restart usage) over the
+// rolling window. The external authority recomputes it on each refresh; the
+// caller arranges for the baseline to EXCLUDE what this process counts locally
+// so the two halves never double-count. Negative values are clamped to zero.
 //
-// The seed is anchored at the current time because the per-entry ages of the
-// reported total aren't carried across, so it influences the budget for a full
-// window from process start. That is deliberately conservative — it never
-// under-counts prior usage. A zero/negative seed is a no-op.
-func (b *TokenBudget) Seed(input, output int) {
-	if input <= 0 && output <= 0 {
-		return
-	}
+// Called once at startup (the seed) and then periodically as the authority
+// reports fresh account totals. Cheap and safe to call on every refresh tick.
+func (b *TokenBudget) SetBaseline(input, output int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.entries = append(b.entries, tokenEntry{
-		ts:     b.now(),
-		input:  max(0, input),
-		output: max(0, output),
-	})
+	b.baselineInput = max(0, input)
+	b.baselineOutput = max(0, output)
 }
 
-// Totals returns the sum of input and output tokens consumed within
-// the rolling window.
+// Totals returns total input and output tokens for the window: the account
+// baseline plus everything this process has recorded locally.
 func (b *TokenBudget) Totals() (input, output int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.prune()
+	input, output = b.baselineInput, b.baselineOutput
 	for _, e := range b.entries {
 		input += e.input
 		output += e.output

--- a/internal/llm/budget.go
+++ b/internal/llm/budget.go
@@ -42,6 +42,31 @@ func (b *TokenBudget) Record(input, output int) {
 	})
 }
 
+// Seed pre-loads consumption that happened before this budget existed — the
+// totals an external authority (the control plane) reports for the rolling
+// window across the whole account, including sibling and previously-destroyed
+// agents. Without it, the window resets to zero every time an agent restarts
+// or is recreated, so the cap would be enforced per agent-instance rather than
+// per account/window: an operator could reset the budget at will by recreating
+// the agent. Seeding closes that.
+//
+// The seed is anchored at the current time because the per-entry ages of the
+// reported total aren't carried across, so it influences the budget for a full
+// window from process start. That is deliberately conservative — it never
+// under-counts prior usage. A zero/negative seed is a no-op.
+func (b *TokenBudget) Seed(input, output int) {
+	if input <= 0 && output <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.entries = append(b.entries, tokenEntry{
+		ts:     b.now(),
+		input:  max(0, input),
+		output: max(0, output),
+	})
+}
+
 // Totals returns the sum of input and output tokens consumed within
 // the rolling window.
 func (b *TokenBudget) Totals() (input, output int) {

--- a/internal/llm/budget_test.go
+++ b/internal/llm/budget_test.go
@@ -57,6 +57,31 @@ func TestTokenBudgetAllowZeroCapMeansUnrestricted(t *testing.T) {
 	assert.True(t, b.Allow(0, 0))
 }
 
+func TestTokenBudgetSeedCountsTowardCap(t *testing.T) {
+	b := NewTokenBudget()
+	b.Seed(90, 8)
+
+	// Seed alone is under the caps.
+	assert.True(t, b.Allow(100, 0))
+	// Fresh consumption stacks on top of the seed.
+	b.Record(10, 0)
+	assert.False(t, b.Allow(100, 0), "seed + recorded usage must exhaust the cap")
+
+	in, out := b.Totals()
+	assert.Equal(t, 100, in)
+	assert.Equal(t, 8, out)
+}
+
+func TestTokenBudgetSeedZeroIsNoop(t *testing.T) {
+	b := NewTokenBudget()
+	b.Seed(0, 0)
+	b.Seed(-5, -1)
+
+	in, out := b.Totals()
+	assert.Equal(t, 0, in)
+	assert.Equal(t, 0, out)
+}
+
 func TestTokenBudgetRollingWindow(t *testing.T) {
 	b := NewTokenBudget()
 	b.window = 100 * time.Millisecond

--- a/internal/llm/budget_test.go
+++ b/internal/llm/budget_test.go
@@ -57,29 +57,55 @@ func TestTokenBudgetAllowZeroCapMeansUnrestricted(t *testing.T) {
 	assert.True(t, b.Allow(0, 0))
 }
 
-func TestTokenBudgetSeedCountsTowardCap(t *testing.T) {
+func TestTokenBudgetBaselineCountsTowardCap(t *testing.T) {
 	b := NewTokenBudget()
-	b.Seed(90, 8)
+	b.SetBaseline(90, 8)
 
-	// Seed alone is under the caps.
+	// Baseline alone is under the caps.
 	assert.True(t, b.Allow(100, 0))
-	// Fresh consumption stacks on top of the seed.
+	// Fresh local consumption stacks on top of the baseline.
 	b.Record(10, 0)
-	assert.False(t, b.Allow(100, 0), "seed + recorded usage must exhaust the cap")
+	assert.False(t, b.Allow(100, 0), "baseline + recorded usage must exhaust the cap")
 
 	in, out := b.Totals()
 	assert.Equal(t, 100, in)
 	assert.Equal(t, 8, out)
 }
 
-func TestTokenBudgetSeedZeroIsNoop(t *testing.T) {
+func TestTokenBudgetSetBaselineReplacesNotAccumulates(t *testing.T) {
 	b := NewTokenBudget()
-	b.Seed(0, 0)
-	b.Seed(-5, -1)
+	b.Record(10, 5) // local usage stays put across baseline refreshes
+
+	b.SetBaseline(100, 50)
+	in, out := b.Totals()
+	assert.Equal(t, 110, in)
+	assert.Equal(t, 55, out)
+
+	// A later refresh replaces the baseline; it does not add to it.
+	b.SetBaseline(40, 20)
+	in, out = b.Totals()
+	assert.Equal(t, 50, in)
+	assert.Equal(t, 25, out)
+}
+
+func TestTokenBudgetSetBaselineClampsNegative(t *testing.T) {
+	b := NewTokenBudget()
+	b.SetBaseline(-5, -1)
 
 	in, out := b.Totals()
 	assert.Equal(t, 0, in)
 	assert.Equal(t, 0, out)
+}
+
+func TestTokenBudgetBaselineSurvivesPrune(t *testing.T) {
+	b := NewTokenBudget()
+	b.window = 50 * time.Millisecond
+	b.SetBaseline(70, 0)
+	b.Record(10, 0)
+
+	time.Sleep(80 * time.Millisecond) // local entry ages out, baseline stays
+	in, _ := b.Totals()
+	assert.Equal(t, 70, in, "baseline is a snapshot and must not be pruned")
 }
 
 func TestTokenBudgetRollingWindow(t *testing.T) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/turborg/turborg/internal/activity"
+	"github.com/turborg/turborg/internal/budgetrefresh"
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/config"
@@ -44,6 +45,9 @@ type Built struct {
 	LLM       llm.Provider       // nil when Anthropic is not configured
 	Activity  *activity.Notifier // never nil; no-op when ACTIVITY_URL is unset
 	StatePush *statepush.Emitter // never nil; inert no-op when STATE_WEBHOOK_URL is unset
+	// BudgetRefresh keeps the token budget's account baseline current while the
+	// agent runs. Nil when the provider isn't budgeted or no endpoint is set.
+	BudgetRefresh *budgetrefresh.Refresher
 }
 
 // Build wires the agent + connectors + gateway from settings. Callers
@@ -163,6 +167,22 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		LLM:       provider,
 		Activity:  notifier,
 		StatePush: stateEmitter,
+	}
+
+	// Live budget refresh: when the provider is budgeted and a refresh endpoint
+	// is configured, poll it so the account baseline tracks sibling agents and
+	// this agent's pre-restart usage while it runs (the env seed above is only a
+	// boot-time snapshot). startedAt is sent as `since` so the control plane
+	// excludes what this process counts locally. nil when not budgeted/unset.
+	if bp, ok := provider.(*llm.BudgetedProvider); ok {
+		built.BudgetRefresh = budgetrefresh.New(
+			s.LLMBudgetURL,
+			s.LLMBudgetToken,
+			s.LLMBudgetRefreshSeconds,
+			time.Now(),
+			bp.Budget(),
+			log,
+		)
 	}
 
 	if s.GatewayEnabled() {
@@ -621,8 +641,32 @@ func Run(ctx context.Context, b *Built) error {
 	if b.StatePush != nil {
 		defer b.StatePush.Stop()
 	}
+
+	rootCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Background budget refresher: keeps the token baseline fresh under rootCtx.
+	// It is NOT part of the cross-stop race (it doesn't gate process lifetime),
+	// but we drain it before returning so no goroutine outlives Run.
+	var refreshDone chan struct{}
+	if b.BudgetRefresh != nil {
+		refreshDone = make(chan struct{})
+		go func() {
+			defer close(refreshDone)
+			_ = b.BudgetRefresh.Run(rootCtx)
+		}()
+	}
+	waitRefresh := func() {
+		if refreshDone != nil {
+			<-refreshDone
+		}
+	}
+
 	if b.Gateway == nil {
-		return b.Agent.Run(ctx)
+		err := b.Agent.Run(rootCtx)
+		cancel()
+		waitRefresh()
+		return err
 	}
 
 	type result struct {
@@ -630,8 +674,6 @@ func Run(ctx context.Context, b *Built) error {
 		err  error
 	}
 	results := make(chan result, 2)
-	rootCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	go func() {
 		err := b.Agent.Run(rootCtx)
@@ -647,6 +689,7 @@ func Run(ctx context.Context, b *Built) error {
 	cancel()
 	b.Gateway.Stop()
 	second := <-results
+	waitRefresh()
 
 	if first.err != nil && !errors.Is(first.err, context.Canceled) {
 		return fmt.Errorf("%s: %w", first.from, first.err)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -106,7 +106,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	// budget instance is shared by the connector/commands (via WireCommon)
 	// AND the web gateway (via buildGateway). WireCommon's own wrap is
 	// idempotent on an already-budgeted provider.
-	provider = BuildBudgetedProvider(a, provider, s.LLMInputTokensPerDay, s.LLMOutputTokensPerDay, log)
+	provider = BuildBudgetedProvider(a, provider, s.LLMInputTokensPerDay, s.LLMOutputTokensPerDay, s.LLMInputTokensUsed, s.LLMOutputTokensUsed, log)
 
 	// The connector-agnostic, transport-independent wiring — builtins, owner
 	// guard, throttles, nudge, store submitters. The pooled runtime calls this
@@ -138,6 +138,8 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		LLM:                       provider,
 		LLMInputCap:               s.LLMInputTokensPerDay,
 		LLMOutputCap:              s.LLMOutputTokensPerDay,
+		LLMInputUsed:              s.LLMInputTokensUsed,
+		LLMOutputUsed:             s.LLMOutputTokensUsed,
 		ActivityHook:              activityHook,
 		Store:                     store,
 	}, log); err != nil {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -415,6 +415,76 @@ func TestHostmaskHelperPatternBehaviors(t *testing.T) {
 
 // --- Run pair stops mutually ---------------------------------------------
 
+func TestBuildWiresBudgetRefreshWhenConfigured(t *testing.T) {
+	base := &config.Settings{
+		CommandPrefix:        "!",
+		AnthropicAPIKey:      "sk-test",
+		AnthropicModel:       "claude-sonnet-4-6",
+		LLMInputTokensPerDay: 4000,
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+
+	// No budget URL → no refresher even though the provider is budgeted.
+	b, err := runtime.Build(base, ircCfg, nil)
+	require.NoError(t, err)
+	assert.Nil(t, b.BudgetRefresh, "no LLM_BUDGET_URL → no refresher")
+
+	// With a URL + token, the refresher is wired.
+	withURL := *base
+	withURL.LLMBudgetURL = "http://sidecar.local/llm-budget"
+	withURL.LLMBudgetToken = "tok"
+	b2, err := runtime.Build(&withURL, ircCfg, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, b2.BudgetRefresh, "budgeted provider + endpoint → refresher")
+}
+
+func TestBuildNoBudgetRefreshWithoutCaps(t *testing.T) {
+	// A URL is set but no caps → provider isn't budgeted → no refresher.
+	s := &config.Settings{
+		CommandPrefix:   "!",
+		AnthropicAPIKey: "sk-test",
+		AnthropicModel:  "claude-sonnet-4-6",
+		LLMBudgetURL:    "http://sidecar.local/llm-budget",
+		LLMBudgetToken:  "tok",
+	}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	assert.Nil(t, b.BudgetRefresh, "unbudgeted provider → no refresher even with a URL")
+}
+
+func TestRunDrainsBudgetRefreshOnCtxCancel(t *testing.T) {
+	s := &config.Settings{
+		CommandPrefix:           "!",
+		AnthropicAPIKey:         "sk-test",
+		AnthropicModel:          "claude-sonnet-4-6",
+		LLMInputTokensPerDay:    4000,
+		LLMBudgetURL:            "http://127.0.0.1:1/llm-budget", // refresh fails fast; loop keeps ticking
+		LLMBudgetToken:          "tok",
+		LLMBudgetRefreshSeconds: 2,
+	}
+	ircCfg := &irc.Settings{
+		Hostname:           "fake",
+		Nick:               "turborg",
+		HandshakeTimeout:   100 * time.Millisecond,
+		ClientPingInterval: 50 * time.Millisecond,
+	}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.BudgetRefresh, "precondition: refresher is wired")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runtime.Run(ctx, b) }()
+
+	cancel()
+	select {
+	case <-done: // Run must drain the refresher goroutine before returning (goleak)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
 func TestRunStandaloneReturnsOnCtxCancel(t *testing.T) {
 	s := &config.Settings{CommandPrefix: "!"}
 	ircCfg := &irc.Settings{

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -203,7 +203,7 @@ func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outp
 		log = slog.Default()
 	}
 	budget := llm.NewTokenBudget()
-	budget.Seed(usedInput, usedOutput)
+	budget.SetBaseline(usedInput, usedOutput)
 	return llm.NewBudgetedProvider(provider, budget, inputCap, outputCap, func(u llm.Usage) {
 		inTotal, outTotal := budget.Totals()
 		log.Info("llm_usage",

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -62,6 +62,13 @@ type CommonParams struct {
 	LLMInputCap  int
 	LLMOutputCap int
 
+	// LLMInputUsed / LLMOutputUsed seed the budget with consumption already
+	// reported across the account for the rolling window (sibling agents and
+	// previously-destroyed ones), so the cap is enforced per account/window
+	// rather than per agent-instance. 0 = fresh window. See TokenBudget.Seed.
+	LLMInputUsed  int
+	LLMOutputUsed int
+
 	// ActivityHook fires on connector activity (bouncer attach, message
 	// traffic). Nil → activity hooks are not attached. Dedicated passes its
 	// Notifier.Hook (a per-event POST to the local sidecar); pooled passes a
@@ -139,7 +146,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	// The wrapped provider is used everywhere: commands, /tb, gateway.
 	// Idempotent — if the runtime already wrapped it (so the gateway can
 	// share the same budget instance), this is a no-op.
-	provider := BuildBudgetedProvider(a, p.LLM, p.LLMInputCap, p.LLMOutputCap, log)
+	provider := BuildBudgetedProvider(a, p.LLM, p.LLMInputCap, p.LLMOutputCap, p.LLMInputUsed, p.LLMOutputUsed, log)
 
 	if provider != nil {
 		ircConn.SetLLMProvider(provider)
@@ -177,7 +184,12 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 // returned unchanged, so the runtime can build it once and share the
 // same budget instance between the gateway and WireCommon. nil in →
 // nil out; caps both 0 → unwrapped (no enforcement).
-func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outputCap int, log *slog.Logger) llm.Provider {
+//
+// usedInput/usedOutput seed the rolling window with consumption already
+// reported across the account for the same window (see TokenBudget.Seed),
+// so the cap is enforced per account/window rather than per agent-instance.
+// Both 0 → no prior usage, fresh window.
+func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outputCap, usedInput, usedOutput int, log *slog.Logger) llm.Provider {
 	if provider == nil {
 		return nil
 	}
@@ -191,6 +203,7 @@ func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outp
 		log = slog.Default()
 	}
 	budget := llm.NewTokenBudget()
+	budget.Seed(usedInput, usedOutput)
 	return llm.NewBudgetedProvider(provider, budget, inputCap, outputCap, func(u llm.Usage) {
 		inTotal, outTotal := budget.Totals()
 		log.Info("llm_usage",

--- a/internal/runtime/wire_test.go
+++ b/internal/runtime/wire_test.go
@@ -150,27 +150,27 @@ func TestWireCommonNoBudgetWhenCapsZero(t *testing.T) {
 
 func TestBuildBudgetedProviderNilReturnsNil(t *testing.T) {
 	a := agent.NewWithPrefix(nil, "!")
-	require.Nil(t, runtime.BuildBudgetedProvider(a, nil, 100, 100, nil))
+	require.Nil(t, runtime.BuildBudgetedProvider(a, nil, 100, 100, 0, 0, nil))
 }
 
 func TestBuildBudgetedProviderNoCapsReturnsRaw(t *testing.T) {
 	a := agent.NewWithPrefix(nil, "!")
 	raw := stubProvider{}
-	got := runtime.BuildBudgetedProvider(a, raw, 0, 0, nil)
+	got := runtime.BuildBudgetedProvider(a, raw, 0, 0, 0, 0, nil)
 	require.Equal(t, raw, got)
 }
 
 func TestBuildBudgetedProviderWrapsWhenCapsSet(t *testing.T) {
 	a := agent.NewWithPrefix(nil, "!")
-	got := runtime.BuildBudgetedProvider(a, stubProvider{}, 100, 50, nil)
+	got := runtime.BuildBudgetedProvider(a, stubProvider{}, 100, 50, 0, 0, nil)
 	_, ok := got.(*llm.BudgetedProvider)
 	require.True(t, ok, "expected a *llm.BudgetedProvider wrapper")
 }
 
 func TestBuildBudgetedProviderIdempotent(t *testing.T) {
 	a := agent.NewWithPrefix(nil, "!")
-	wrapped := runtime.BuildBudgetedProvider(a, stubProvider{}, 100, 50, nil)
-	again := runtime.BuildBudgetedProvider(a, wrapped, 100, 50, nil)
+	wrapped := runtime.BuildBudgetedProvider(a, stubProvider{}, 100, 50, 0, 0, nil)
+	again := runtime.BuildBudgetedProvider(a, wrapped, 100, 50, 0, 0, nil)
 	require.Same(t, wrapped, again, "re-wrapping must return the same instance")
 }
 
@@ -180,7 +180,7 @@ func TestBuildBudgetedProviderPublishesUsageEvent(t *testing.T) {
 	a.Events.Subscribe(agent.EventLLMUsage, func(_ context.Context, ev *agent.Event) {
 		got <- ev
 	})
-	wrapped := runtime.BuildBudgetedProvider(a, &usageProvider{in: 30, out: 12}, 1000, 500, nil)
+	wrapped := runtime.BuildBudgetedProvider(a, &usageProvider{in: 30, out: 12}, 1000, 500, 0, 0, nil)
 	_, _, err := wrapped.Ask(context.Background(), "hi")
 	require.NoError(t, err)
 	select {

--- a/internal/server/hot_reload_test.go
+++ b/internal/server/hot_reload_test.go
@@ -109,6 +109,31 @@ func TestCommandsOnlyChange(t *testing.T) {
 		"a channel change alongside a command change is not commands-only")
 }
 
+func TestLiveUpdatableOnlyChangeIgnoresTokenUsageBaseline(t *testing.T) {
+	base := specWithChannel("x", "#one")
+	base.PlanCapabilities = &PlanCapabilities{LLMInputTokensPerDay: 4000, LLMInputTokensUsed: 100}
+
+	// Only the usage baseline moved (the feed refreshes it every poll).
+	movedBaseline := specWithChannel("x", "#one")
+	movedBaseline.PlanCapabilities = &PlanCapabilities{LLMInputTokensPerDay: 4000, LLMInputTokensUsed: 3900}
+	require.True(t, liveUpdatableOnlyChange(base, movedBaseline),
+		"a change confined to the usage baseline must be applied without a reconnect")
+	require.True(t, commandSetsEqual(base.Commands, movedBaseline.Commands),
+		"command sets are unchanged here")
+
+	// A real cap change (not just usage) must still force a restart.
+	capChange := specWithChannel("x", "#one")
+	capChange.PlanCapabilities = &PlanCapabilities{LLMInputTokensPerDay: 40000, LLMInputTokensUsed: 3900}
+	require.False(t, liveUpdatableOnlyChange(base, capChange),
+		"a plan-cap change is not a live-updatable-only change")
+
+	// A channel change alongside a baseline move must still force a restart.
+	chChange := specWithChannel("x", "#two")
+	chChange.PlanCapabilities = movedBaseline.PlanCapabilities
+	require.False(t, liveUpdatableOnlyChange(base, chChange),
+		"a connector change is not a live-updatable-only change")
+}
+
 func TestReloadCommandsSwapsInPlace(t *testing.T) {
 	a := agent.NewWithPrefix(testLogger(), "!")
 	a.Commands.SetMaxDynamic(-1)
@@ -217,6 +242,50 @@ func TestUpdateCommandsOnlyReloadsWithoutRestart(t *testing.T) {
 	events <- TenantEvent{Kind: TenantUpserted, Spec: chSpec}
 	require.Eventually(t, func() bool { return runs.Load() == 2 }, 2*time.Second, 10*time.Millisecond,
 		"a connector change must restart the work loop")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}
+
+// TestUpdateTokenUsageBaselineDoesNotRestart guards the regression the
+// account-wide budget change could introduce: the feed refreshes
+// llm_*_tokens_used on every poll as tokens accrue, and that must NOT drop the
+// IRC session. A spec that differs only in the usage baseline is a no-op for
+// the work loop.
+func TestUpdateTokenUsageBaselineDoesNotRestart(t *testing.T) {
+	var runs atomic.Int32
+	base := TenantSpec{
+		TurborgID:        "x",
+		RuntimeMode:      "pooled",
+		Connectors:       []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "self"}, Secrets: map[string]any{}}},
+		PlanCapabilities: &PlanCapabilities{LLMInputTokensPerDay: 4000, LLMInputTokensUsed: 0},
+	}
+
+	events := make(chan TenantEvent)
+	src := &StaticSource{Tenants: []TenantSpec{base}, Events: events}
+	srv := New(src, testLogger())
+	srv.workFactory = func(tn *Tenant) func(context.Context) error {
+		return func(ctx context.Context) error {
+			runs.Add(1)
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return runs.Load() == 1 }, 2*time.Second, 5*time.Millisecond)
+
+	// Three successive feed polls, each reporting more usage. None may restart.
+	for _, used := range []int{1000, 2500, 3900} {
+		s := base
+		s.PlanCapabilities = &PlanCapabilities{LLMInputTokensPerDay: 4000, LLMInputTokensUsed: used}
+		events <- TenantEvent{Kind: TenantUpserted, Spec: s}
+	}
+	require.Never(t, func() bool { return runs.Load() != 1 }, 200*time.Millisecond, 20*time.Millisecond,
+		"a usage-baseline-only change must never restart the work loop")
 
 	cancel()
 	require.ErrorIs(t, <-done, context.Canceled)

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -363,7 +363,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// shared by the connector/commands (WireCommon) and the web gateway
 			// below. WireCommon's own wrap is idempotent on this.
 			cp := t.commonParams(cs, caps, settings.Nick, store, ignoredNicks, cmds)
-			budgetedProvider := runtime.BuildBudgetedProvider(a, cp.LLM, cp.LLMInputCap, cp.LLMOutputCap, t.log)
+			budgetedProvider := runtime.BuildBudgetedProvider(a, cp.LLM, cp.LLMInputCap, cp.LLMOutputCap, cp.LLMInputUsed, cp.LLMOutputUsed, t.log)
 			cp.LLM = budgetedProvider
 			if err := runtime.WireCommon(a, conn, cp, t.log); err != nil {
 				t.log.Error("skipping irc connector: wiring failed", "err", err)
@@ -446,7 +446,7 @@ func (t *Tenant) applyTierSettings(s *irc.Settings, caps *PlanCapabilities) {
 // dedicated runtime does (from TURBORG_COMMANDS).
 func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick string, store messages.Store, ignoredNicks []string, cmds []commands.Definition) runtime.CommonParams {
 	var limits irc.ClientLimits
-	var outMax, outWin, nudge, cmdMax, cmdWin, customCmdMax, llmInCap, llmOutCap int
+	var outMax, outWin, nudge, cmdMax, cmdWin, customCmdMax, llmInCap, llmOutCap, llmInUsed, llmOutUsed int
 	if caps != nil {
 		limits = irc.ClientLimits{
 			NickLocked:             caps.NickLocked,
@@ -459,6 +459,7 @@ func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick 
 		cmdMax, cmdWin = caps.CommandMaxPerWindow, caps.CommandWindowSeconds
 		customCmdMax = caps.CustomCommandsMax
 		llmInCap, llmOutCap = caps.LLMInputTokensPerDay, caps.LLMOutputTokensPerDay
+		llmInUsed, llmOutUsed = caps.LLMInputTokensUsed, caps.LLMOutputTokensUsed
 	}
 
 	// Activity hook: mark this tenant active in the pool's coalescing
@@ -490,6 +491,8 @@ func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick 
 		LLM:                   t.llmProvider,
 		LLMInputCap:           llmInCap,
 		LLMOutputCap:          llmOutCap,
+		LLMInputUsed:          llmInUsed,
+		LLMOutputUsed:         llmOutUsed,
 		ActivityHook:          activityHook,
 		Store:                 store,
 	}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -535,11 +535,24 @@ func (t *Tenant) update(spec TenantSpec) {
 	cancel := t.runCancel
 	t.mu.Unlock()
 
-	// Command-only change: reload in place, no reconnect. Falls through to a
-	// restart only if the tenant isn't currently running (between runs).
-	if commandsOnlyChange(prev, spec) && t.reloadCommands(spec.Commands) {
-		t.log.Info("tenant commands reloaded in place", "commands", len(spec.Commands))
-		return
+	// In-place, no-reconnect changes. The LLM-usage baseline (llm_*_tokens_used)
+	// is refreshed on every feed poll as tokens accrue, so it must NOT trigger a
+	// reconnect — that would drop the IRC session every few seconds. For pooled
+	// tenants the per-account cap equals the per-tenant cap (a pooled account
+	// owns one turborg), so local in-process counting is exact and the baseline
+	// only matters as the restart-recovery seed applied at build time; a live
+	// change to it alone is a no-op here. A command-set change still reloads in
+	// place. Anything else falls through to a restart.
+	if liveUpdatableOnlyChange(prev, spec) {
+		if commandSetsEqual(prev.Commands, spec.Commands) {
+			return // only the usage baseline moved — nothing to reconnect for
+		}
+		if t.reloadCommands(spec.Commands) {
+			t.log.Info("tenant commands reloaded in place", "commands", len(spec.Commands))
+			return
+		}
+		// Not currently running — fall through to a restart, which re-seeds the
+		// budget from the new spec at build time.
 	}
 
 	t.log.Info("tenant spec changed; restarting", "connectors", t.connectorTypes())
@@ -560,6 +573,36 @@ func (t *Tenant) update(spec TenantSpec) {
 func commandsOnlyChange(a, b TenantSpec) bool {
 	a.Commands = nil
 	b.Commands = nil
+	return reflect.DeepEqual(a, b)
+}
+
+// liveUpdatableOnlyChange reports whether two differing specs differ in nothing
+// but fields that can be applied to a running tenant WITHOUT a reconnect: the
+// command set and the LLM-usage baseline (llm_*_tokens_used, which the feed
+// refreshes continuously). Both the command set and the baseline are zeroed
+// before comparison so a change confined to them returns true.
+func liveUpdatableOnlyChange(a, b TenantSpec) bool {
+	a.Commands, b.Commands = nil, nil
+	a.PlanCapabilities = capsWithoutTokenUsage(a.PlanCapabilities)
+	b.PlanCapabilities = capsWithoutTokenUsage(b.PlanCapabilities)
+	return reflect.DeepEqual(a, b)
+}
+
+// capsWithoutTokenUsage returns a copy of caps with the live LLM-usage baseline
+// fields zeroed, so spec comparisons can ignore them. Returns nil unchanged
+// (never dereferences a nil pointer or mutates the caller's struct).
+func capsWithoutTokenUsage(caps *PlanCapabilities) *PlanCapabilities {
+	if caps == nil {
+		return nil
+	}
+	c := *caps
+	c.LLMInputTokensUsed = 0
+	c.LLMOutputTokensUsed = 0
+	return &c
+}
+
+// commandSetsEqual reports whether two command slices are identical.
+func commandSetsEqual(a, b []commands.Definition) bool {
 	return reflect.DeepEqual(a, b)
 }
 

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -101,6 +101,14 @@ type PlanCapabilities struct {
 	LLMInputTokensPerDay  int `json:"llm_input_tokens_per_day"`
 	LLMOutputTokensPerDay int `json:"llm_output_tokens_per_day"`
 
+	// LLMInputTokensUsed / LLMOutputTokensUsed seed the budget with consumption
+	// the control plane has already recorded across the account for the rolling
+	// window (this tenant's prior incarnations + sibling tenants). They make the
+	// cap enforce per account/window rather than per tenant-instance, so a
+	// delete+recreate can't reset the window. 0 = fresh window.
+	LLMInputTokensUsed  int `json:"llm_input_tokens_used"`
+	LLMOutputTokensUsed int `json:"llm_output_tokens_used"`
+
 	// LLM carries the OpenAI-compatible router config for LLM-type commands.
 	// Documentation-only on the turborg side: the pooled process builds one
 	// shared provider from its own env (the API key is a server-side secret,


### PR DESCRIPTION
## Problem

The LLM token budget (\`internal/llm/budget.go\`) was an in-memory, per-process counter that started at zero on every boot. The rolling-window cap was therefore enforced **per agent-instance, not per operator/window**: destroying and recreating an agent reset the window and handed out a fresh allowance each time.

## Fix

- Add \`TokenBudget.Seed(input, output)\` to pre-load the window with usage already consumed across it.
- Thread a used-tokens input through \`BuildBudgetedProvider\` → \`CommonParams\`:
  - **Single-process runtime:** \`LLM_INPUT_TOKENS_USED\` / \`LLM_OUTPUT_TOKENS_USED\` env.
  - **Pooled runtime:** \`llm_input_tokens_used\` / \`llm_output_tokens_used\` tenant-spec fields.
- The operator supplies usage-so-far at boot; the budget starts pre-loaded, so the cap holds across restarts/recreates instead of resetting.

Idempotency of \`BuildBudgetedProvider\` guarantees the budget is seeded exactly once.

## Tests

- New \`TokenBudget.Seed\` unit tests (counts toward cap; zero/negative is a no-op).
- Updated \`BuildBudgetedProvider\` callers.
- \`make lint test cover-gate\` green (total coverage 94.0%).

---

## Update — account-wide hardening (live baseline refresh)

The initial seed closed delete/recreate churn but left concurrent agents able to reach ~N× the cap. This makes the baseline live:

- `TokenBudget.SetBaseline` replaces (not accumulates) the account baseline; enforcement = baseline + local recorded usage. Local counting stays exact per process.
- New `internal/budgetrefresh` poller (dedicated runtime) refreshes the baseline every few seconds with `?since=<process start>`, so the response excludes what this process counts locally (no double-count) while keeping its pre-restart usage. Fail-safe (keeps last baseline on error); drained on shutdown.
- Pooled runtime: a usage-baseline-only spec change is applied in place and never triggers an IRC reconnect (`liveUpdatableOnlyChange`).

Tradeoff (per chosen "near-real-time" model): a few seconds of cross-agent staleness, not literally zero overage. Each agent's own usage is always exact.

Gates green: `make lint test cover-gate` (total 94.0%).
