### PR TITLE
test: add coverage headroom above the 94% gate

### DIFF
--- a/internal/activity/notifier_test.go
+++ b/internal/activity/notifier_test.go
@@ -155,6 +155,22 @@ func TestNotifier_SwallowsBadRequestURL(t *testing.T) {
 	assert.Equal(t, 0, doer.calls)
 }
 
+func TestNotifier_HookMarksWithBackgroundContext(t *testing.T) {
+	doer := &stubDoer{status: http.StatusNoContent}
+	n := activity.New("http://example.invalid/", "", nil)
+	n.SetHTTPClient(doer)
+	// Hook is the closure-free entry point the runtime wires into the
+	// connector/gateway attach callbacks; it must post the reason just
+	// like Mark with a Background context.
+	n.Hook(activity.ReasonBouncerAttach)
+	n.Wait()
+
+	doer.mu.Lock()
+	defer doer.mu.Unlock()
+	require.Equal(t, 1, doer.calls)
+	assert.Contains(t, string(doer.lastBody), activity.ReasonBouncerAttach)
+}
+
 func TestNotifier_SetHTTPClientOnNilReceiverIsSafe(t *testing.T) {
 	var n *activity.Notifier
 	// Must not panic.

--- a/internal/commands/builder_test.go
+++ b/internal/commands/builder_test.go
@@ -115,6 +115,19 @@ func TestBuildLLMReportsProviderError(t *testing.T) {
 	assert.Contains(t, out.Text, "rate limited")
 }
 
+func TestBuildLLMReportsBudgetExhausted(t *testing.T) {
+	prov := &recordingProvider{err: llm.ErrBudgetExhausted}
+	built := commands.Build([]commands.Definition{
+		{Name: "ask", Type: commands.TypeLLM, Template: "{args}", Access: commands.AccessOwner},
+	}, prov, nil, nil)
+	require.Len(t, built, 1)
+
+	out := dispatch(t, built[0], agent.NewInbound("irc", "#room", "bob", "!ask hi"), []string{"hi"})
+	require.NotNil(t, out)
+	assert.Contains(t, out.Text, "budget")
+	assert.NotContains(t, out.Text, "sorry", "budget exhaustion gets its own message, not the generic error reply")
+}
+
 func TestBuildSkipsLLMCommandWithoutProvider(t *testing.T) {
 	built := commands.Build([]commands.Definition{
 		{Name: "ask", Type: commands.TypeLLM, Template: "{args}", Access: commands.AccessOwner},

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -188,6 +188,20 @@ func TestNormalizeAcceptsMaxConnectorsPerAgentUnrestricted(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNormalizeRejectsNegativeLLMInputTokensUsed(t *testing.T) {
+	t.Setenv("TURBORG_LLM_INPUT_TOKENS_USED", "-1")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM_INPUT_TOKENS_USED")
+}
+
+func TestNormalizeRejectsNegativeLLMOutputTokensUsed(t *testing.T) {
+	t.Setenv("TURBORG_LLM_OUTPUT_TOKENS_USED", "-1")
+	_, err := config.Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM_OUTPUT_TOKENS_USED")
+}
+
 func TestNormalizeRejectsNegativeMaxConnectorsPerAgent(t *testing.T) {
 	t.Setenv("TURBORG_MAX_CONNECTORS_PER_AGENT", "-1")
 	_, err := config.Load()

--- a/internal/connector/irc/bouncer_test.go
+++ b/internal/connector/irc/bouncer_test.go
@@ -1098,6 +1098,8 @@ func TestChathistoryRejectsInvalidInputs(t *testing.T) {
 		{"bad limit", "CHATHISTORY LATEST #test * abc", "INVALID_PARAMS"},
 		{"unknown subcommand", "CHATHISTORY AROUND #test * 50", "UNKNOWN_COMMAND"},
 		{"bad selector", "CHATHISTORY BEFORE #test msgid=xyz 50", "INVALID_PARAMS"},
+		{"latest non-star bad selector", "CHATHISTORY LATEST #test garbage 50", "INVALID_PARAMS"},
+		{"zero limit", "CHATHISTORY LATEST #test * 0", "INVALID_PARAMS"},
 	}
 
 	for _, tc := range cases {
@@ -1122,6 +1124,95 @@ func TestChathistoryRejectsInvalidInputs(t *testing.T) {
 			assert.True(t, sawFail, "expected FAIL CHATHISTORY %s for %q", tc.code, tc.cmd)
 		})
 	}
+}
+
+// TestChathistoryLatestWithConcreteSelectorCapsLimit covers the two
+// LATEST branches that the happy-path `*` test skips: a concrete
+// timestamp selector (treated as an older-than bound) and a limit
+// above chathistoryMaxLimit, which is clamped rather than rejected.
+func TestChathistoryLatestWithConcreteSelectorCapsLimit(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+
+	base := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
+	attachStoreWithSeed(t, b, []messages.Message{
+		{Channel: "#test", Nick: "a", Text: "old", TS: base},
+		{Channel: "#test", Nick: "b", Text: "newer", TS: base.Add(10 * time.Second)},
+	})
+
+	conn, r := bouncerClient(t, addr)
+	negotiateAndPass(t, conn, r, "batch draft/chathistory", "hunter2")
+	drainUntilEndOfWelcome(t, conn, r)
+
+	// Concrete selector → older-than bound (like BEFORE); limit 9999 is
+	// silently clamped to chathistoryMaxLimit instead of failing.
+	writeLine(t, conn, "CHATHISTORY LATEST #test timestamp=2026-05-21T12:00:10Z 9999")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var historyLines []string
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if strings.HasPrefix(line, "BATCH -") {
+			break
+		}
+		if strings.Contains(line, "PRIVMSG #test") {
+			historyLines = append(historyLines, line)
+		}
+	}
+	require.Len(t, historyLines, 1)
+	assert.Contains(t, historyLines[0], ":old")
+}
+
+// TestChathistoryWithoutStoreReturnsEmptyBatch covers the nil-store
+// branch: when no message store is configured the bouncer answers with
+// an empty BATCH rather than a FAIL, since "no history available" is a
+// valid response.
+func TestChathistoryWithoutStoreReturnsEmptyBatch(t *testing.T) {
+	b, addr := freshBouncer(t, "hunter2")
+	state := irc.NewChannelState()
+	state.OnSelfJoin("#test")
+	b.AttachState(state, "turborg", "ident", "host")
+	// Deliberately no AttachMessageStore → currentMessageStore() is nil.
+
+	conn, r := bouncerClient(t, addr)
+	negotiateAndPass(t, conn, r, "batch draft/chathistory", "hunter2")
+	drainUntilEndOfWelcome(t, conn, r)
+
+	writeLine(t, conn, "CHATHISTORY LATEST #test * 50")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var sawBatchStart, sawBatchEnd, sawFail bool
+	var historyLines int
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			break
+		}
+		line = strings.TrimRight(line, "\r\n")
+		switch {
+		case strings.HasPrefix(line, "BATCH +"):
+			sawBatchStart = true
+		case strings.HasPrefix(line, "BATCH -"):
+			sawBatchEnd = true
+		case strings.HasPrefix(line, "FAIL CHATHISTORY"):
+			sawFail = true
+		case strings.Contains(line, "PRIVMSG #test"):
+			historyLines++
+		}
+		if sawBatchEnd {
+			break
+		}
+	}
+	assert.True(t, sawBatchStart, "expected an opening BATCH")
+	assert.True(t, sawBatchEnd, "expected a closing BATCH")
+	assert.False(t, sawFail, "missing store must not FAIL")
+	assert.Zero(t, historyLines, "no store → no history lines")
 }
 
 // drainUntilEndOfWelcome reads until the welcome flush has settled so

--- a/internal/llm/openaicompat/provider_test.go
+++ b/internal/llm/openaicompat/provider_test.go
@@ -79,6 +79,19 @@ func TestAskSurfacesAPIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "rate limited")
 }
 
+func TestAskErrorsOnUndecodableBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("this is not json"))
+	}))
+	defer srv.Close()
+
+	p, err := openaicompat.New(openaicompat.Settings{APIKey: "k", BaseURL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+	_, _, err = p.Ask(context.Background(), "hi")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
 func TestNewDefaultsBaseURLModelAndMaxTokens(t *testing.T) {
 	p, err := openaicompat.New(openaicompat.Settings{APIKey: "k"})
 	require.NoError(t, err)

--- a/internal/messages/messages_test.go
+++ b/internal/messages/messages_test.go
@@ -34,6 +34,16 @@ func TestMemoryStoreEmptyChannelNoop(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestMemoryStoreRecentUnknownChannelEmpty(t *testing.T) {
+	s := messages.NewMemoryStore(0)
+	require.NoError(t, s.Submit(context.Background(), mkMsg("#a", "alice", "hi", time.Now())))
+	// A channel name that was never written to has no bucket; Recent
+	// returns nil rather than panicking on the missing map entry.
+	got, err := s.Recent(context.Background(), "#never", time.Time{}, 10)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
 func TestMemoryStoreSubmitAndRecent(t *testing.T) {
 	s := messages.NewMemoryStore(0)
 	ctx := context.Background()


### PR DESCRIPTION
## Why

Release PR #67 (chore(main): release 0.10.0) is blocked solely by the **Coverage gate** check: CI measured **93.9% (4536/4829)**, just under the 94% threshold, even though the same tree measures a stable **94.0%** locally. The total gate sits right on the threshold, so the documented goroutine-scheduling variance in the IRC reconnect supervisor's `select` branches is enough to tip CI below the line on an unlucky run. The release PR carries no source changes, so the fix is to raise the deterministic coverage floor.

## What

Cover genuinely-untested branches — several in the new CHATHISTORY feature shipping in 0.10.0 — to bring the total to **~94.3% (4555/4829)**, ~17 statements of headroom:

- **config**: reject negative `LLM_INPUT_TOKENS_USED` / `LLM_OUTPUT_TOKENS_USED` (the `PER_DAY` siblings were already tested; the rolling-window `USED` seeds were not)
- **commands**: the LLM command budget-exhausted reply path
- **llm/openaicompat**: an undecodable response body surfaces a decode error
- **messages**: `Recent` on a never-written channel returns empty rather than panicking
- **activity**: `Notifier.Hook` posts with a background context
- **connector/irc CHATHISTORY**: `LATEST` with a concrete selector + limit clamp, the nil-store empty-batch response, and two more reject cases

Test-only; no production code changes. Once merged, release-please will refresh PR #67 and its coverage gate will pass.