### PR TITLE
feat(activity): count only genuine owner presence for idle auto-pause

### DIFF
--- a/internal/activity/notifier.go
+++ b/internal/activity/notifier.go
@@ -1,12 +1,17 @@
 // Package activity exposes a tiny fire-and-forget webhook client the agent
 // uses to signal meaningful runtime events to a remote observer.
 //
-// Three call sites in the wider tree fire Mark with a stable reason
-// string: the IRC outbound PRIVMSG/NOTICE path ("bot_spoke"), the
-// bouncer's post-auth attach pool ("bouncer_attach"), and the WS
-// gateway's handshake-complete branch ("ws_attach"). Each Mark is a
-// single POST with a small JSON body; failures are logged at debug and
-// never block the caller — the notifier is observability, not control.
+// Activity means genuine owner presence, never "the bot is doing work"
+// or "messages are flowing through the channel". Call sites fire Mark
+// only for owner-driven signals: a bouncer client attaching
+// ("bouncer_attach"), an owner message through the web chat
+// ("ws_message"), an owner /tb command ("tb_command"), and a periodic
+// presence heartbeat while a bouncer client is attached or a web session
+// is engaged ("presence"). Inbound channel traffic, the bot's own
+// replies, and bare idle dashboard tabs deliberately do NOT fire Mark.
+// Each Mark is a single POST with a small JSON body; failures are logged
+// at debug and never block the caller — the notifier is observability,
+// not control.
 //
 // When TURBORG_ACTIVITY_URL is unset the package returns a Notifier
 // whose Mark is a no-op, so self-host operators who don't run an
@@ -24,12 +29,13 @@ import (
 	"time"
 )
 
-// Reason identifiers for the three documented call sites. Stable values
+// Reason identifiers for the owner-presence call sites. Stable values
 // the observer can dispatch on without parsing free-form text.
 const (
-	ReasonBotSpoke      = "bot_spoke"
 	ReasonBouncerAttach = "bouncer_attach"
-	ReasonWSAttach      = "ws_attach"
+	ReasonWSMessage     = "ws_message"
+	ReasonTBCommand     = "tb_command"
+	ReasonPresence      = "presence"
 )
 
 // defaultTimeout caps individual HTTP POSTs so a wedged observer cannot
@@ -93,10 +99,10 @@ func (n *Notifier) Mark(_ context.Context, reason string) {
 
 // Hook returns a context-free callback shape suitable for handing to
 // surfaces that emit a stable reason string (the IRC connector's
-// SetActivityHook / SetBouncerAttachHook and the WS gateway's
-// OnClientAttached). Equivalent to calling Mark with a Background
-// context; exists so the runtime wires the notifier without an
-// in-line closure that the cover gate has to chase.
+// SetBouncerAttachHook and the WS gateway's OnActivity). Equivalent to
+// calling Mark with a Background context; exists so the runtime wires
+// the notifier without an in-line closure that the cover gate has to
+// chase.
 func (n *Notifier) Hook(reason string) {
 	n.Mark(context.Background(), reason)
 }

--- a/internal/activity/notifier_test.go
+++ b/internal/activity/notifier_test.go
@@ -25,14 +25,14 @@ func TestNotifier_DisabledWhenURLEmpty(t *testing.T) {
 	n := activity.New("", "", nil)
 	assert.False(t, n.Enabled())
 	// Calling Mark on a disabled notifier is safe and spawns no goroutine.
-	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Mark(context.Background(), activity.ReasonWSMessage)
 	n.Wait()
 }
 
 func TestNotifier_NilReceiverIsSafe(t *testing.T) {
 	var n *activity.Notifier
 	assert.False(t, n.Enabled())
-	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Mark(context.Background(), activity.ReasonWSMessage)
 	n.Wait()
 }
 
@@ -57,7 +57,7 @@ func TestNotifier_PostsReasonAndBearerToken(t *testing.T) {
 	n := activity.New(server.URL, "secret-token", nil)
 	require.True(t, n.Enabled())
 	n.Mark(context.Background(), activity.ReasonBouncerAttach)
-	n.Mark(context.Background(), activity.ReasonWSAttach)
+	n.Mark(context.Background(), activity.ReasonTBCommand)
 	n.Wait()
 
 	mu.Lock()
@@ -66,7 +66,7 @@ func TestNotifier_PostsReasonAndBearerToken(t *testing.T) {
 	assert.Equal(t, "Bearer secret-token", auth)
 	reasons := []string{received[0]["reason"], received[1]["reason"]}
 	assert.Contains(t, reasons, activity.ReasonBouncerAttach)
-	assert.Contains(t, reasons, activity.ReasonWSAttach)
+	assert.Contains(t, reasons, activity.ReasonTBCommand)
 }
 
 func TestNotifier_NoAuthHeaderWhenTokenEmpty(t *testing.T) {
@@ -79,7 +79,7 @@ func TestNotifier_NoAuthHeaderWhenTokenEmpty(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	n := activity.New(server.URL, "", nil)
-	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Mark(context.Background(), activity.ReasonWSMessage)
 	n.Wait()
 
 	assert.Empty(t, auth.Load().(string))
@@ -119,13 +119,13 @@ func TestNotifier_LogsAndSwallowsNon2xx(t *testing.T) {
 	doer := &stubDoer{status: http.StatusInternalServerError}
 	n := activity.New("http://example.invalid/", "", nil)
 	n.SetHTTPClient(doer)
-	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Mark(context.Background(), activity.ReasonWSMessage)
 	n.Wait()
 
 	doer.mu.Lock()
 	defer doer.mu.Unlock()
 	assert.Equal(t, 1, doer.calls)
-	assert.Contains(t, string(doer.lastBody), activity.ReasonBotSpoke)
+	assert.Contains(t, string(doer.lastBody), activity.ReasonWSMessage)
 }
 
 func TestNotifier_SwallowsTransportError(t *testing.T) {
@@ -133,7 +133,7 @@ func TestNotifier_SwallowsTransportError(t *testing.T) {
 	n := activity.New("http://example.invalid/", "", nil)
 	n.SetHTTPClient(doer)
 	// Must not panic or block.
-	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Mark(context.Background(), activity.ReasonWSMessage)
 	n.Wait()
 }
 
@@ -147,7 +147,7 @@ func TestNotifier_SwallowsBadRequestURL(t *testing.T) {
 	n := activity.New("http://bad\nurl/", "", nil)
 	doer := &stubDoer{}
 	n.SetHTTPClient(doer)
-	n.Mark(context.Background(), activity.ReasonBotSpoke)
+	n.Mark(context.Background(), activity.ReasonWSMessage)
 	n.Wait()
 	// The request never reached the doer because NewRequest failed.
 	doer.mu.Lock()

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -24,6 +24,12 @@ import (
 // https://ircv3.net/specs/extensions/server-time
 const serverTimeLayout = "2006-01-02T15:04:05.000Z"
 
+// activityHeartbeatInterval is how often the bouncer re-asserts owner
+// presence while a client is attached. Well under any free-tier idle
+// window (4h), so an attached client never lets the bot idle-pause. A
+// var, not a const, so tests can shorten it.
+var activityHeartbeatInterval = 10 * time.Minute
+
 const (
 	// defaultClientPingInterval is how often the bouncer PINGs each attached
 	// client. Two jobs: (1) keep an idle connection's bytes flowing so a NAT
@@ -406,6 +412,15 @@ func (b *Bouncer) currentMessageStore() messages.Store {
 // handleTB dispatches /tb subcommands from attached IRC clients.
 // Format: TB SUMMARIZE [#channel] [N]
 func (b *Bouncer) handleTB(client *BouncerClient, msg Message) {
+	// A /tb command is an explicit owner action — mark presence so it
+	// resets the idle timer even if no client heartbeat is due yet.
+	b.mu.Lock()
+	hook := b.onAttach
+	b.mu.Unlock()
+	if hook != nil {
+		hook("tb_command")
+	}
+
 	if len(msg.Params) == 0 {
 		b.notifyService(client, "Usage: /tb summarize [#channel] [N]")
 		return
@@ -684,7 +699,38 @@ func (b *Bouncer) start(ctx context.Context, listen bool) error {
 	} else {
 		b.log.Info("bouncer ready (listenerless; served via ServeConn)")
 	}
+
+	// Presence heartbeat: while at least one client stays attached, the
+	// owner is present, so keep re-asserting activity for the whole
+	// connection (a single attach pulse would let the idle timer stop a
+	// bot whose owner has HexChat open all day). Exits on Stop via bctx.
+	b.wg.Add(1)
+	go b.activityHeartbeat(bctx)
 	return nil
+}
+
+// activityHeartbeat fires the attach hook with the "presence" reason on a
+// fixed interval for as long as any client is attached. It is how a live
+// bouncer connection stays "active for its entire duration" against the
+// single-timestamp idle-pause model, without coupling to client traffic.
+func (b *Bouncer) activityHeartbeat(ctx context.Context) {
+	defer b.wg.Done()
+	t := time.NewTicker(activityHeartbeatInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			b.mu.Lock()
+			attached := len(b.clients)
+			hook := b.onAttach
+			b.mu.Unlock()
+			if attached > 0 && hook != nil {
+				hook("presence")
+			}
+		}
+	}
 }
 
 // ServeConn handles one already-accepted client connection instead of one

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -127,13 +127,6 @@ type Connector struct {
 	// the configured owner nick. nil = disabled.
 	ownerNudge *OwnerNudge
 
-	// onBotSpoke, when non-nil, fires for each bot-originated outbound
-	// PRIVMSG. Wired by runtime so an external observer can distinguish
-	// bot-driven activity from incoming channel chatter. Bouncer-tunneled
-	// PRIVMSGs go through a different code path (AttachUpstream callback)
-	// and are NOT considered bot_spoke — those are bouncer-attach activity.
-	onBotSpoke func(reason string)
-
 	// currentNick is the live nick the server confirmed for us. It
 	// starts as settings.Nick (the requested value), gets updated by
 	// the 001 RPL_WELCOME (where the server tells us the nick it
@@ -323,14 +316,6 @@ func (c *Connector) OutboundThrottle() *Throttle { return c.outboundThrottle }
 // after each successful PRIVMSG write and the nudge emits a DM when
 // the count crosses a multiple of EveryN.
 func (c *Connector) SetOwnerNudge(n *OwnerNudge) { c.ownerNudge = n }
-
-// SetActivityHook installs a callback fired for each bot-originated
-// outbound PRIVMSG. Pass nil to disable. Wired by runtime so an
-// observer learns the bot is doing work, even on dashboard-only or
-// silent-channel deployments where log scraping for PRIVMSG would miss
-// the signal. Bouncer-tunneled and incoming PRIVMSG do NOT fire this
-// hook — those reflect user activity, not bot activity.
-func (c *Connector) SetActivityHook(hook func(reason string)) { c.onBotSpoke = hook }
 
 // SetBouncerAttachHook installs a callback the bouncer fires on each
 // successful client auth. Pass nil to disable. Must be called before
@@ -528,9 +513,6 @@ func (c *Connector) Send(env *agent.OutboundEnvelope) error {
 	// so the nudge DM doesn't recurse back through this method and
 	// double-count.
 	c.ownerNudge.Note(cli.WriteLine)
-	if c.onBotSpoke != nil {
-		c.onBotSpoke("bot_spoke")
-	}
 	return nil
 }
 

--- a/internal/connector/irc/connector_test.go
+++ b/internal/connector/irc/connector_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -456,55 +455,4 @@ func TestConnectorOutboundThrottleAccessors(t *testing.T) {
 	c.SetOutboundThrottle(tr)
 	assert.Same(t, tr, c.OutboundThrottle(),
 		"OutboundThrottle should return the exact pointer we set")
-}
-
-func TestConnectorActivityHookFiresOnBotOriginatedPrivmsg(t *testing.T) {
-	fs := fakeirc.New(t)
-	defer fs.Close()
-
-	conn := irc.New(&irc.Settings{
-		Hostname: "127.0.0.1",
-		Port:     fs.Port(),
-		Nick:     "turborg",
-		Channels: []string{"#test"},
-	}, nil, nil)
-
-	var (
-		mu      sync.Mutex
-		reasons []string
-	)
-	conn.SetActivityHook(func(reason string) {
-		mu.Lock()
-		reasons = append(reasons, reason)
-		mu.Unlock()
-	})
-
-	a := agent.New(nil)
-	a.AddConnector(conn)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	done := make(chan error, 1)
-	go func() { done <- a.Run(ctx) }()
-
-	require.True(t,
-		fs.WaitFor(containsPrefix("JOIN #test"), 2*time.Second),
-		"connector did not JOIN; received: %v", fs.Received(),
-	)
-
-	require.NoError(t, conn.Send(&agent.OutboundEnvelope{
-		Connector: "irc", Channel: "#test", Text: "hi",
-	}))
-
-	require.Eventually(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		return len(reasons) == 1 && reasons[0] == "bot_spoke"
-	}, time.Second, 10*time.Millisecond, "Send must fire the activity hook with reason=bot_spoke")
-
-	cancel()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("agent did not shut down")
-	}
 }

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1666,4 +1667,42 @@ func TestApplyPrefixModesToStateGuards(t *testing.T) {
 	require.NotNil(t, info)
 	_, present := info.Members["ghost"]
 	assert.False(t, present, "MODE for a non-member mustn't materialise the nick")
+}
+
+// TestBouncerActivityHeartbeat proves the presence heartbeat: while at
+// least one client is attached the bouncer re-asserts "presence" every
+// interval (so an attached client stays "active for its duration"); with
+// no client attached it stays silent. Exits cleanly on context cancel.
+func TestBouncerActivityHeartbeat(t *testing.T) {
+	old := activityHeartbeatInterval
+	activityHeartbeatInterval = 5 * time.Millisecond
+	t.Cleanup(func() { activityHeartbeatInterval = old })
+
+	var presence atomic.Int32
+	b := &Bouncer{
+		clients: map[*BouncerClient]struct{}{},
+		onAttach: func(reason string) {
+			if reason == "presence" {
+				presence.Add(1)
+			}
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b.wg.Add(1)
+	go b.activityHeartbeat(ctx)
+
+	// No clients attached → no presence, even across several ticks.
+	time.Sleep(30 * time.Millisecond)
+	assert.Zero(t, presence.Load(), "no attached client must not heartbeat")
+
+	// Attach a client → presence fires for as long as it stays attached.
+	b.mu.Lock()
+	b.clients[&BouncerClient{}] = struct{}{}
+	b.mu.Unlock()
+	require.Eventually(t, func() bool { return presence.Load() >= 1 },
+		time.Second, 5*time.Millisecond, "attached client must heartbeat presence")
+
+	cancel()
+	b.wg.Wait()
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -296,7 +296,7 @@ func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, lo
 		TBSummarizeMaxMessages: s.TBSummarizeMaxMessages,
 	}
 	if notifier.Enabled() {
-		opts.OnClientAttached = notifier.Hook
+		opts.OnActivity = notifier.Hook
 	}
 	if s.IdleShutdownEnabled() {
 		opts.IdleShutdownSeconds = s.GatewayIdleShutdownSeconds

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -69,11 +69,14 @@ type CommonParams struct {
 	LLMInputUsed  int
 	LLMOutputUsed int
 
-	// ActivityHook fires on connector activity (bouncer attach, message
-	// traffic). Nil → activity hooks are not attached. Dedicated passes its
-	// Notifier.Hook (a per-event POST to the local sidecar); pooled passes a
-	// hook that marks the tenant active in the pool's coalescing aggregator
-	// (a per-event POST per tenant would hammer the control plane).
+	// ActivityHook fires on owner-presence signals the bouncer raises:
+	// a client attaching, and a periodic presence heartbeat while a client
+	// stays attached. Nil → the attach hook is not wired. Dedicated passes
+	// its Notifier.Hook (a per-event POST to the local sidecar); pooled
+	// passes a hook that marks the tenant active in the pool's coalescing
+	// aggregator (a per-event POST per tenant would hammer the control
+	// plane). The bot's own outbound traffic is NOT activity and has no
+	// hook — only genuine owner presence resets the idle timer.
 	ActivityHook func(reason string)
 
 	// Store backs bouncer welcome replay + web-shell scrollback + CHATHISTORY.
@@ -118,7 +121,6 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	ircConn.SetClientLimits(p.Limits)
 
 	if p.ActivityHook != nil {
-		ircConn.SetActivityHook(p.ActivityHook)
 		ircConn.SetBouncerAttachHook(p.ActivityHook)
 	}
 

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -394,7 +394,12 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 				if caps != nil {
 					tbCap = caps.TBSummarizeMaxMessages
 				}
-				gw, err := buildTenantGateway(conn, gatewayToken, t.log, store, budgetedProvider, tbCap)
+				gwActivity := func(string) {
+					if t.activity != nil {
+						t.activity.Mark(t.ID)
+					}
+				}
+				gw, err := buildTenantGateway(conn, gatewayToken, t.log, store, budgetedProvider, tbCap, gwActivity)
 				if err != nil {
 					t.log.Error("skipping web gateway", "err", err)
 					continue

--- a/internal/server/tenant_gateway.go
+++ b/internal/server/tenant_gateway.go
@@ -31,7 +31,7 @@ const (
 // router serves the shared Handler() per request. No MessageStore: pooled
 // scrollback lives in accounts-api and is a follow-up; live streaming works
 // without it.
-func buildTenantGateway(bridge *irc.Connector, token string, log *slog.Logger, store messages.Store, llmProvider llm.Provider, tbSummarizeCap int) (*web.Gateway, error) {
+func buildTenantGateway(bridge *irc.Connector, token string, log *slog.Logger, store messages.Store, llmProvider llm.Provider, tbSummarizeCap int, onActivity func(reason string)) (*web.Gateway, error) {
 	verifier, err := web.NewStaticPasswordVerifier(token)
 	if err != nil {
 		return nil, fmt.Errorf("gateway verifier: %w", err)
@@ -47,6 +47,10 @@ func buildTenantGateway(bridge *irc.Connector, token string, log *slog.Logger, s
 		MessageStore:           store,
 		LLMProvider:            llmProvider,
 		TBSummarizeMaxMessages: tbSummarizeCap,
+		// Owner-presence from the pooled web shell marks the tenant active
+		// in the pool's coalescing aggregator (same sink the bouncer attach
+		// hook uses) — engaged web session / owner /tb keep it alive.
+		OnActivity: onActivity,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/server/web_router_test.go
+++ b/internal/server/web_router_test.go
@@ -31,7 +31,7 @@ func liveGatewayTenant(t *testing.T, id, token string) *Tenant {
 		Username: "bot",
 		RealName: "pooled tenant",
 	}, testLogger(), bus)
-	gw, err := buildTenantGateway(conn, token, testLogger(), nil, nil, 0)
+	gw, err := buildTenantGateway(conn, token, testLogger(), nil, nil, 0, nil)
 	require.NoError(t, err)
 	gw.Subscribe(bus)
 	t.Cleanup(gw.Stop)
@@ -144,7 +144,7 @@ func TestWebGatewayRouterUpgradeAndAuth(t *testing.T) {
 // the guard is the StaticPasswordVerifier's, so prove it here.
 func TestBuildTenantGatewayEmptyToken(t *testing.T) {
 	conn := irc.New(&irc.Settings{Hostname: "127.0.0.1", Port: 6667, Nick: "bot"}, testLogger(), nil)
-	_, err := buildTenantGateway(conn, "", testLogger(), nil, nil, 0)
+	_, err := buildTenantGateway(conn, "", testLogger(), nil, nil, 0, nil)
 	require.Error(t, err)
 }
 

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -28,6 +28,12 @@ const (
 	channelLogCap = 200
 )
 
+// activityHeartbeatInterval is how often an engaged web session
+// re-asserts owner presence. Well under any free-tier idle window (4h),
+// so an engaged, open dashboard never lets the bot idle-pause. A var,
+// not a const, so tests can shorten it.
+var activityHeartbeatInterval = 10 * time.Minute
+
 // IRCBridge is the narrow slice of the IRC connector the gateway
 // depends on. Keeps the package boundary clean — the gateway never
 // reaches into IRC-specific internals beyond these methods.
@@ -75,11 +81,13 @@ type Options struct {
 	IdleShutdownSeconds int
 	OnIdleShutdown      func()
 
-	// OnClientAttached fires once per successful WS handshake, with a
-	// stable reason identifier. nil = disabled. Wired by runtime so an
-	// external observer can learn that a dashboard client is actively
-	// using this agent — distinct from "bot is alive" log signal.
-	OnClientAttached func(reason string)
+	// OnActivity fires on owner-presence signals from the web session,
+	// with a stable reason identifier ("ws_message", "tb_command",
+	// "presence"). nil = disabled. A bare dashboard handshake is NOT a
+	// signal — only an owner who actually sends a chat message or /tb
+	// command counts as present, after which a periodic "presence"
+	// heartbeat keeps the session active for as long as it stays open.
+	OnActivity func(reason string)
 
 	// MessageStore is the read/write seam for channel history. The
 	// gateway calls Submit on every observed inbound + outbound
@@ -142,6 +150,11 @@ type Gateway struct {
 type client struct {
 	conn *websocket.Conn
 	addr string
+	// engaged flips true the first time this session sends an owner
+	// signal (a chat message or /tb). Only then does the presence
+	// heartbeat keep the session active — a bare idle tab never does.
+	// Guarded by Gateway.mu.
+	engaged bool
 }
 
 func New(bridge IRCBridge, sender Sender, opts Options) (*Gateway, error) {
@@ -348,9 +361,11 @@ func (g *Gateway) handleWS(w http.ResponseWriter, r *http.Request) {
 	g.metrics.connections++
 	g.metMu.Unlock()
 	g.log.Info("web auth success", "ip", ip)
-	if g.opts.OnClientAttached != nil {
-		g.opts.OnClientAttached("ws_attach")
-	}
+	// A bare handshake is NOT activity — opening the dashboard (or a tab
+	// left sitting for hours) must not keep a free-tier bot alive. The
+	// session only starts counting once the owner actually sends a
+	// message or /tb (see readLoop), after which this heartbeat keeps it
+	// active for the session's duration.
 
 	connectedAt := time.Now()
 	defer func() {
@@ -370,7 +385,56 @@ func (g *Gateway) handleWS(w http.ResponseWriter, r *http.Request) {
 	g.sendState(ctx, c)
 	g.sendInitialConnectorState(ctx, c)
 	g.replayBuffers(ctx, c)
+
+	// Presence heartbeat for the session, gated on engagement: it only
+	// fires once the owner has sent a message or /tb (see markEngaged),
+	// and stops when readLoop returns (disconnect). Scoped to this
+	// connection so it can't outlive it.
+	hbCtx, hbCancel := context.WithCancel(ctx)
+	hbDone := make(chan struct{})
+	go func() {
+		defer close(hbDone)
+		g.sessionHeartbeat(hbCtx, c)
+	}()
+
 	g.readLoop(ctx, c)
+	hbCancel()
+	<-hbDone
+}
+
+// sessionHeartbeat re-asserts owner presence on a fixed interval for as
+// long as the session stays engaged and connected — how a web session
+// counts as "active for its duration" against the single-timestamp idle
+// model. A session that never engages (bare tab) never fires.
+func (g *Gateway) sessionHeartbeat(ctx context.Context, c *client) {
+	t := time.NewTicker(activityHeartbeatInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			g.mu.Lock()
+			engaged := c.engaged
+			g.mu.Unlock()
+			if engaged && g.opts.OnActivity != nil {
+				g.opts.OnActivity("presence")
+			}
+		}
+	}
+}
+
+// markEngaged records that the owner took an explicit action in this
+// session (chat message or /tb) and fires the matching activity reason.
+// The first call flips the session engaged so sessionHeartbeat starts
+// keeping it alive; subsequent calls just re-pulse the timer.
+func (g *Gateway) markEngaged(c *client, reason string) {
+	g.mu.Lock()
+	c.engaged = true
+	g.mu.Unlock()
+	if g.opts.OnActivity != nil {
+		g.opts.OnActivity(reason)
+	}
 }
 
 // sendInitialConnectorState publishes a one-shot connector.state_changed
@@ -594,6 +658,10 @@ func (g *Gateway) dispatchInbound(ctx context.Context, c *client, p map[string]a
 		if ch == "" || text == "" {
 			return
 		}
+		// The owner typed and sent a message — genuine presence. Mark it
+		// before the upstream/throttle gates so engagement counts even
+		// when the send is rejected (the owner is still here).
+		g.markEngaged(c, "ws_message")
 		// Gate on upstream state — if the connector isn't registered
 		// the WS send_message would either silently disappear (state
 		// != registered, supervisor reconnecting) or race against
@@ -740,6 +808,12 @@ func (g *Gateway) dispatchInbound(ctx context.Context, c *client, p map[string]a
 	case "history":
 		g.handleHistoryOp(ctx, c, p)
 	case "tb":
+		// An owner /tb is an explicit action — resets the idle timer
+		// once. Unlike a chat message it does not flip the session
+		// engaged, so it alone won't start the presence heartbeat.
+		if g.opts.OnActivity != nil {
+			g.opts.OnActivity("tb_command")
+		}
 		g.handleTBOp(ctx, c, p)
 	}
 }

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -276,13 +276,13 @@ func TestWSAuthAcceptsBearerHeader(t *testing.T) {
 	_ = conn.Close(websocket.StatusNormalClosure, "")
 }
 
-func TestWSAttachHookFiresOnSuccessfulHandshake(t *testing.T) {
+func TestWSActivityFiresOnOwnerMessageNotBareAttach(t *testing.T) {
 	var (
 		mu      sync.Mutex
 		reasons []string
 	)
 	opts := newOptions(t, "secret")
-	opts.OnClientAttached = func(reason string) {
+	opts.OnActivity = func(reason string) {
 		mu.Lock()
 		reasons = append(reasons, reason)
 		mu.Unlock()
@@ -293,17 +293,47 @@ func TestWSAttachHookFiresOnSuccessfulHandshake(t *testing.T) {
 	conn := dialWS(t, g.Addr(), "secret")
 	defer conn.Close(websocket.StatusNormalClosure, "")
 
+	// A bare handshake (open dashboard, no interaction) is NOT activity.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	n := len(reasons)
+	mu.Unlock()
+	require.Zero(t, n, "bare WS attach must not fire activity")
+
+	// An owner message is — fired before the upstream/throttle gates, so
+	// it counts even if the send itself is rejected.
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","channel":"#test","text":"hi"}`)))
 	require.Eventually(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(reasons) == 1 && reasons[0] == "ws_attach"
-	}, time.Second, 10*time.Millisecond)
+		for _, r := range reasons {
+			if r == "ws_message" {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond, "owner message must fire ws_message")
+
+	// An owner /tb is also an explicit action → tb_command.
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"tb"}`)))
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, r := range reasons {
+			if r == "tb_command" {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond, "owner /tb must fire tb_command")
 }
 
-func TestWSAttachHookSilentOnAuthFailure(t *testing.T) {
+func TestWSActivitySilentOnAuthFailure(t *testing.T) {
 	var fired atomic.Bool
 	opts := newOptions(t, "right-secret")
-	opts.OnClientAttached = func(_ string) { fired.Store(true) }
+	opts.OnActivity = func(_ string) { fired.Store(true) }
 	g, _, td := startGateway(t, opts, newFakeBridge("turborg"), &fakeSender{})
 	defer td()
 

--- a/internal/web/internal_test.go
+++ b/internal/web/internal_test.go
@@ -1,10 +1,14 @@
 package web
 
 import (
+	"context"
 	"net/http"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // White-box tests for unexported helpers. The integration tests in
@@ -16,6 +20,43 @@ func TestExtractTokenHeaderFallback(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodGet, "http://x/ws", nil)
 	r.Header.Set("Authorization", "Bearer hunter2")
 	assert.Equal(t, "hunter2", extractToken(r))
+}
+
+// TestSessionHeartbeatEngagedVsBare drives sessionHeartbeat directly: an
+// engaged session re-asserts "presence" on every tick; a bare session
+// (no message sent) never fires; both exit promptly on ctx cancel.
+func TestSessionHeartbeatEngagedVsBare(t *testing.T) {
+	old := activityHeartbeatInterval
+	activityHeartbeatInterval = 5 * time.Millisecond
+	t.Cleanup(func() { activityHeartbeatInterval = old })
+
+	var presence atomic.Int32
+	g := &Gateway{opts: Options{OnActivity: func(r string) {
+		if r == "presence" {
+			presence.Add(1)
+		}
+	}}}
+
+	// Engaged → heartbeats fire.
+	engaged := &client{engaged: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); g.sessionHeartbeat(ctx, engaged) }()
+	require.Eventually(t, func() bool { return presence.Load() >= 1 },
+		time.Second, 5*time.Millisecond, "engaged session must heartbeat")
+	cancel()
+	<-done
+
+	// Bare (never engaged) → no heartbeat, even across several ticks.
+	presence.Store(0)
+	bare := &client{engaged: false}
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	done2 := make(chan struct{})
+	go func() { defer close(done2); g.sessionHeartbeat(ctx2, bare) }()
+	time.Sleep(40 * time.Millisecond)
+	cancel2()
+	<-done2
+	assert.Zero(t, presence.Load(), "bare session must never heartbeat")
 }
 
 func TestExtractTokenCaseInsensitiveBearerScheme(t *testing.T) {


### PR DESCRIPTION
## Why

Free-tier turborgs auto-pause after 4h idle. "Activity" was being reset by the wrong things — the bot's own replies and (via the sidecar log-scrape) any channel traffic — so a busy channel or a chatty bot kept a container alive indefinitely with no human present. Activity should mean the **owner** is present.

## What counts now

Resets the idle timer:
- **Bouncer client attached** → presence heartbeat for the entire connection.
- **Engaged web session** (owner sent a chat message) → presence heartbeat for the session's duration.
- **Owner `/tb` command** or **owner web-chat message** → one-shot reset.

No longer counts:
- bot's own outbound replies (removed `bot_spoke`)
- bare idle dashboard tab (removed on-handshake `ws_attach`)
- inbound channel traffic, others' skill invocations, PING/PONG keepalives, automated reconnects

## How

- A 10-minute presence heartbeat (`var activityHeartbeatInterval`) keeps an attached bouncer client / engaged web session alive against the single last-active-timestamp model; goroutines are scoped to the connection / bouncer lifecycle (goleak-safe).
- Shared by dedicated and pooled runtimes via the connector attach hook and the gateway's new `OnActivity` hook.

Pairs with the sidecar change that stops treating `PRIVMSG`/`NOTICE` log lines as activity (cap-hit + LLM-usage scraping untouched).

## Tests
lint clean, `-race` suite passes, coverage gate 94.4%. Added direct tests for both heartbeats, engaged-vs-bare web session, `ws_message`/`tb_command`, and the bouncer presence heartbeat.