### PR TITLE
feat(connector/irc): gate AI history commands behind channel-op consent on strict networks

### DIFF
--- a/internal/connector/irc/aistrict_test.go
+++ b/internal/connector/irc/aistrict_test.go
@@ -1,0 +1,138 @@
+package irc_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/messages"
+)
+
+func TestChannelStateIsOperator(t *testing.T) {
+	s := irc.NewChannelState()
+	s.OnSelfJoin("#ch")
+	s.OnNamesReply("#ch", []string{"@alice", "+bob", "carol", "%dave", "&eve", "~fred"})
+	s.OnNamesEnd("#ch")
+
+	// op (@), admin (&), owner (~) all count as operator-or-higher.
+	for _, nick := range []string{"alice", "eve", "fred"} {
+		assert.Truef(t, s.IsOperator("#ch", nick), "%q should be operator", nick)
+	}
+	// voice (+), halfop (%), and plain members do not.
+	for _, nick := range []string{"bob", "dave", "carol"} {
+		assert.Falsef(t, s.IsOperator("#ch", nick), "%q should NOT be operator", nick)
+	}
+
+	// Channel and nick comparison both fold case.
+	assert.True(t, s.IsOperator("#CH", "ALICE"))
+
+	// Unknown nick / channel / empty nick / nil receiver are all false.
+	assert.False(t, s.IsOperator("#ch", "nobody"))
+	assert.False(t, s.IsOperator("#nope", "alice"))
+	assert.False(t, s.IsOperator("#ch", ""))
+	var nilState *irc.ChannelState
+	assert.False(t, nilState.IsOperator("#ch", "alice"))
+}
+
+func TestClientLimitsAIStrictDenyMessage(t *testing.T) {
+	// No override → the neutral built-in default.
+	var l irc.ClientLimits
+	assert.Equal(t, irc.DefaultAIStrictMessage, l.AIStrictDenyMessage())
+
+	// Override wins (lets the control plane supply network-specific wording).
+	l.AIStrictMessage = "op consent required here"
+	assert.Equal(t, "op consent required here", l.AIStrictDenyMessage())
+}
+
+// strictBouncerLimits is the policy the gate tests install: the AI gate on,
+// a recognisable notice, and a non-zero summarize cap so the only thing
+// standing between the request and the LLM is the +o check.
+func strictBouncerLimits() irc.ClientLimits {
+	return irc.ClientLimits{
+		AIStrict:               true,
+		AIStrictMessage:        "op consent required here",
+		TBSummarizeMaxMessages: 200,
+	}
+}
+
+func TestBouncerTBSummarizeAIStrictDeniesNonOp(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	// Bot is present but NOT opped.
+	state.OnNamesReply("#test", []string{"turborg", "alice"})
+	state.OnNamesEnd("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+	b.AttachClientLimits(strictBouncerLimits())
+
+	store := messages.NewMemoryStore(0)
+	_ = store.Submit(context.Background(), messages.Message{
+		Channel: "#test", Nick: "alice", Text: "hi", TS: time.Now(),
+	})
+	b.AttachMessageStore(store)
+
+	conn, r := bouncerClient(t, addr)
+	defer conn.Close()
+	authSimple(t, conn, r, "hunter2")
+
+	writeLine(t, conn, "TB SUMMARIZE #test")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var gotDeny, gotSummarizing bool
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if strings.Contains(line, "op consent required here") {
+			gotDeny = true
+		}
+		if strings.Contains(line, "Summarizing") {
+			gotSummarizing = true
+		}
+	}
+	assert.True(t, gotDeny, "a non-op must be denied with the policy notice")
+	assert.False(t, gotSummarizing, "a denied request must not start summarizing")
+}
+
+func TestBouncerTBSummarizeAIStrictAllowsOp(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	// Bot holds +o → an op opped it, which is the consent signal.
+	state.OnNamesReply("#test", []string{"@turborg", "alice"})
+	state.OnNamesEnd("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+	b.AttachClientLimits(strictBouncerLimits())
+	b.AttachMessageStore(messages.NewMemoryStore(0))
+
+	conn, r := bouncerClient(t, addr)
+	defer conn.Close()
+	authSimple(t, conn, r, "hunter2")
+
+	writeLine(t, conn, "TB SUMMARIZE #test")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var gotDeny, gotSummarizing bool
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		if strings.Contains(line, "op consent required here") {
+			gotDeny = true
+		}
+		// No LLM is attached, so the goroutine will error afterwards — but
+		// "Summarizing" is emitted only once the +o gate has passed.
+		if strings.Contains(line, "Summarizing") {
+			gotSummarizing = true
+			break
+		}
+	}
+	assert.False(t, gotDeny, "an opped bot must not be denied")
+	assert.True(t, gotSummarizing, "an opped bot should proceed past the gate")
+}

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -438,6 +438,16 @@ func (b *Bouncer) handleTBSummarize(client *BouncerClient, args []string) {
 	}
 
 	limits := b.currentClientLimits()
+
+	// On a strict network, AI history commands require the bot to hold
+	// channel-operator status in the target channel (an op granting the
+	// bot +o is the consent signal). Applies to every history-consuming
+	// /tb AI subcommand; non-AI subcommands (e.g. usage) are unaffected.
+	if limits.AIStrict && !b.botIsChannelOperator(channel) {
+		b.notifyService(client, limits.AIStrictDenyMessage())
+		return
+	}
+
 	cap := limits.TBSummarizeMaxMessages
 	store := b.currentMessageStore()
 
@@ -459,6 +469,18 @@ func (b *Bouncer) handleTBSummarize(client *BouncerClient, args []string) {
 		}
 		b.notifyService(client, "["+channel+" summary] "+summary)
 	}()
+}
+
+// botIsChannelOperator reports whether the bot's own upstream nick holds
+// channel-operator status (+o or higher) in channel, per the tracked
+// upstream channel state. Used to gate AI history commands on strict
+// networks. False when state isn't attached yet.
+func (b *Bouncer) botIsChannelOperator(channel string) bool {
+	b.upstreamMu.RLock()
+	state := b.state
+	nick := b.upstreamNick
+	b.upstreamMu.RUnlock()
+	return state.IsOperator(channel, nick)
 }
 
 func (b *Bouncer) AttachUpstream(send SendUpstreamFunc) {

--- a/internal/connector/irc/policy.go
+++ b/internal/connector/irc/policy.go
@@ -34,6 +34,38 @@ type ClientLimits struct {
 	// TBSummarizeMaxMessages caps how many channel messages /tb summarize
 	// can consume. 0 = feature disabled.
 	TBSummarizeMaxMessages int
+
+	// AIStrict gates the channel-history-consuming /tb AI command family
+	// (e.g. /tb summarize) behind channel-operator consent, for upstream
+	// networks whose bot policy requires it. When true, those commands only
+	// run if the bot holds channel-operator status (mode +o or higher) in
+	// the target channel — an op granting the bot +o is the consent signal.
+	// False (the default) leaves the AI commands unrestricted. Other /tb
+	// subcommands (e.g. usage) are never gated by this flag.
+	AIStrict bool
+
+	// AIStrictMessage is the operator-facing notice returned when an AI
+	// history command is blocked under AIStrict because the bot lacks
+	// channel-operator status. Empty falls back to DefaultAIStrictMessage,
+	// so a strict network's specific policy text can be supplied by the
+	// operator without baking any one network's wording into the framework.
+	AIStrictMessage string
+}
+
+// DefaultAIStrictMessage is the network-neutral notice sent when an AI
+// history command is denied under AIStrict and no AIStrictMessage override
+// was configured. Operators on a network with a published bot policy
+// typically override it with that policy's specific wording and URL.
+const DefaultAIStrictMessage = "AI commands that read channel history require channel-operator status here, per this network's bot policy."
+
+// AIStrictDenyMessage returns the notice to send when an AI history command
+// is blocked under AIStrict — the configured override, or the neutral
+// default when none is set.
+func (l ClientLimits) AIStrictDenyMessage() string {
+	if l.AIStrictMessage != "" {
+		return l.AIStrictMessage
+	}
+	return DefaultAIStrictMessage
 }
 
 // CapHitKind maps an IRC command to the canonical "kind" label used in

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -90,6 +90,17 @@ type Settings struct {
 	CTCPMaxPerWindow  int  `env:"CTCP_MAX_PER_WINDOW" envDefault:"3"`
 	CTCPWindowSeconds int  `env:"CTCP_WINDOW_SECONDS" envDefault:"30"`
 
+	// AIStrict requires the bot to hold channel-operator status (+o) in a
+	// channel before AI commands that read its history (e.g. /tb summarize)
+	// will run there. Off by default; set it on networks whose bot policy
+	// requires operator consent for LLM processing of channel messages.
+	AIStrict bool `env:"AI_STRICT"`
+
+	// AIStrictMessage overrides the notice sent when an AI history command
+	// is denied under AIStrict. Empty uses the neutral built-in default;
+	// set it to a network's specific policy wording/URL.
+	AIStrictMessage string `env:"AI_STRICT_MESSAGE"`
+
 	// UpstreamWarnAfter is the dwell time in disconnected_transient
 	// before the reconnect supervisor fires its operator-visible warn
 	// hook. 0 disables the warn step.

--- a/internal/connector/irc/state.go
+++ b/internal/connector/irc/state.go
@@ -10,6 +10,13 @@ import (
 // containment.
 const memberPrefixes = "@+%&~"
 
+// operatorPrefixes are the member-prefix characters that denote channel-
+// operator status (mode +o) or higher in the standard prefix hierarchy
+// (~ owner > & admin > @ op). Halfop (%) and voice (+) rank below an
+// operator and are deliberately excluded — "operator" here means +o or
+// above.
+const operatorPrefixes = "@&~"
+
 // ChannelInfo is per-channel state cached from observed server messages.
 // The bouncer replays this to new clients on auth so they pick up the
 // bot's view of the network instead of starting blank.
@@ -49,6 +56,31 @@ func (s *ChannelState) Get(channel string) *ChannelInfo {
 		return nil
 	}
 	return cloneChannelInfo(info)
+}
+
+// IsOperator reports whether nick currently holds channel-operator status
+// (mode +o) or higher in channel, per the tracked RPL_NAMREPLY / MODE
+// member prefixes. Channel lookup is case-insensitive (matching Get); the
+// nick comparison folds ASCII case so a bot nick observed in a different
+// case than the caller supplies still matches. Returns false when the
+// receiver is nil, the nick is empty, the channel is unknown, or the nick
+// carries no operator-level prefix.
+func (s *ChannelState) IsOperator(channel, nick string) bool {
+	if s == nil || nick == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	info, ok := s.channels[strings.ToLower(channel)]
+	if !ok {
+		return false
+	}
+	for member, prefix := range info.Members {
+		if strings.EqualFold(member, nick) {
+			return strings.ContainsAny(prefix, operatorPrefixes)
+		}
+	}
+	return false
 }
 
 // Count returns how many channels are currently joined. Cheap (no

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -142,6 +142,10 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 			RealnameLocked:         s.RealnameLocked,
 			MaxChannels:            s.MaxChannels,
 			TBSummarizeMaxMessages: s.TBSummarizeMaxMessages,
+			// Per-connector network policy (the strict-network AI gate)
+			// lives on the IRC settings, not the top-level config.
+			AIStrict:        ircCfg.AIStrict,
+			AIStrictMessage: ircCfg.AIStrictMessage,
 		},
 		Owner:                     owner,
 		OutboundMaxPerWindow:      s.OutboundMaxPerWindow,

--- a/internal/server/connector_irc.go
+++ b/internal/server/connector_irc.go
@@ -38,6 +38,10 @@ func settingsFromConnectorSpec(cs ConnectorSpec) (*irc.Settings, error) {
 		AuthMode: stringField(cs.Config, "auth_mode"),
 		Channels: stringSlice(cs.Config, "channels"),
 
+		// Per-connector network policy: the strict-network AI gate.
+		AIStrict:        boolField(cs.Config, "ai_strict", false),
+		AIStrictMessage: stringField(cs.Config, "ai_strict_message"),
+
 		SASLUser:         stringField(cs.Secrets, "sasl_user"),
 		SASLPassword:     stringField(cs.Secrets, "sasl_password"),
 		NickServPassword: stringField(cs.Secrets, "nickserv_password"),

--- a/internal/server/connector_irc_test.go
+++ b/internal/server/connector_irc_test.go
@@ -42,6 +42,23 @@ func TestSettingsFromConnectorSpec(t *testing.T) {
 	require.Equal(t, "p", s.SASLPassword)
 }
 
+func TestSettingsMapsAIStrictPolicy(t *testing.T) {
+	// Absent → the strict-network AI gate stays off (the default).
+	s, err := settingsFromConnectorSpec(ircConfig(nil))
+	require.NoError(t, err)
+	require.False(t, s.AIStrict)
+	require.Empty(t, s.AIStrictMessage)
+
+	// Present → ai_strict + its notice map onto the connector settings.
+	s, err = settingsFromConnectorSpec(ircConfig(map[string]any{
+		"ai_strict":         true,
+		"ai_strict_message": "op consent required here",
+	}))
+	require.NoError(t, err)
+	require.True(t, s.AIStrict)
+	require.Equal(t, "op consent required here", s.AIStrictMessage)
+}
+
 func TestSettingsWiresBouncerPasswordFromSecrets(t *testing.T) {
 	// The spec carries bouncer_password in secrets; settingsFromConnectorSpec
 	// must read it so the (listenerless) bouncer the SNI router feeds is enabled.

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -462,6 +462,12 @@ func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick 
 		llmInUsed, llmOutUsed = caps.LLMInputTokensUsed, caps.LLMOutputTokensUsed
 	}
 
+	// The strict-network AI gate is a per-connector network policy, not a
+	// plan cap — source it from the connector spec so it applies regardless
+	// of whether caps were supplied.
+	limits.AIStrict = boolField(cs.Config, "ai_strict", false)
+	limits.AIStrictMessage = stringField(cs.Config, "ai_strict_message")
+
 	// Activity hook: mark this tenant active in the pool's coalescing
 	// aggregator. Nil when no control plane is configured.
 	var activityHook func(string)

--- a/internal/web/aistrict_test.go
+++ b/internal/web/aistrict_test.go
@@ -1,0 +1,79 @@
+package web_test
+
+import (
+	"context"
+	"testing"
+
+	"encoding/json"
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// strictGatewayBridge returns a bridge whose ClientLimits enable the AI gate
+// with a recognisable notice. Channel membership is set by the caller.
+func strictGatewayBridge() *fakeBridge {
+	b := newFakeBridge("turborg")
+	b.limits = irc.ClientLimits{
+		AIStrict:        true,
+		AIStrictMessage: "op consent required here",
+	}
+	return b
+}
+
+func TestTBOpSummarizeAIStrictDeniesNonOp(t *testing.T) {
+	bridge := strictGatewayBridge()
+	bridge.state.OnSelfJoin("#x")
+	// Bot present but NOT opped.
+	bridge.state.OnNamesReply("#x", []string{"turborg", "alice"})
+	bridge.state.OnNamesEnd("#x")
+
+	opts := newOptions(t, "p")
+	opts.LLMProvider = &testLLM{response: "should not run"}
+	opts.TBSummarizeMaxMessages = 200
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+
+	body, _ := json.Marshal(map[string]any{
+		"op": "tb", "sub": "summarize", "channel": "#x",
+	})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	// The gate returns before tb_status, so the first frame is the error.
+	got := readJSON(t, conn)
+	assert.Equal(t, "tb_error", got["op"])
+	assert.Equal(t, "op consent required here", got["message"])
+}
+
+func TestTBOpSummarizeAIStrictAllowsOp(t *testing.T) {
+	bridge := strictGatewayBridge()
+	bridge.state.OnSelfJoin("#x")
+	// Bot holds +o → consent granted, the command runs.
+	bridge.state.OnNamesReply("#x", []string{"@turborg", "alice"})
+	bridge.state.OnNamesEnd("#x")
+
+	opts := newOptions(t, "p")
+	opts.LLMProvider = &testLLM{response: "chat summary"}
+	opts.TBSummarizeMaxMessages = 200
+	g, _, td := startGateway(t, opts, bridge, &fakeSender{})
+	defer td()
+
+	conn := dialWS(t, g.Addr(), "p")
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	drainInitialFrames(t, conn)
+
+	body, _ := json.Marshal(map[string]any{
+		"op": "tb", "sub": "summarize", "channel": "#x",
+	})
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText, body))
+
+	// Gate passed → first frame is tb_status, not the deny error.
+	got := readJSON(t, conn)
+	assert.Equal(t, "tb_status", got["op"])
+}

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -877,6 +877,15 @@ func (g *Gateway) handleTBSummarize(ctx context.Context, c *client, channel stri
 		g.sendTo(ctx, c, map[string]any{"op": "tb_error", "message": "/tb summarize is not available on your plan."})
 		return
 	}
+
+	// On a strict network, AI history commands require the bot to hold
+	// channel-operator status in the target channel — the same gate the
+	// bouncer applies, sourced from the shared ClientLimits.
+	if limits := g.bridge.ClientLimits(); limits.AIStrict && !g.bridge.State().IsOperator(channel, g.bridge.CurrentNick()) {
+		g.sendTo(ctx, c, map[string]any{"op": "tb_error", "message": limits.AIStrictDenyMessage()})
+		return
+	}
+
 	if n <= 0 {
 		n = 200
 	}


### PR DESCRIPTION
## What

Adds an operator policy for networks whose bot policy requires channel-operator consent before a bot has an LLM process channel messages.

- **`ClientLimits.AIStrict`** — when set, the channel-history-consuming `/tb` AI command family (e.g. `/tb summarize`) runs only if the bot holds channel-operator status (`+o` or higher) in the target channel. Other `/tb` subcommands (e.g. `usage`) are unaffected. Off by default, so behaviour on all other networks is unchanged.
- **`ClientLimits.AIStrictMessage`** — optional override for the refusal notice, with a neutral built-in default (`DefaultAIStrictMessage`). Lets the operator supply a network's specific policy wording/URL without baking any one network's text into the framework.
- **`ChannelState.IsOperator(channel, nick)`** — reports `+o`-or-higher from the tracked `RPL_NAMREPLY`/`MODE` member prefixes (case-insensitive, nil-safe). Both the bouncer and the web gateway consult it before running an AI history command.

## Wiring

- **Dedicated**: `TURBORG_IRC_AI_STRICT` + `TURBORG_IRC_AI_STRICT_MESSAGE` on `irc.Settings`, threaded into `ClientLimits` in `runtime.Build`.
- **Pooled**: `ai_strict` / `ai_strict_message` on the IRC connector spec, mapped in `settingsFromConnectorSpec` and applied to the tenant's `ClientLimits` in `commonParams`.

The consent model: an op granting the bot `+o` is the signal that AI history features are welcome in that channel.

## Tests

- `ChannelState.IsOperator` matrix (op/admin/owner vs voice/halfop/plain, case-folding, unknown/empty/nil).
- `ClientLimits.AIStrictDenyMessage` default vs override.
- Bouncer `/tb summarize` deny (non-op) and allow (opped) integration tests.
- Web gateway `/tb summarize` deny/allow over a real WS.
- Connector-spec mapping of `ai_strict` / `ai_strict_message`.

`make lint` clean, full `-race` suite green, coverage gate satisfied (94.0%).