### PR TITLE
feat(runtime): live-reload data-driven commands on a single agent

### DIFF
--- a/cmd/devirc/main.go
+++ b/cmd/devirc/main.go
@@ -75,12 +75,12 @@ type server struct {
 }
 
 type client struct {
-	conn  net.Conn
-	nick  string
-	w     *bufio.Writer
-	wmu   sync.Mutex
-	saslState string // "", "PLAIN", "done"
-	capLS bool
+	conn       net.Conn
+	nick       string
+	w          *bufio.Writer
+	wmu        sync.Mutex
+	saslState  string // "", "PLAIN", "done"
+	capLS      bool
 	registered bool
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -226,13 +226,13 @@ func TestAgentDrainReturnsOnInboundChannelClose(t *testing.T) {
 
 type failingStart struct{ fakeconn.Conn }
 
-func (f *failingStart) Name() string                                { return "failing" }
-func (f *failingStart) Start(_ context.Context) error               { return errors.New("nope") }
-func (f *failingStart) Run(_ context.Context) error                 { return nil }
-func (f *failingStart) Stop(_ context.Context) error                { return nil }
-func (f *failingStart) Inbound() <-chan *agent.InboundEnvelope      { return nil }
-func (f *failingStart) Send(_ *agent.OutboundEnvelope) error        { return nil }
-func (f *failingStart) ClaimSupervision() bool                      { return false }
+func (f *failingStart) Name() string                           { return "failing" }
+func (f *failingStart) Start(_ context.Context) error          { return errors.New("nope") }
+func (f *failingStart) Run(_ context.Context) error            { return nil }
+func (f *failingStart) Stop(_ context.Context) error           { return nil }
+func (f *failingStart) Inbound() <-chan *agent.InboundEnvelope { return nil }
+func (f *failingStart) Send(_ *agent.OutboundEnvelope) error   { return nil }
+func (f *failingStart) ClaimSupervision() bool                 { return false }
 
 type sendFails struct {
 	*fakeconn.Conn

--- a/internal/agent/commands_test.go
+++ b/internal/agent/commands_test.go
@@ -142,8 +142,12 @@ func TestCommandRegistryHandlerError(t *testing.T) {
 
 func TestCommandRegistryNames(t *testing.T) {
 	r := agent.NewCommandRegistry("!")
-	r.Register("a", func(context.Context, *agent.InboundEnvelope, []string) (*agent.OutboundEnvelope, error) { return nil, nil }, nil)
-	r.Register("b", func(context.Context, *agent.InboundEnvelope, []string) (*agent.OutboundEnvelope, error) { return nil, nil }, nil)
+	r.Register("a", func(context.Context, *agent.InboundEnvelope, []string) (*agent.OutboundEnvelope, error) {
+		return nil, nil
+	}, nil)
+	r.Register("b", func(context.Context, *agent.InboundEnvelope, []string) (*agent.OutboundEnvelope, error) {
+		return nil, nil
+	}, nil)
 	assert.ElementsMatch(t, []string{"a", "b"}, r.Names())
 }
 

--- a/internal/commandrefresh/refresh.go
+++ b/internal/commandrefresh/refresh.go
@@ -1,0 +1,146 @@
+// Package commandrefresh keeps a single dedicated agent's data-driven command
+// set current while it runs, without a reconnect.
+//
+// A dedicated agent boots with the command set baked into TURBORG_COMMANDS.
+// That set is fixed for the life of the process unless something tells the
+// running agent to reload it. This package polls an endpoint for the tenant's
+// current command set and, when it changes, applies it in place via a
+// caller-supplied callback (which rebuilds the handlers + ReplaceDynamic). It
+// is the dedicated-runtime mirror of what the pooled runtime already does from
+// its tenant feed, so the two share identical hot-reload semantics (an atomic
+// in-place swap — no IRC reconnect).
+//
+// Wire contract the operator must serve at the configured URL:
+//
+//	GET <url>
+//	  Authorization: Bearer <token>
+//	  Status: 200 on success.
+//	  Body: a JSON array of command definitions, the same wire shape as
+//	        TURBORG_COMMANDS / the pooled tenant feed's `commands`:
+//	        [{"name","type","template","instructions","access","allowlist"}, ...]
+//
+// Failures are non-fatal: the last applied set stays in force and the loop
+// retries on the next tick.
+package commandrefresh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/turborg/turborg/internal/commands"
+)
+
+const (
+	defaultInterval = 15 * time.Second
+	minInterval     = 2 * time.Second
+	requestTimeout  = 10 * time.Second
+)
+
+// Apply installs a new command set on the live agent. The runtime supplies a
+// closure that rebuilds the handlers (with the agent's provider + owner-trust)
+// and swaps them via CommandRegistry.ReplaceDynamic.
+type Apply func(defs []commands.Definition)
+
+// Refresher periodically pulls the tenant's command set and applies changes.
+type Refresher struct {
+	endpoint string
+	token    string
+	interval time.Duration
+	apply    Apply
+	client   *http.Client
+	log      *slog.Logger
+
+	last     []commands.Definition
+	haveLast bool
+}
+
+// New returns nil when refresh is not configured (no endpoint/token or no
+// apply callback) — so the caller can plug the result into an optional field
+// and gate the feature with a single non-nil check. intervalSeconds <= 0 uses
+// the default; values below the floor are clamped up.
+func New(endpoint, token string, intervalSeconds int, apply Apply, log *slog.Logger) *Refresher {
+	if endpoint == "" || token == "" || apply == nil {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	interval := time.Duration(intervalSeconds) * time.Second
+	switch {
+	case intervalSeconds <= 0:
+		interval = defaultInterval
+	case interval < minInterval:
+		interval = minInterval
+	}
+	return &Refresher{
+		endpoint: endpoint,
+		token:    token,
+		interval: interval,
+		apply:    apply,
+		client:   &http.Client{Timeout: requestTimeout},
+		log:      log.With("component", "command-refresh"),
+	}
+}
+
+// Run reloads once immediately, then on every interval tick, until ctx is
+// cancelled. Always returns nil (cancellation is the normal exit); the error
+// return exists for symmetry with the other runnables the runtime supervises.
+func (r *Refresher) Run(ctx context.Context) error {
+	r.refreshOnce(ctx)
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			r.refreshOnce(ctx)
+		}
+	}
+}
+
+func (r *Refresher) refreshOnce(ctx context.Context) {
+	defs, err := r.fetch(ctx)
+	if err != nil {
+		// Keep the last applied set; a brief stale command set is safe.
+		r.log.Debug("command refresh failed; keeping last set", "err", err)
+		return
+	}
+	// Skip the swap when nothing changed, mirroring the pooled runtime's
+	// commandSetsEqual gate so an unchanged poll is a no-op.
+	if r.haveLast && reflect.DeepEqual(r.last, defs) {
+		return
+	}
+	r.apply(defs)
+	r.last = defs
+	r.haveLast = true
+	r.log.Info("commands reloaded in place", "commands", len(defs))
+}
+
+func (r *Refresher) fetch(ctx context.Context) ([]commands.Definition, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.token)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var defs []commands.Definition
+	if err := json.NewDecoder(resp.Body).Decode(&defs); err != nil {
+		return nil, fmt.Errorf("decode body: %w", err)
+	}
+	return defs, nil
+}

--- a/internal/commandrefresh/refresh_test.go
+++ b/internal/commandrefresh/refresh_test.go
@@ -1,0 +1,153 @@
+package commandrefresh
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/turborg/turborg/internal/commands"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+type spyApply struct {
+	mu    sync.Mutex
+	calls int
+	last  []commands.Definition
+}
+
+func (s *spyApply) apply(defs []commands.Definition) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.last = defs
+}
+
+func (s *spyApply) snapshot() (int, []commands.Definition) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls, s.last
+}
+
+func TestNewReturnsNilWhenUnconfigured(t *testing.T) {
+	s := &spyApply{}
+	assert.Nil(t, New("", "tok", 0, s.apply, nil), "no endpoint → nil")
+	assert.Nil(t, New("http://x", "", 0, s.apply, nil), "no token → nil")
+	assert.Nil(t, New("http://x", "tok", 0, nil, nil), "no apply → nil")
+	assert.NotNil(t, New("http://x", "tok", 0, s.apply, nil))
+}
+
+func TestRefreshAppliesCommandsAndSendsAuth(t *testing.T) {
+	var gotAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`[{"name":"weather","type":"llm","template":"{args}","access":"owner"}]`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "secret-tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	calls, last := s.snapshot()
+	assert.Equal(t, 1, calls)
+	require.Len(t, last, 1)
+	assert.Equal(t, "weather", last[0].Name)
+	assert.Equal(t, commands.AccessOwner, last[0].Access)
+	assert.Equal(t, "Bearer secret-tok", gotAuth.Load())
+}
+
+func TestRefreshSkipsApplyWhenUnchanged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"ping","type":"static","template":"pong","access":"everyone"}]`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+	r.refreshOnce(context.Background()) // identical response → no second apply
+
+	calls, _ := s.snapshot()
+	assert.Equal(t, 1, calls, "an unchanged command set must not trigger a second swap")
+}
+
+func TestRefreshKeepsLastSetOnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	calls, _ := s.snapshot()
+	assert.Equal(t, 0, calls, "a non-200 must not apply a command set")
+}
+
+func TestRefreshKeepsLastSetOnMalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	calls, _ := s.snapshot()
+	assert.Equal(t, 0, calls, "a body that fails to decode must not apply a command set")
+}
+
+func TestRunRefreshesImmediatelyAndStopsOnCancel(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 0, s.apply, nil)
+	require.NotNil(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return hits.Load() >= 1 }, time.Second, 10*time.Millisecond,
+		"Run must refresh once immediately")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestNewClampsSubFloorInterval(t *testing.T) {
+	r := New("http://x", "tok", 1, (&spyApply{}).apply, nil) // 1s < floor
+	require.NotNil(t, r)
+	assert.Equal(t, minInterval, r.interval)
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -152,6 +152,21 @@ type Settings struct {
 	// (15s); values below the floor are clamped up by the refresher.
 	LLMBudgetRefreshSeconds int `env:"LLM_BUDGET_REFRESH_SECONDS"`
 
+	// CommandsURL is an optional endpoint the agent polls to hot-reload its
+	// data-driven command set while it runs — no reconnect. SaaS deployments
+	// point it at the sidecar's per-container commands handler, which forwards
+	// the tenant's resolved command set from the control plane. Empty = no live
+	// reload (the boot TURBORG_COMMANDS set is fixed, correct for self-host).
+	// This gives a dedicated agent the same in-place ReplaceDynamic the pooled
+	// runtime already does from its tenant feed.
+	CommandsURL string `env:"COMMANDS_URL"`
+	// CommandsToken is the bearer sent on every commands poll. Defaults to
+	// MessageSinkToken via normalize() when unset — same per-container endpoint.
+	CommandsToken string `env:"COMMANDS_TOKEN"`
+	// CommandsRefreshSeconds is the poll interval. 0 uses the package default;
+	// values below the floor are clamped up by the refresher.
+	CommandsRefreshSeconds int `env:"COMMANDS_REFRESH_SECONDS"`
+
 	// CustomCommandsMax caps the dynamic-command registry. 0 = no
 	// commands, -1 = unrestricted. Bounds the command set loaded from
 	// TURBORG_COMMANDS (and any later runtime registrations).
@@ -300,6 +315,11 @@ func (s *Settings) normalize() error {
 	// the message sink, so it reuses that bearer unless overridden.
 	if s.LLMBudgetToken == "" {
 		s.LLMBudgetToken = s.MessageSinkToken
+	}
+	// The commands poll terminates at the same per-container endpoint, so it
+	// reuses that bearer unless overridden.
+	if s.CommandsToken == "" {
+		s.CommandsToken = s.MessageSinkToken
 	}
 	return nil
 }

--- a/internal/connector/irc/ratelimit.go
+++ b/internal/connector/irc/ratelimit.go
@@ -32,9 +32,9 @@ type RateLimiter struct {
 	Lockout     time.Duration
 	now         Clock
 
-	mu           sync.Mutex
-	failures     map[string][]time.Time
-	lockedUntil  map[string]time.Time
+	mu          sync.Mutex
+	failures    map[string][]time.Time
+	lockedUntil map[string]time.Time
 }
 
 func NewRateLimiter(maxFailures int, window, lockout time.Duration, clock Clock) (*RateLimiter, error) {

--- a/internal/connector/irc/state.go
+++ b/internal/connector/irc/state.go
@@ -18,11 +18,11 @@ type ChannelInfo struct {
 	// case-insensitive but display preserves the form the server used.
 	Name string
 
-	Topic        string
-	TopicSet     bool
-	TopicSetBy   string
-	TopicSetAt   int64
-	Members      map[string]string // nick → mode prefix ("", "@", "+", "%", "&", "~")
+	Topic         string
+	TopicSet      bool
+	TopicSetBy    string
+	TopicSetAt    int64
+	Members       map[string]string // nick → mode prefix ("", "@", "+", "%", "&", "~")
 	NamesComplete bool
 }
 

--- a/internal/messagesink/sink_test.go
+++ b/internal/messagesink/sink_test.go
@@ -28,9 +28,9 @@ func quietLogger() *slog.Logger {
 // sidecar/messages_sink_test.go pins the other end of the same wire.
 func TestSinkWireShape(t *testing.T) {
 	var (
-		mu      sync.Mutex
-		got     []*http.Request
-		bodies  [][]byte
+		mu     sync.Mutex
+		got    []*http.Request
+		bodies [][]byte
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
@@ -307,7 +307,7 @@ func TestRequestBuildErrorIsAbsorbed(t *testing.T) {
 	// Push directly into the buffer and call flushOnce — bypasses the
 	// goroutine so the test stays deterministic.
 	s.buffer = []Entry{{
-		MsgID: "01HX0000000000000000000000",
+		MsgID:   "01HX0000000000000000000000",
 		Channel: "#x", Nick: "n", Text: "t",
 		Ts: "2026-06-01T00:00:00.000000Z",
 	}}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -22,8 +22,9 @@ import (
 	"time"
 
 	"github.com/turborg/turborg/internal/activity"
-	"github.com/turborg/turborg/internal/budgetrefresh"
 	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/budgetrefresh"
+	"github.com/turborg/turborg/internal/commandrefresh"
 	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/config"
 	"github.com/turborg/turborg/internal/connector/irc"
@@ -48,6 +49,10 @@ type Built struct {
 	// BudgetRefresh keeps the token budget's account baseline current while the
 	// agent runs. Nil when the provider isn't budgeted or no endpoint is set.
 	BudgetRefresh *budgetrefresh.Refresher
+	// CommandRefresh hot-reloads the data-driven command set in place while the
+	// agent runs (the dedicated mirror of the pooled feed-driven reload). Nil
+	// when COMMANDS_URL is unset (self-host: the boot set is fixed).
+	CommandRefresh *commandrefresh.Refresher
 }
 
 // Build wires the agent + connectors + gateway from settings. Callers
@@ -112,6 +117,20 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	// idempotent on an already-budgeted provider.
 	provider = BuildBudgetedProvider(a, provider, s.LLMInputTokensPerDay, s.LLMOutputTokensPerDay, s.LLMInputTokensUsed, s.LLMOutputTokensUsed, log)
 
+	// Owner-trust + per-sender guard config, shared by the initial command
+	// wiring and the live command refresher so a hot reload rebuilds handlers
+	// with exactly the same access rules.
+	owner := GuardParams{
+		OwnerMode:            s.OwnerMode,
+		OwnerNick:            s.OwnerNick,
+		OwnerAccount:         s.OwnerAccount,
+		OwnerHostmask:        s.OwnerHostmask,
+		IgnoredNicks:         s.IgnoredNicks,
+		BotNick:              ircCfg.Nick,
+		CommandMaxPerWindow:  s.CommandMaxPerWindow,
+		CommandWindowSeconds: s.CommandWindowSeconds,
+	}
+
 	// The connector-agnostic, transport-independent wiring — builtins, owner
 	// guard, throttles, nudge, store submitters. The pooled runtime calls this
 	// same WireCommon from its tenant builder, so the two modes can't drift.
@@ -124,16 +143,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 			MaxChannels:            s.MaxChannels,
 			TBSummarizeMaxMessages: s.TBSummarizeMaxMessages,
 		},
-		Owner: GuardParams{
-			OwnerMode:            s.OwnerMode,
-			OwnerNick:            s.OwnerNick,
-			OwnerAccount:         s.OwnerAccount,
-			OwnerHostmask:        s.OwnerHostmask,
-			IgnoredNicks:         s.IgnoredNicks,
-			BotNick:              ircCfg.Nick,
-			CommandMaxPerWindow:  s.CommandMaxPerWindow,
-			CommandWindowSeconds: s.CommandWindowSeconds,
-		},
+		Owner:                     owner,
 		OutboundMaxPerWindow:      s.OutboundMaxPerWindow,
 		OutboundWindowSeconds:     s.OutboundWindowSeconds,
 		OwnerNick:                 s.OwnerNick,
@@ -184,6 +194,18 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 			log,
 		)
 	}
+
+	// Live command hot-reload: when COMMANDS_URL is set, poll the per-container
+	// commands endpoint and swap the dynamic command set in place — the same
+	// ReplaceDynamic the pooled runtime does from its feed, so a dedicated
+	// container picks up skill attach/detach/edit without a respawn/reconnect.
+	built.CommandRefresh = commandrefresh.New(
+		s.CommandsURL,
+		s.CommandsToken,
+		s.CommandsRefreshSeconds,
+		func(defs []commands.Definition) { ApplyCommands(a, defs, provider, owner, log) },
+		log,
+	)
 
 	if s.GatewayEnabled() {
 		gw, err := buildGateway(s, ircConn, a, log, notifier, store, provider)
@@ -260,13 +282,13 @@ func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, lo
 		return nil, fmt.Errorf("runtime: gateway ratelimit: %w", err)
 	}
 	opts := web.Options{
-		Host:         s.GatewayHost,
-		Port:         s.GatewayPort,
-		Verifier:     verifier,
-		RateLimiter:  rl,
-		Log:          log,
-		MessageStore: store,
-		LLMProvider:  llmProvider,
+		Host:                   s.GatewayHost,
+		Port:                   s.GatewayPort,
+		Verifier:               verifier,
+		RateLimiter:            rl,
+		Log:                    log,
+		MessageStore:           store,
+		LLMProvider:            llmProvider,
 		TBSummarizeMaxMessages: s.TBSummarizeMaxMessages,
 	}
 	if notifier.Enabled() {
@@ -416,20 +438,20 @@ func isChannelTarget(s string) bool {
 // are inert until the operator opts in.
 //
 //   - "none":     refuse every !command. Bots running as pure relays,
-//                 log-only agents, or personal-bouncer use cases sit
-//                 here. Throttle still runs against anonymous scope so
-//                 a misconfigured throttle gate doesn't silently allow.
+//     log-only agents, or personal-bouncer use cases sit
+//     here. Throttle still runs against anonymous scope so
+//     a misconfigured throttle gate doesn't silently allow.
 //   - "self":     trust messages where the sender's nick equals the
-//                 bot's own nick. Useful for personal AI assistants
-//                 where the operator attaches via the bouncer and IS
-//                 the bot. The IRC network won't allow nick collisions,
-//                 so the sender check is sufficient on its own.
+//     bot's own nick. Useful for personal AI assistants
+//     where the operator attaches via the bouncer and IS
+//     the bot. The IRC network won't allow nick collisions,
+//     so the sender check is sufficient on its own.
 //   - "external": trust messages from OwnerNick, verified via the
-//                 IRCv3 account-tag. OwnerAccount overrides the
-//                 expected account name (defaults to OwnerNick). When
-//                 the network has no services and no account-tag
-//                 arrives, fall back to hostmask matching against
-//                 OwnerHostmask when it's set. Without either, deny.
+//     IRCv3 account-tag. OwnerAccount overrides the
+//     expected account name (defaults to OwnerNick). When
+//     the network has no services and no account-tag
+//     arrives, fall back to hostmask matching against
+//     OwnerHostmask when it's set. Without either, deny.
 //
 // Owner checks fail closed: ambiguous signals never resolve to "trust".
 // This matters most precisely when the verification pipeline is
@@ -645,20 +667,28 @@ func Run(ctx context.Context, b *Built) error {
 	rootCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Background budget refresher: keeps the token baseline fresh under rootCtx.
-	// It is NOT part of the cross-stop race (it doesn't gate process lifetime),
-	// but we drain it before returning so no goroutine outlives Run.
-	var refreshDone chan struct{}
-	if b.BudgetRefresh != nil {
-		refreshDone = make(chan struct{})
+	// Background refreshers: keep the token baseline and the command set fresh
+	// under rootCtx. Neither gates process lifetime (they're not in the cross-
+	// stop race), but we drain them before returning so no goroutine outlives
+	// Run. Each exposes Run(ctx) error and exits when rootCtx is cancelled.
+	var refreshDones []chan struct{}
+	startRefresher := func(run func(context.Context) error) {
+		done := make(chan struct{})
+		refreshDones = append(refreshDones, done)
 		go func() {
-			defer close(refreshDone)
-			_ = b.BudgetRefresh.Run(rootCtx)
+			defer close(done)
+			_ = run(rootCtx)
 		}()
 	}
+	if b.BudgetRefresh != nil {
+		startRefresher(b.BudgetRefresh.Run)
+	}
+	if b.CommandRefresh != nil {
+		startRefresher(b.CommandRefresh.Run)
+	}
 	waitRefresh := func() {
-		if refreshDone != nil {
-			<-refreshDone
+		for _, done := range refreshDones {
+			<-done
 		}
 	}
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -109,9 +109,9 @@ func TestBuildActivityNoopWhenURLUnset(t *testing.T) {
 
 func TestBuildActivityEnabledWhenURLSet(t *testing.T) {
 	s := &config.Settings{
-		CommandPrefix:           "!",
-		ActivityURL:             "http://observer.local/mark",
-		ActivityToken:           "shh",
+		CommandPrefix:               "!",
+		ActivityURL:                 "http://observer.local/mark",
+		ActivityToken:               "shh",
 		GatewayPassword:             "hunter2",
 		GatewayHost:                 "127.0.0.1",
 		GatewayPort:                 0,
@@ -548,7 +548,6 @@ func TestRunWithGatewayUnwindsWhileConnectorRetries(t *testing.T) {
 		t.Fatal("Run did not unwind the gateway/agent pair on ctx cancel")
 	}
 }
-
 
 // --- LoadIRCSettings ------------------------------------------------------
 

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -168,11 +168,27 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 
 	// Install the tenant's data-driven commands. The dynamic set is fully
 	// owned by ReplaceDynamic, so a later hot reload swaps it atomically.
-	built := commands.Build(p.Commands, provider, func(d commands.Definition) agent.CommandGuard {
-		return PerCommandGuard(string(d.Access), d.Allowlist, p.Owner)
+	ApplyCommands(a, p.Commands, provider, p.Owner, log)
+	return nil
+}
+
+// ApplyCommands rebuilds the data-driven command set from defs and swaps it
+// into the agent's registry in place via ReplaceDynamic — an atomic, no-
+// reconnect hot reload. It is the single source of truth for turning command
+// Definitions into live handlers, shared by initial wiring (WireCommon), the
+// pooled runtime's feed-driven reload, and the dedicated runtime's command
+// refresher, so the three can't drift in how a command is built or
+// access-gated. The registry-wide ignore/throttle guard set at wire time is
+// untouched; per-command access (owner / allowlist / everyone) is reapplied
+// from each Definition.
+func ApplyCommands(a *agent.Agent, defs []commands.Definition, provider llm.Provider, owner GuardParams, log *slog.Logger) {
+	if log == nil {
+		log = slog.Default()
+	}
+	built := commands.Build(defs, provider, func(d commands.Definition) agent.CommandGuard {
+		return PerCommandGuard(string(d.Access), d.Allowlist, owner)
 	}, log)
 	a.Commands.ReplaceDynamic(built)
-	return nil
 }
 
 // BuildBudgetedProvider wraps an llm.Provider with rolling-24h budget

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -631,10 +631,8 @@ func (t *Tenant) reloadCommands(defs []commands.Definition) bool {
 		IgnoredNicks:  ignoredNicks,
 		BotNick:       conn.CurrentNick(),
 	}
-	built := commands.Build(defs, t.llmProvider, func(d commands.Definition) agent.CommandGuard {
-		return runtime.PerCommandGuard(string(d.Access), d.Allowlist, owner)
-	}, t.log)
-	a.Commands.ReplaceDynamic(built)
+	// Same in-place swap the dedicated runtime's command refresher uses.
+	runtime.ApplyCommands(a, defs, t.llmProvider, owner, t.log)
 	return true
 }
 

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"errors"
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"errors"
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"

--- a/tests/fixtures/fakeconn/conn.go
+++ b/tests/fixtures/fakeconn/conn.go
@@ -18,10 +18,10 @@ type Conn struct {
 
 	inbox chan *agent.InboundEnvelope
 
-	mu       sync.Mutex
-	sent     []*agent.OutboundEnvelope
-	started  bool
-	stopped  bool
+	mu          sync.Mutex
+	sent        []*agent.OutboundEnvelope
+	started     bool
+	stopped     bool
 	inboxClosed bool
 }
 
@@ -33,9 +33,9 @@ func New(name string) *Conn {
 	}
 }
 
-func (c *Conn) Name() string                                { return c.NameStr }
-func (c *Conn) Inbound() <-chan *agent.InboundEnvelope      { return c.inbox }
-func (c *Conn) ClaimSupervision() bool                      { return c.SupervisedB }
+func (c *Conn) Name() string                           { return c.NameStr }
+func (c *Conn) Inbound() <-chan *agent.InboundEnvelope { return c.inbox }
+func (c *Conn) ClaimSupervision() bool                 { return c.SupervisedB }
 
 func (c *Conn) Start(_ context.Context) error {
 	c.mu.Lock()


### PR DESCRIPTION
Adds an optional commands poller so a long-lived single-tenant agent can hot-reload its data-driven command set in place (`CommandRegistry.ReplaceDynamic`) with no reconnect — mirroring the pooled runtime's feed-driven reload via a shared `ApplyCommands` helper.

New envs: `TURBORG_COMMANDS_URL` / `TURBORG_COMMANDS_TOKEN` / `TURBORG_COMMANDS_REFRESH_SECONDS` (empty URL = no live reload, self-host default).

Second commit is gofmt formatting normalization (no behavior change).