### PR TITLE
docs: align comments and docs with framework-neutral framing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 #
 # Variable layout:
 #   TURBORG_*                  cross-cutting bot settings (config.Settings)
-#   TURBORG_GATEWAY_*          control-plane gateway (WS protocol + reference UI)
+#   TURBORG_GATEWAY_*          web gateway (WS protocol + reference UI)
 #   TURBORG_<CONNECTOR>_*      per-connector settings (e.g. irc.Settings)
 #
 # Per-connector vars further group by sub-feature, e.g. for IRC:
@@ -33,7 +33,10 @@
 # TURBORG_COMMAND_PREFIX=!                               # leading character for the command trigger
 # TURBORG_COMMAND_MAX_PER_WINDOW=5                       # per-sender sliding-window throttle
 # TURBORG_COMMAND_WINDOW_SECONDS=30
-# TURBORG_CUSTOM_COMMANDS_MAX=0                          # cap on commands the registry accepts; -1 = unlimited
+# Cap on how many commands the registry accepts. The default (0) rejects ALL
+# commands — so to load your own TURBORG_COMMANDS you must raise this. -1 =
+# unlimited (the right value for most self-host setups); a positive N caps it.
+TURBORG_CUSTOM_COMMANDS_MAX=-1
 
 # TURBORG_COMMANDS is a JSON array of command definitions. Placeholders {nick},
 # {args}, {channel} are substituted in the template. type=static replies with
@@ -95,13 +98,13 @@
 # =============================================================================
 # Gateway (TURBORG_GATEWAY_*, optional — set password to enable)
 # =============================================================================
-# Control-plane gateway for the agent: WebSocket protocol that streams
-# events to clients and accepts command ops, plus a bundled vanilla-JS
-# reference UI at http://<host>:<port>/. The Go type is web.Gateway; the
-# env names describe the role (control plane), not the transport, so they
-# survive future protocol/connector additions.
+# Web gateway for the agent: WebSocket protocol that streams events to
+# clients and accepts command ops, plus a bundled vanilla-JS reference UI
+# at http://<host>:<port>/. The Go type is web.Gateway; the env names
+# describe the role, not the transport, so they survive future
+# protocol/connector additions.
 #
-# SaaS deployments swap StaticPasswordVerifier for a JWT/session-aware
+# Embedders can swap StaticPasswordVerifier for a JWT/session-aware
 # verifier; the wire protocol is unchanged.
 
 # TURBORG_GATEWAY_PASSWORD=hunter2
@@ -111,10 +114,11 @@
 # TURBORG_GATEWAY_FAILURE_WINDOW_SECONDS=60
 # TURBORG_GATEWAY_LOCKOUT_SECONDS=300
 
-# SaaS lifecycle: when set, the gateway calls its idle-shutdown callback
-# N seconds after the last WS client disconnects. Free-tier containers
-# set this; premium / always-on bouncer instances leave it unset. Bouncer
-# connections do NOT extend the timer — only WS clients do.
+# Idle auto-pause: when set, the gateway calls its idle-shutdown callback
+# N seconds after the last WS client disconnects. Leave unset for an
+# always-on bot. Bouncer connections do NOT extend the timer — only WS
+# clients do. (Wiring the callback to an actual stop is up to the embedder;
+# the bundled binary just logs it.)
 # TURBORG_GATEWAY_IDLE_SHUTDOWN_SECONDS=300
 
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,9 +18,9 @@ builds:
       - amd64
       - arm64
 
-  # The pooled multi-tenant runtime, shipped in the SAME image as /turborg
-  # (the sidecar PoolManager runs it via an entrypoint override). Without this
-  # build the published image only has /turborg and pooled hosts can't boot.
+  # The pooled multi-instance runtime, shipped in the SAME image as /turborg
+  # (run it via an entrypoint override). Without this build the published image
+  # only has /turborg and pooled hosts can't boot.
   - id: turborg-server
     main: ./cmd/turborg-server
     binary: turborg-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN CGO_ENABLED=0 go build \
     -ldflags="-s -w -X github.com/turborg/turborg/internal/version.Version=${VERSION}" \
     -o /turborg ./cmd/turborg
 
-# turborg-server: the pooled multi-tenant runtime. Shipped in the same image
-# so the hosted sidecar can run either binary — it overrides the entrypoint to
-# /turborg-server on pooled hosts. Single-tenant / OSS use keeps /turborg.
+# turborg-server: the pooled multi-instance runtime. Shipped in the same image
+# so an operator can run either binary — override the entrypoint to
+# /turborg-server to run a pool. Single-bot use keeps the default /turborg.
 RUN CGO_ENABLED=0 go build \
     -trimpath \
     -ldflags="-s -w -X github.com/turborg/turborg/internal/version.Version=${VERSION}" \

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,9 +7,8 @@ LABEL org.opencontainers.image.source="https://github.com/turborg/turborg"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY turborg /turborg
-# Pooled multi-tenant runtime — same image, started via an entrypoint override
-# by the sidecar PoolManager. GoReleaser stages both build binaries into the
-# docker context.
+# Pooled multi-instance runtime — same image, started via an entrypoint
+# override. GoReleaser stages both build binaries into the docker context.
 COPY turborg-server /turborg-server
 
 EXPOSE 8765

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Go ≥1.26](https://img.shields.io/badge/go-%E2%89%A51.26-00ADD8.svg)](https://go.dev/dl/)
 [![CI](https://github.com/turborg/turborg/actions/workflows/ci.yml/badge.svg)](https://github.com/turborg/turborg/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)](.testcoverage.yml)
+[![Coverage](https://img.shields.io/badge/coverage-94%25-brightgreen.svg)](.testcoverage.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/turborg/turborg)](https://goreportcard.com/report/github.com/turborg/turborg)
 
 ## What it does
@@ -14,7 +14,7 @@ turborg connects an IRC nick to a network, joins channels, runs commands you reg
 
 - **A real IRC connector** — TLS, SASL PLAIN, NickServ identify, IRCv3 `server-time` + `account-tag`, full PRIVMSG / JOIN / PART / KICK / NICK / TOPIC tracking, per-channel state cached from the wire.
 - **A built-in IRC bouncer** — local clients connect to the bot's loopback port, authenticate with a password, and tunnel through the bot's upstream session. The bot stays in control while a human can lurk and chat from their own client.
-- **A WebSocket gateway + reference web UI** — vanilla-JS single-page client at `/` with channel sidebar, member list, slash commands, IndexedDB-backed scrollback, browser notifications. The protocol is stable and documented so SaaS deployments can swap in their own UI.
+- **A WebSocket gateway + reference web UI** — vanilla-JS single-page client at `/` with channel sidebar, member list, slash commands, IndexedDB-backed scrollback, browser notifications. The protocol is stable and documented so embedders can swap in their own UI.
 - **A normalized `Envelope`** — the same handler that runs on IRC will also run on Discord / Telegram / Web when those connectors land.
 - **Data-driven commands** — the bot ships with none. Define commands as data (a trigger name, a `static` or `llm` type, a template, and an access policy); they're loaded from config and dispatched at runtime. No recompile to add or change one.
 - **Optional LLM, not the centerpiece** — point a command at an LLM (Anthropic, or any OpenAI-compatible endpoint via the router) and it answers prompts. Leave the LLM unset and the rest of the bot doesn't care.
@@ -162,17 +162,27 @@ LLM providers are **optional**. turborg runs perfectly fine as a pure command-dr
 
 ```
 turborg/
-├── cmd/turborg/                 entry point — wires cobra + config + runtime
+├── cmd/
+│   ├── turborg/                 single-bot entry point — cobra + config + runtime
+│   ├── turborg-server/          pooled runtime — many bots in one process
+│   ├── devirc/                  tiny IRC stub for local dev
+│   └── loadgen/                 footprint/load harness for the pooled runtime
 ├── examples/turborg_irc/        minimal embeddable example (runnable)
 ├── internal/
 │   ├── agent/                   Agent, EventBus, CommandRegistry, Envelope
 │   ├── connector/irc/           IRC connector + bouncer + protocol + state
-│   ├── llm/anthropic/           Anthropic Claude with streaming + prompt caching
+│   ├── llm/                     Provider interface + budget; anthropic/ + openaicompat/
 │   ├── web/                     WebSocket gateway + embedded reference UI
+│   ├── commands/                data-driven command definitions → handlers/guards
+│   ├── messages/ messagesink/   channel-history store + durable forwarding
+│   ├── statepush/ activity/     optional state + activity webhooks
+│   ├── budgetrefresh/ commandrefresh/  optional live budget + command hot-reload
+│   ├── ident/                   source-port → ident registry (RFC-1413 backing)
+│   ├── server/                  pooled multi-instance runtime internals
 │   ├── config/                  TURBORG_* settings (env-driven)
 │   ├── runtime/                 build the wired agent from settings
 │   ├── hive/                    Hive client (noop stub today)
-│   ├── logging/                 slog handler factory
+│   ├── logging/ safe/           slog handler factory + goroutine helpers
 │   └── version/                 single Version constant
 ├── tests/fixtures/              FakeIRCServer + FakeConnector for tests
 └── .github/workflows/           ci + release + cla
@@ -187,7 +197,7 @@ make cover-gate            # enforce per-package + total thresholds (.testcovera
 make lint                  # golangci-lint run ./...
 ```
 
-CI runs the same gates plus a Go 1.26 test job and a build smoke test. **Total coverage gate: ≥ 95%.**
+CI runs the same gates plus a Go 1.26 test job and a build smoke test. **Total coverage gate: ≥ 94%.**
 
 ## Contributing
 

--- a/cmd/loadgen/main.go
+++ b/cmd/loadgen/main.go
@@ -1,7 +1,7 @@
-// Command loadgen measures the pooled turborg runtime's footprint under load
-// (multi-tenancy plan WS2 M8). It boots N synthetic tenants against an
-// in-process fake IRC sink, waits for them all to register upstream, then
-// reports RAM + goroutine cost — the numbers that drive pool host sizing.
+// Command loadgen measures the pooled turborg runtime's footprint under load.
+// It boots N synthetic tenants against an in-process fake IRC sink, waits for
+// them all to register upstream, then reports RAM + goroutine cost — the
+// numbers that drive pool host sizing.
 //
 //	go run ./cmd/loadgen -tenants 10000 -channels 2 -duration 30s
 //

--- a/cmd/turborg-server/main.go
+++ b/cmd/turborg-server/main.go
@@ -1,10 +1,10 @@
-// Command turborg-server runs the multi-tenant ("pooled") turborg runtime:
+// Command turborg-server runs the pooled (multi-instance) turborg runtime:
 // one process that holds N tenants, each an isolated agent. It runs alongside
-// the single-tenant `turborg` binary, which stays the default for env-driven
-// hobbyist/OSS deployments.
+// the single-instance `turborg` binary, which stays the default for env-driven
+// single-bot deployments.
 //
-// M1 is lifecycle-only — tenants attach/detach from a file source but run no
-// connector behaviour yet. See accounts-api/dev/PLAN-multi-tenancy.md (WS2).
+// Tenants attach and detach from a configurable source — a local JSON file or
+// an HTTP feed (see selectSource).
 package main
 
 import (
@@ -31,7 +31,7 @@ import (
 )
 
 // defaultAnthropicModel mirrors config.Settings' ANTHROPIC_MODEL envDefault so
-// the pooled process picks the same model the dedicated runtime does when the
+// the pooled process picks the same model the single-instance runtime does when the
 // operator doesn't override it.
 const defaultAnthropicModel = "claude-sonnet-4-6"
 
@@ -119,9 +119,9 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 
 	srv := server.New(source, log)
 	// Point each tenant's connector-state emitter at the control plane (the same
-	// accounts-api base the HTTP feed uses). Empty on the file-source/OSS path →
-	// state-sync stays off. The receiver authorizes via the host token + host-
-	// owns check, so the control-plane token suffices.
+	// base URL the HTTP feed uses). Empty on the file-source path → state-sync
+	// stays off. The receiver authorizes via the host token, so the
+	// control-plane token suffices.
 	srv.SetControlPlane(os.Getenv("TURBORG_CONTROL_PLANE_URL"), os.Getenv("TURBORG_CONTROL_PLANE_TOKEN"))
 
 	// Shared LLM provider for LLM-type commands, built once from the pool
@@ -157,14 +157,14 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 		func(a string) error { return srv.ServeBouncerRouter(ctx, a) })
 
 	// Pooled web-shell ingress: one HTTP router fronts every tenant's `/ws`
-	// gateway (the sidecar proxy forwards `/c/<turborg_id>` here when the tenant
-	// has no dedicated container). Same fail-fast contract as the bouncer router.
+	// gateway (an upstream proxy forwards `/c/<id>` here, addressed by tenant
+	// id). Same fail-fast contract as the bouncer router.
 	startOptionalRouter(ctx, "web-gateway-router", os.Getenv("TURBORG_GATEWAY_ROUTER_ADDR"), cancel, log,
 		func(a string) error { return srv.ServeWebGatewayRouter(ctx, a) })
 
-	// Ident router: the sidecar's RFC-1413 responder resolves an inbound ident
-	// query to (this container's IP, source port) via conntrack, then asks here
-	// for the tenant's ident. Empty addr disables it (no sidecar / OSS self-host).
+	// Ident router: an external RFC-1413 (ident) responder resolves an inbound
+	// query to (this host's IP, source port), then asks here for the matching
+	// tenant's ident. Empty addr disables it.
 	startOptionalRouter(ctx, "ident-router", os.Getenv("TURBORG_IDENT_ROUTER_ADDR"), cancel, log,
 		func(a string) error { return ident.ServeRouter(ctx, a, srv.Idents()) })
 
@@ -186,10 +186,10 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 }
 
 // applyMemoryLimit sets the Go soft memory limit (GOMEMLIMIT) from
-// TURBORG_GOMEMLIMIT_BYTES when present. The sidecar derives it from the pool
-// container's memory allocation so GC works harder near the ceiling instead of
-// the kernel OOM-killing a process that holds every pooled tenant. Unset keeps
-// Go's default (the runtime still honours a natively-set GOMEMLIMIT env).
+// TURBORG_GOMEMLIMIT_BYTES when present. Set it from the process's memory
+// allocation so GC works harder near the ceiling instead of the kernel
+// OOM-killing a process that holds every pooled tenant. Unset keeps Go's
+// default (the runtime still honours a natively-set GOMEMLIMIT env).
 func applyMemoryLimit(log *slog.Logger) {
 	v := os.Getenv("TURBORG_GOMEMLIMIT_BYTES")
 	if v == "" {
@@ -205,8 +205,8 @@ func applyMemoryLimit(log *slog.Logger) {
 }
 
 // selectSource picks the tenant source from the environment. When
-// TURBORG_CONTROL_PLANE_URL is set, the hosted HTTP feed (accounts-api) is
-// used; otherwise tenants come from the local JSON file (OSS / self-host).
+// TURBORG_CONTROL_PLANE_URL is set, the HTTP feed is used; otherwise tenants
+// come from the local JSON file.
 func selectSource(log *slog.Logger) (server.TenantSource, string) {
 	if base := os.Getenv("TURBORG_CONTROL_PLANE_URL"); base != "" {
 		return &server.HTTPSource{

--- a/cmd/turborg/main.go
+++ b/cmd/turborg/main.go
@@ -108,14 +108,13 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Ident reporting for the sidecar's RFC-1413 responder — same mechanism as
-	// the pooled runtime, so a dedicated (paid) container names itself on
+	// Ident reporting for an external RFC-1413 (ident) responder — same
+	// mechanism as the pooled runtime, so the bot names itself on
 	// "identd required" networks and drops the ~ prefix. The connector reports
-	// its source port → ident; the router (this container's bridge IP) serves it
-	// to the sidecar, which resolved the query to us via conntrack. Set before
-	// runtime.Run starts the connector. Disabled when the addr is unset (OSS
-	// self-host with no sidecar); a bind failure is non-fatal — the bot still
-	// connects, just unverified.
+	// its source port → ident; the router (this host's IP) serves it to the
+	// responder, which resolved the inbound query to us. Set before runtime.Run
+	// starts the connector. Disabled when the addr is unset; a bind failure is
+	// non-fatal — the bot still connects, just unverified.
 	if built.IRC != nil {
 		idents := ident.NewRegistry()
 		built.IRC.SetIdentReporter(idents)

--- a/docs/connectors/irc.md
+++ b/docs/connectors/irc.md
@@ -193,7 +193,7 @@ scrollback; see below.)
 
 ## Gateway (cross-reference)
 
-The bot also exposes a control-plane gateway (WS protocol + reference
+The bot also exposes a web gateway (WS protocol + reference
 UI) that today streams IRC events and accepts `say`/`join`/`kick` ops
 flowing back through the agent. The gateway is **not** an IRC
 sub-feature — it's a top-level surface that just happens to surface
@@ -226,7 +226,4 @@ hive).
 - **Sample env file:** [`/.env.example`](../../.env.example)
 - **Source of truth:** `internal/connector/irc/settings.go` — every
   field here has an `env:"…"` tag matching the variable name above.
-- **Gateway internals (SaaS-only):** `docs/backend/PLAN.md` (gitignored;
-  shared with the xshellz orchestrator team out-of-band).
-- **WS protocol + reference UI gap list (SaaS-only):** `docs/ui/PLAN.md`
-  (gitignored; shared with the xshellz Angular team out-of-band).
+- **Gateway reference:** [`docs/gateway.md`](../gateway.md).

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -1,6 +1,6 @@
 # Gateway
 
-turborg's **control-plane gateway** is a single HTTP server that
+turborg's **web gateway** is a single HTTP server that
 exposes:
 
 - `/ws` — a JSON-over-WebSocket protocol that streams agent events to
@@ -38,13 +38,13 @@ message composer.
 
 | Variable | Type | Default | Notes |
 |---|---|---|---|
-| `TURBORG_GATEWAY_PASSWORD` | string | `""` | **Set this to enable the gateway.** Unset = gateway disabled, no listener. SaaS deployments swap `StaticPasswordVerifier` for a JWT- or session-aware `TokenVerifier`; the wire protocol is unchanged. |
+| `TURBORG_GATEWAY_PASSWORD` | string | `""` | **Set this to enable the gateway.** Unset = gateway disabled, no listener. Embedders can swap `StaticPasswordVerifier` for a JWT- or session-aware `TokenVerifier`; the wire protocol is unchanged. |
 | `TURBORG_GATEWAY_HOST` | string | `127.0.0.1` | Listen interface. **Keep on loopback** unless you put a TLS-terminating reverse proxy in front — WebSocket auth tokens travel in cleartext over plain HTTP. |
 | `TURBORG_GATEWAY_PORT` | int | `8765` | HTTP listen port. |
 | `TURBORG_GATEWAY_MAX_FAILED_ATTEMPTS` | int | `5` | Per-IP brute-force cap on `/ws` auth. |
 | `TURBORG_GATEWAY_FAILURE_WINDOW_SECONDS` | int | `60` | Failure-counter window. |
 | `TURBORG_GATEWAY_LOCKOUT_SECONDS` | int | `300` | Lockout duration after the threshold trips. |
-| `TURBORG_GATEWAY_IDLE_SHUTDOWN_SECONDS` | int | `0` (disabled) | When > 0, the gateway calls its `OnIdleShutdown` callback N seconds after the **last WebSocket client** disconnects. The xshellz SaaS sidecar wires this to a `docker stop` for free-tier auto-pause. Bouncer connections do **not** extend the timer — only WS clients do, since the bouncer is intentionally a different SLA tier. |
+| `TURBORG_GATEWAY_IDLE_SHUTDOWN_SECONDS` | int | `0` (disabled) | When > 0, the gateway calls its `OnIdleShutdown` callback N seconds after the **last WebSocket client** disconnects. An embedder can wire this to a process/container stop for idle auto-pause; the bundled binary just logs it. Bouncer connections do **not** extend the timer — only WS clients do. |
 
 ---
 
@@ -52,9 +52,9 @@ message composer.
 
 - The reference UI at `/` is intentionally **vanilla JS / single file /
   no build step**. Polished, production-grade frontend work belongs in
-  a separate client (xshellz operates an Angular one downstream).
-- The wire protocol is byte-stable across patch releases. SaaS clients
-  rely on this — coordinate any change with the downstream UI team.
+  a separate client built against the same WS protocol.
+- The wire protocol is byte-stable across patch releases — embedders
+  with their own UI can rely on this.
 - **Port 0 is legal** in code (it tells `net.Listen` to pick an
   OS-assigned port). The env default is `8765`, so production
   deployments always get a stable port; port-0 is reserved for tests.
@@ -70,6 +70,5 @@ message composer.
 
 - **Sample env file:** [`/.env.example`](../.env.example)
 - **Source of truth:** `internal/web/gateway.go`, `internal/config/settings.go`
-  (the `Gateway*` fields).
-- **WS protocol details (SaaS-only):** `docs/ui/PLAN.md` (gitignored;
-  shared with downstream UI teams out-of-band).
+  (the `Gateway*` fields), and the bundled reference UI in
+  `internal/web/static/index.html`.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -28,8 +28,8 @@ func New(log *slog.Logger) *Agent {
 }
 
 // NewWithPrefix is the same as New but lets callers pick a non-default
-// command prefix (e.g. "." or ".bot"). Useful for SaaS multi-tenancy where
-// every agent owns its own prefix.
+// command prefix (e.g. "." or ".bot"). Useful for multi-instance deployments
+// where every agent owns its own prefix.
 //
 // Agents ship with no commands registered — all commands are user-defined
 // and installed via the registry's dynamic path (ReplaceDynamic), wired by

--- a/internal/agent/commands.go
+++ b/internal/agent/commands.go
@@ -117,7 +117,7 @@ func (r *CommandRegistry) RegisterDynamic(name string, handler CommandHandler, p
 // ReplaceDynamic atomically swaps the entire set of dynamic (user-defined)
 // commands for the given batch, leaving Register-installed entries
 // untouched. It is the hot-reload primitive: the pooled runtime calls it
-// when a tenant's attached commands change, and the dedicated control
+// when a tenant's attached commands change, and the single-instance control
 // endpoint calls it on a push — neither drops the IRC connection.
 //
 // The swap happens under the write lock; Dispatch only ever RLocks, so a

--- a/internal/budgetrefresh/refresh.go
+++ b/internal/budgetrefresh/refresh.go
@@ -4,8 +4,8 @@
 // The in-process TokenBudget counts exactly what THIS process consumes, but
 // the cap is meant to hold across the whole account/window — including sibling
 // agents and this agent's own pre-restart usage. Those live in the control
-// plane, not in memory. This package polls the control plane (via the local
-// sidecar, the same transport the message store uses) and pushes the latest
+// plane, not in memory. This package polls the control plane (the configured
+// HTTP endpoint, same transport the message store uses) and pushes the latest
 // "everyone else" total into the budget as its baseline.
 //
 // Wire contract the operator must serve at the configured URL:

--- a/internal/commandrefresh/refresh.go
+++ b/internal/commandrefresh/refresh.go
@@ -1,12 +1,12 @@
-// Package commandrefresh keeps a single dedicated agent's data-driven command
+// Package commandrefresh keeps a single single-instance agent's data-driven command
 // set current while it runs, without a reconnect.
 //
-// A dedicated agent boots with the command set baked into TURBORG_COMMANDS.
+// A single-instance agent boots with the command set baked into TURBORG_COMMANDS.
 // That set is fixed for the life of the process unless something tells the
 // running agent to reload it. This package polls an endpoint for the tenant's
 // current command set and, when it changes, applies it in place via a
 // caller-supplied callback (which rebuilds the handlers + ReplaceDynamic). It
-// is the dedicated-runtime mirror of what the pooled runtime already does from
+// is the single-instance-runtime mirror of what the pooled runtime already does from
 // its tenant feed, so the two share identical hot-reload semantics (an atomic
 // in-place swap — no IRC reconnect).
 //

--- a/internal/commands/builder.go
+++ b/internal/commands/builder.go
@@ -4,7 +4,7 @@
 // policy, and — for LLM commands — an optional model override.
 //
 // The package is transport-agnostic: definitions arrive as JSON from the
-// tenant feed (pooled) or a TURBORG_COMMANDS env var (dedicated), are
+// tenant feed (pooled) or a TURBORG_COMMANDS env var (single-instance), are
 // decoded into Definition values, and built into agent.DynamicCommand
 // batches that the runtime swaps into a live registry via ReplaceDynamic.
 // Per-command guards are injected by the runtime (which owns owner-trust
@@ -52,7 +52,7 @@ const (
 )
 
 // Definition is one user-defined command. It is the byte-stable wire shape
-// shared by the pooled feed and the dedicated spawn payload.
+// shared by the pooled feed and the single-instance spawn payload.
 type Definition struct {
 	Name     string `json:"name"`
 	Type     Type   `json:"type"`

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -70,7 +70,7 @@ type Settings struct {
 	CommandMaxPerWindow  int `env:"COMMAND_MAX_PER_WINDOW"  envDefault:"5"`
 	CommandWindowSeconds int `env:"COMMAND_WINDOW_SECONDS"  envDefault:"30"`
 
-	// Gateway is the bot's control-plane surface: WS protocol + bundled
+	// Gateway is the bot's web management surface: WS protocol + bundled
 	// reference UI. Today it streams IRC events; the env vars don't
 	// promise a specific protocol or connector, so the same names
 	// survive any future transport/connector additions.
@@ -138,27 +138,25 @@ type Settings struct {
 
 	// LLMBudgetURL is an optional endpoint the agent polls to keep the token
 	// budget's account baseline current while it runs (the boot seed above is
-	// only a point-in-time value). SaaS deployments point it at the sidecar's
-	// per-container budget handler, which forwards to the control plane; the
-	// agent sends its start time as `?since=` so the response can exclude what
-	// it counts locally. Empty = no live refresh (the boot seed is all there
-	// is, which is correct for self-host single-agent installs).
+	// only a point-in-time value). Point it at a service that tracks usage
+	// across restarts; the agent sends its start time as `?since=` so the
+	// response can exclude what it counts locally. Empty = no live refresh (the
+	// boot seed is all there is, which is correct for single-agent installs).
 	LLMBudgetURL string `env:"LLM_BUDGET_URL"`
 	// LLMBudgetToken is the bearer sent on every budget poll. Defaults to
-	// MessageSinkToken via normalize() when unset — both terminate at the same
-	// per-container endpoint with the same bearer.
+	// MessageSinkToken via normalize() when unset — both typically terminate at
+	// the same endpoint with the same bearer.
 	LLMBudgetToken string `env:"LLM_BUDGET_TOKEN"`
 	// LLMBudgetRefreshSeconds is the poll interval. 0 uses the package default
 	// (15s); values below the floor are clamped up by the refresher.
 	LLMBudgetRefreshSeconds int `env:"LLM_BUDGET_REFRESH_SECONDS"`
 
 	// CommandsURL is an optional endpoint the agent polls to hot-reload its
-	// data-driven command set while it runs — no reconnect. SaaS deployments
-	// point it at the sidecar's per-container commands handler, which forwards
-	// the tenant's resolved command set from the control plane. Empty = no live
-	// reload (the boot TURBORG_COMMANDS set is fixed, correct for self-host).
-	// This gives a dedicated agent the same in-place ReplaceDynamic the pooled
-	// runtime already does from its tenant feed.
+	// data-driven command set while it runs — no reconnect. Point it at a
+	// service that serves the latest command set as JSON. Empty = no live
+	// reload (the boot TURBORG_COMMANDS set is fixed). This gives a
+	// single-instance agent the same in-place ReplaceDynamic the pooled runtime
+	// already does from its tenant feed.
 	CommandsURL string `env:"COMMANDS_URL"`
 	// CommandsToken is the bearer sent on every commands poll. Defaults to
 	// MessageSinkToken via normalize() when unset — same per-container endpoint.
@@ -199,13 +197,11 @@ type Settings struct {
 	// summary delivered through IRC itself.
 	OwnerDMNudgeEvery int `env:"OWNER_DM_NUDGE_EVERY"`
 
-	// IgnoredNicks is the operator's (or, in SaaS, the end user's) chat-
-	// ignore list. Senders matching one of these nicks (case-insensitive)
-	// are denied early in the command guard — !commands never dispatch,
-	// future LLM triggers will skip them too. Distinct from the per-tier
-	// PlanCapabilities knobs above: this is per-USER policy, surfaced via
-	// the sidecar's IgnoredNicks SpawnRequest field. Hot-update path:
-	// /update-env recreates the container with the new CSV.
+	// IgnoredNicks is the operator's chat-ignore list. Senders matching one of
+	// these nicks (case-insensitive) are denied early in the command guard —
+	// !commands never dispatch, future LLM triggers will skip them too. This is
+	// per-bot policy, set by the operator. Changing it takes effect on the next
+	// restart.
 	//
 	// Empty = no ignores. CSV in env (TURBORG_IGNORED_NICKS=alice,bob);
 	// whitespace + case are normalized at guard-build time.
@@ -248,17 +244,16 @@ type Settings struct {
 	StateWebhookDebounceMs int `env:"STATE_WEBHOOK_DEBOUNCE_MS" envDefault:"250"`
 
 	// MessageSinkURL is the endpoint the gateway POSTs durable
-	// message batches to. SaaS deployments point this at the
-	// sidecar's per-container /messages handler (the sidecar then
-	// forwards upstream to accounts-api). Empty = self-host: no
-	// durable mirror, the gateway's in-memory ring is still the
-	// only history (already replayed on (re)connect).
+	// message batches to. Point it at a service that persists them
+	// for long-term history. Empty = no durable mirror, the gateway's
+	// in-memory ring is still the only history (already replayed on
+	// (re)connect).
 	MessageSinkURL string `env:"MESSAGE_SINK_URL"`
 
 	// MessageSinkToken is sent as a bearer Authorization header on
-	// every message-sink POST. Mirrors StateWebhookToken — same
-	// per-container token reused, since both endpoints terminate at
-	// the same sidecar gating on the same ActivityTracker.
+	// every message-sink POST. Mirrors StateWebhookToken — the same
+	// token can be reused when both endpoints terminate at the same
+	// receiver.
 	MessageSinkToken string `env:"MESSAGE_SINK_TOKEN"`
 
 	// MessageStoreURL is the endpoint the bouncer (CHATHISTORY) +
@@ -305,8 +300,8 @@ func (s *Settings) normalize() error {
 	s.AllowedLLMModels = trimDropEmpties(s.AllowedLLMModels)
 
 	// MessageStoreToken defaults to the sink token — both halves
-	// usually terminate at the same accounts-api endpoint with the
-	// same per-container bearer. Operators who want different tokens
+	// usually terminate at the same endpoint with the same bearer.
+	// Operators who want different tokens
 	// for read vs. write set MESSAGE_STORE_TOKEN explicitly.
 	if s.MessageStoreToken == "" {
 		s.MessageStoreToken = s.MessageSinkToken
@@ -409,8 +404,8 @@ func (s *Settings) HostnameAllowed(hostname string) bool {
 // registered.
 func (s *Settings) AnthropicEnabled() bool { return s.AnthropicAPIKey != "" }
 
-// GatewayEnabled reports whether the control-plane gateway should be
-// started. False = no listener, no UI, no /ws endpoint.
+// GatewayEnabled reports whether the web gateway should be started.
+// False = no listener, no UI, no /ws endpoint.
 func (s *Settings) GatewayEnabled() bool { return s.GatewayPassword != "" }
 
 // IdleShutdownEnabled reports whether the gateway's idle-shutdown timer

--- a/internal/connector/irc/bouncer.go
+++ b/internal/connector/irc/bouncer.go
@@ -25,8 +25,8 @@ import (
 const serverTimeLayout = "2006-01-02T15:04:05.000Z"
 
 // activityHeartbeatInterval is how often the bouncer re-asserts owner
-// presence while a client is attached. Well under any free-tier idle
-// window (4h), so an attached client never lets the bot idle-pause. A
+// presence while a client is attached. Well under any reasonable idle
+// window, so an attached client never lets the bot idle-pause. A
 // var, not a const, so tests can shorten it.
 var activityHeartbeatInterval = 10 * time.Minute
 
@@ -697,7 +697,7 @@ func (b *Bouncer) Start(ctx context.Context) error {
 // connections are delivered by the caller via ServeConn instead of an accept
 // loop. This is the pooled-runtime path — one turborg-server process fronts
 // every tenant behind a single SNI/PROXY-v2 router, so per-tenant bouncers
-// must not each bind a port. Dedicated mode still uses Start (own host port).
+// must not each bind a port. Single-instance mode still uses Start (own host port).
 // Everything past the listener — auth, replay, state surfacing, keepalive —
 // is identical across both, so the bouncer behaviour is one source of truth.
 func (b *Bouncer) StartListenerless(ctx context.Context) error {

--- a/internal/connector/irc/client.go
+++ b/internal/connector/irc/client.go
@@ -37,8 +37,8 @@ func (c *Client) currentLog() *slog.Logger {
 
 // LocalPort returns the local TCP source port of the upstream connection, or 0
 // when unavailable. The pooled ident responder keys on this: SNAT preserves the
-// source port for the single pool container's egress, so the port an IRC server
-// queries on :113 is exactly this one, letting the sidecar map it back to the
+// source port for the pool process's egress, so the port an IRC server queries
+// on :113 is exactly this one, letting an external responder map it back to the
 // tenant's ident.
 func (c *Client) LocalPort() int {
 	if c.conn == nil {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -63,7 +63,7 @@ type Connector struct {
 	// conn's LocalAddr is unreliable). 0 = nothing registered.
 	identPort int
 	// identReporter receives localPort→ident updates for the pooled RFC-1413
-	// responder. Nil in dedicated runtime / tests (reporting disabled).
+	// responder. Nil in single-instance runtime / tests (reporting disabled).
 	identReporter IdentReporter
 
 	// machine is the per-connector upstream state machine. External
@@ -76,7 +76,7 @@ type Connector struct {
 	bouncer *Bouncer
 	// bouncerListenerless brings the bouncer up without its own TCP listener
 	// (pooled runtime): the pool's SNI/PROXY-v2 router feeds connections in via
-	// ServeBouncerConn. Default false = dedicated mode (bouncer binds a port).
+	// ServeBouncerConn. Default false = single-instance mode (bouncer binds a port).
 	bouncerListenerless bool
 	ctcp                *Throttle
 
@@ -286,7 +286,7 @@ func (c *Connector) getClient() *Client {
 
 // SetIdentReporter installs the pooled ident reporter. Must be called before
 // Start so the first connect is reported. Nil (the default) disables ident
-// reporting — dedicated runtime + tests.
+// reporting — single-instance runtime + tests.
 func (c *Connector) SetIdentReporter(r IdentReporter) { c.identReporter = r }
 
 // setClient swaps the upstream client. Used by Start (initial dial) and
@@ -394,7 +394,7 @@ func (c *Connector) TBTLDR(ctx context.Context, url string) (string, error) {
 // SetBouncerListenerless selects the pooled-runtime bouncer path: the bouncer
 // comes up without binding a TCP port and is fed connections by the pool's
 // SNI/PROXY-v2 router via ServeBouncerConn, instead of its own accept loop.
-// Must be called before Start. Default (false) keeps dedicated mode, where the
+// Must be called before Start. Default (false) keeps single-instance mode, where the
 // bouncer binds its own host port.
 func (c *Connector) SetBouncerListenerless(v bool) { c.bouncerListenerless = v }
 

--- a/internal/connector/irc/ident.go
+++ b/internal/connector/irc/ident.go
@@ -2,14 +2,14 @@ package irc
 
 // IdentReporter receives the live mapping between an upstream connection's
 // local TCP source port and the tenant's IRC ident (the USER value). The pooled
-// runtime implements it so the sidecar's RFC-1413 responder can answer an IRC
+// runtime implements it so an external RFC-1413 responder can answer an IRC
 // server's ident query with a real, verified username instead of the
 // HIDDEN-USER stub (which leaves the user with a ~-prefixed ident and trips the
 // "identd required" gate on networks like IRCnet/Undernet).
 //
 // Implementations must be safe for concurrent use; the connector calls Set/Clear
-// from its reconnect supervisor goroutine. A nil reporter (dedicated runtime,
-// tests) disables reporting entirely.
+// from its reconnect supervisor goroutine. A nil reporter (single-instance
+// runtime, tests) disables reporting entirely.
 type IdentReporter interface {
 	// Set records that the connection on localPort belongs to ident.
 	Set(localPort int, ident string)

--- a/internal/connector/irc/ident_report_internal_test.go
+++ b/internal/connector/irc/ident_report_internal_test.go
@@ -37,7 +37,9 @@ type fakeConn struct {
 	port int
 }
 
-func (f fakeConn) LocalAddr() net.Addr { return &net.TCPAddr{IP: net.IPv4(10, 201, 1, 2), Port: f.port} }
+func (f fakeConn) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(10, 201, 1, 2), Port: f.port}
+}
 
 func TestSetClientReportsAndClearsIdent(t *testing.T) {
 	rep := newRecordingReporter()

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -153,7 +153,7 @@ func parseChannelList(raw string) []string {
 // ApplyDefaults fills the operational fields a HAND-BUILT Settings leaves at
 // their zero value with the same defaults the env loader applies — so a Settings
 // built from a spec (the pooled runtime's settingsFromConnectorSpec) behaves
-// identically to the env-loaded dedicated path (CTCP auto-reply on, liveness
+// identically to the env-loaded single-instance path (CTCP auto-reply on, liveness
 // probing, reconnect escalation, …). The values mirror the `envDefault` tags
 // above; this is the single place the hand-built path picks them up.
 //

--- a/internal/connector/irc/tb.go
+++ b/internal/connector/irc/tb.go
@@ -96,7 +96,7 @@ func (h *tbHandler) tbSummarize(ctx context.Context, channel string, n int, cap 
 		return "", fmt.Errorf("no message history available")
 	}
 	if cap <= 0 {
-		return "", fmt.Errorf("/tb summarize is not available on your plan")
+		return "", fmt.Errorf("/tb summarize is not enabled")
 	}
 	if n <= 0 {
 		n = tbSummarizeDefaultLimit

--- a/internal/connector/irc/tb_test.go
+++ b/internal/connector/irc/tb_test.go
@@ -113,7 +113,7 @@ func TestTBSummarizeZeroCap(t *testing.T) {
 	h := newTBHandler(slog.Default())
 	h.setLLM(&fakeLLM{response: "ok"})
 	_, err := h.tbSummarize(context.Background(), "#test", 0, 0, messages.NewMemoryStore(100))
-	assert.ErrorContains(t, err, "not available on your plan")
+	assert.ErrorContains(t, err, "not enabled")
 }
 
 func TestTBSummarizeEmptyChannel(t *testing.T) {

--- a/internal/connector/irc/upstream_state.go
+++ b/internal/connector/irc/upstream_state.go
@@ -422,8 +422,8 @@ func DescribeUpstreamState(state UpstreamState, networkName, serverReason string
 
 // SeverityForUpstreamState maps a state to the severity label used by
 // the WS gateway's connector.state_changed event payload. Mirrors the
-// three-level scheme the test UI + appui will use to colour-code
-// banners and decide whether to disable the send input.
+// three-level scheme a front-end uses to colour-code banners and
+// decide whether to disable the send input.
 //
 //   - "info" for registered (the recovery "back live" event)
 //   - "warning" for connecting/registering and recoverable disconnects

--- a/internal/ident/registry.go
+++ b/internal/ident/registry.go
@@ -1,12 +1,11 @@
 // Package ident maintains the live mapping from an upstream IRC connection's
 // local TCP source port to the owning tenant's IRC ident (the USER value), and
-// serves it over HTTP for the sidecar's RFC-1413 (ident) responder.
+// serves it over HTTP for an external RFC-1413 (ident) responder.
 //
 // One Registry per turborg process: the pooled server shares a single Registry
-// across every tenant; a dedicated container holds a single entry. The sidecar
-// resolves an incoming ident query to (containerIP, sourcePort) via conntrack,
-// then asks that container's router for the ident — so this same code backs
-// both runtimes.
+// across every tenant; a single-instance process holds a single entry. The
+// responder resolves an incoming ident query to (hostIP, sourcePort), then asks
+// that process's router for the ident — so this same code backs both runtimes.
 package ident
 
 import "sync"

--- a/internal/ident/router.go
+++ b/internal/ident/router.go
@@ -11,18 +11,18 @@ import (
 )
 
 // routerReadHeaderTimeout bounds the header read on an accepted request so a
-// slow caller can't pin a connection. The only caller is the sidecar on the
-// same host, so this is generous.
+// slow caller can't pin a connection. The only caller is the ident responder on
+// the same host, so this is generous.
 const routerReadHeaderTimeout = 5 * time.Second
 
-// ServeRouter answers the sidecar's ident-backing lookups:
+// ServeRouter answers ident-backing lookups:
 //
 //	GET /ident?port=<localSourcePort>  → 200 text/plain <ident> | 404
 //
-// The sidecar resolves an inbound RFC-1413 query to (containerIP, sourcePort)
-// via conntrack, then asks the container that owns the connection — this router
-// — for the ident. Bound to TURBORG_IDENT_ROUTER_ADDR; the sidecar (host
-// network) reaches it on the container's bridge IP. Mirrors web_router.go.
+// An external RFC-1413 responder resolves an inbound ident query to
+// (hostIP, sourcePort), then asks the process that owns the connection — this
+// router — for the ident. Bound to TURBORG_IDENT_ROUTER_ADDR. Mirrors
+// web_router.go.
 //
 // Blocks until ctx is cancelled or the listener fails.
 func ServeRouter(ctx context.Context, addr string, reg *Registry) error {

--- a/internal/messages/http.go
+++ b/internal/messages/http.go
@@ -47,9 +47,9 @@ type HTTPStore struct {
 	log      *slog.Logger
 
 	// entropy + entropyMu mint ULIDs for messages submitted without an
-	// explicit ID. Receiver-side validators require a 26-char ULID; the
-	// previous "let the receiver mint it" contract turned out to be
-	// untrue in accounts-api, so the responsibility lives here.
+	// explicit ID. Receiver-side validators require a 26-char ULID; a
+	// "let the receiver mint it" contract proved unreliable, so the
+	// responsibility lives here.
 	entropy   *rand.Rand
 	entropyMu sync.Mutex
 }

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -1,11 +1,11 @@
 // Package messages defines the durable channel-history seam turborg
 // uses for replay (on bouncer / WS attach) and on-demand scrollback
 // (CHATHISTORY for IRC clients, the WS `history` op for the bundled
-// reference UI and downstream UIs like xshellz's Angular client).
+// reference UI and any downstream client).
 //
 // Two implementations ship in this package:
 //
-//   - MemoryStore — bounded per-channel ring, the self-host default.
+//   - MemoryStore — bounded per-channel ring, the default.
 //     History is lost on restart; cap is 200 lines per channel,
 //     mirroring the prior in-memory rings the bouncer and gateway each
 //     held independently.

--- a/internal/messagesink/sink.go
+++ b/internal/messagesink/sink.go
@@ -1,9 +1,7 @@
 // Package messagesink holds the HTTP plumbing turborg uses to forward
-// recorded channel messages to a configured sink endpoint. In the
-// xshellz SaaS deployment that endpoint is the sidecar's per-container
-// /messages handler, which in turn batches upstream to accounts-api;
-// in self-host the sink is unconfigured (TURBORG_MESSAGE_SINK_URL
-// empty) and recording stops at the gateway's in-memory ring.
+// recorded channel messages to a configured sink endpoint for durable
+// storage. When the sink is unconfigured (TURBORG_MESSAGE_SINK_URL
+// empty) recording stops at the gateway's in-memory ring.
 //
 // The contract is documented at the env-var level — operators point
 // TURBORG_MESSAGE_SINK_URL at any HTTP receiver that accepts the
@@ -20,9 +18,7 @@ import (
 	"time"
 )
 
-// Entry is the wire shape we POST to the sink. Mirrors the
-// MessageEntry the sidecar handler expects and the
-// IngestMessageEntry accounts-api ingests.
+// Entry is the wire shape we POST to the sink.
 type Entry struct {
 	MsgID   string         `json:"msg_id"`
 	Channel string         `json:"channel"`
@@ -33,9 +29,8 @@ type Entry struct {
 	Meta    map[string]any `json:"meta,omitempty"`
 }
 
-// flush triggers + batch-size + interval. Tuned for the "1s/10 msgs"
-// behaviour described in accounts-api's dev/PLAN-message-store.md.
-// At low msg-rate channels the 1s ticker is the rate-limiting flush;
+// flush triggers + batch-size + interval. Tuned for "1s/10 msgs"
+// behaviour. At low msg-rate channels the 1s ticker is the rate-limiting flush;
 // at high msg-rate channels the size threshold kicks first and keeps
 // per-batch latency bounded.
 const (

--- a/internal/messagesink/sink_test.go
+++ b/internal/messagesink/sink_test.go
@@ -18,14 +18,13 @@ func quietLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// TestSinkWireShape pins the contract with sidecar:
+// TestSinkWireShape pins the contract with the receiver:
 //   - POST to the configured endpoint, no path mutation
 //   - Authorization: Bearer <token>
 //   - Content-Type: application/json
 //   - Body: {"messages":[{msg_id, channel, nick, text, ts, kind?}, ...]}
 //
-// Any drift here breaks turborg → sidecar; the corresponding test in
-// sidecar/messages_sink_test.go pins the other end of the same wire.
+// Any drift here breaks the receiver's ingestion of this wire shape.
 func TestSinkWireShape(t *testing.T) {
 	var (
 		mu     sync.Mutex
@@ -96,7 +95,7 @@ func TestSinkWireShape(t *testing.T) {
 
 // TestSinkNilWhenUnconfigured matches the cap_hit + statepush
 // convention: missing env = nil constructor = silent no-op upstream.
-// Lets self-host turborg run without a SaaS backplane.
+// Lets turborg run without a message-store backend.
 func TestSinkNilWhenUnconfigured(t *testing.T) {
 	if got := New("", "tok", nil); got != nil {
 		t.Error("empty endpoint should yield nil sink")
@@ -153,7 +152,7 @@ func TestSizeTriggersFlushAheadOfTicker(t *testing.T) {
 }
 
 // TestNon2xxResponseDoesNotPanic exercises the error branch in post():
-// the sink-side endpoint can answer 4xx/5xx (accounts-api outage,
+// the sink-side endpoint can answer 4xx/5xx (receiver outage,
 // auth drift, etc.) and we must absorb it best-effort instead of
 // crashing the gateway. msg_id idempotency on the receiving side
 // makes a future retry harmless so we don't bother with one here.

--- a/internal/runtime/messages_test.go
+++ b/internal/runtime/messages_test.go
@@ -140,7 +140,7 @@ func TestMakeStoreSubmitterEmptyChannelNoop(t *testing.T) {
 // command replies (!ping → pong) attribute correctly to the bot.
 // OutboundEnvelope has no Sender field — the bot is implicit — so the
 // submitter must consult the botNick callback to populate the
-// row's nick. accounts-api's IngestMessageEntry validator rejects
+// row's nick. The receiver's validator rejects an
 // empty nick with 422, which silently dropped every command reply
 // until this seam was added.
 func TestMakeStoreSubmitterOutboundUsesBotNick(t *testing.T) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -50,7 +50,7 @@ type Built struct {
 	// agent runs. Nil when the provider isn't budgeted or no endpoint is set.
 	BudgetRefresh *budgetrefresh.Refresher
 	// CommandRefresh hot-reloads the data-driven command set in place while the
-	// agent runs (the dedicated mirror of the pooled feed-driven reload). Nil
+	// agent runs (the single-instance mirror of the pooled feed-driven reload). Nil
 	// when COMMANDS_URL is unset (self-host: the boot set is fixed).
 	CommandRefresh *commandrefresh.Refresher
 }
@@ -82,12 +82,11 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	notifier := activity.New(s.ActivityURL, s.ActivityToken, log)
 	ircConn := irc.New(ircCfg, log, a.Events)
 
-	// State-webhook emitter (transport: PUT to STATE_WEBHOOK_URL, which the
-	// sidecar mirrors to accounts-api). Mirrors authoritative per-connector
-	// state whenever it changes; inert no-op when STATE_WEBHOOK_URL is unset.
-	// Wired before WireCommon so the connector's change hooks are observed from
-	// boot. This is the dedicated transport; the pooled runtime POSTs directly
-	// to the control plane instead.
+	// State-webhook emitter (transport: PUT to STATE_WEBHOOK_URL). Mirrors
+	// authoritative per-connector state whenever it changes; inert no-op when
+	// STATE_WEBHOOK_URL is unset. Wired before WireCommon so the connector's
+	// change hooks are observed from boot. This is the single-instance
+	// transport; the pooled runtime POSTs directly to the control plane instead.
 	stateClient := statepush.NewClient(s.StateWebhookURL, s.StateWebhookToken, log)
 	stateEmitter := statepush.NewEmitter(
 		stateClient,
@@ -102,7 +101,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	store, sink := buildMessageStore(s, log)
 	_ = sink // referenced for lifecycle parity; closing happens with the agent
 
-	// Dedicated activity transport: a per-event POST to the local sidecar via
+	// Single-instance activity transport: a per-event POST to ACTIVITY_URL via
 	// the Notifier. Only wired when configured; the pooled runtime supplies its
 	// own coalescing hook instead (per-event POSTs to the control plane don't
 	// scale across a pool).
@@ -187,7 +186,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	// Live budget refresh: when the provider is budgeted and a refresh endpoint
 	// is configured, poll it so the account baseline tracks sibling agents and
 	// this agent's pre-restart usage while it runs (the env seed above is only a
-	// boot-time snapshot). startedAt is sent as `since` so the control plane
+	// boot-time snapshot). startedAt is sent as `since` so the endpoint
 	// excludes what this process counts locally. nil when not budgeted/unset.
 	if bp, ok := provider.(*llm.BudgetedProvider); ok {
 		built.BudgetRefresh = budgetrefresh.New(
@@ -202,7 +201,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 
 	// Live command hot-reload: when COMMANDS_URL is set, poll the per-container
 	// commands endpoint and swap the dynamic command set in place — the same
-	// ReplaceDynamic the pooled runtime does from its feed, so a dedicated
+	// ReplaceDynamic the pooled runtime does from its feed, so a single-instance
 	// container picks up skill attach/detach/edit without a respawn/reconnect.
 	built.CommandRefresh = commandrefresh.New(
 		s.CommandsURL,
@@ -318,10 +317,10 @@ func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, lo
 // any) so the caller can own its lifecycle.
 //
 //   - MESSAGE_STORE_URL + MESSAGE_SINK_URL both set → HTTPStore
-//     (durable read + write through accounts-api).
+//     (durable read + write through the configured endpoints).
 //   - MESSAGE_SINK_URL set, MESSAGE_STORE_URL unset → MemoryStore for
 //     reads but writes still mirror through the sink (legacy half).
-//   - Neither set → MemoryStore only (self-host default).
+//   - Neither set → MemoryStore only (default).
 func buildMessageStore(s *config.Settings, log *slog.Logger) (messages.Store, *messagesink.Sink) {
 	if log == nil {
 		log = slog.Default()
@@ -351,7 +350,7 @@ func buildMessageStore(s *config.Settings, log *slog.Logger) (messages.Store, *m
 // sender — specifically EventMessageSent from agent.handle, where the
 // OutboundEnvelope has no Sender field (bot identity is implicit). The
 // receiving side validates nick as non-empty, so without this fallback
-// command replies (!ping → pong) silently 422'd at accounts-api and
+// command replies (!ping → pong) silently 422'd at the receiver and
 // never landed in the durable history. The callback shape lets us
 // re-resolve the nick on every event — handy when the bot renames
 // mid-session (NICK changes); avoids stamping the original boot-time

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -431,7 +431,7 @@ func TestBuildWiresBudgetRefreshWhenConfigured(t *testing.T) {
 
 	// With a URL + token, the refresher is wired.
 	withURL := *base
-	withURL.LLMBudgetURL = "http://sidecar.local/llm-budget"
+	withURL.LLMBudgetURL = "http://control-plane.local/llm-budget"
 	withURL.LLMBudgetToken = "tok"
 	b2, err := runtime.Build(&withURL, ircCfg, nil)
 	require.NoError(t, err)
@@ -444,7 +444,7 @@ func TestBuildNoBudgetRefreshWithoutCaps(t *testing.T) {
 		CommandPrefix:   "!",
 		AnthropicAPIKey: "sk-test",
 		AnthropicModel:  "claude-sonnet-4-6",
-		LLMBudgetURL:    "http://sidecar.local/llm-budget",
+		LLMBudgetURL:    "http://control-plane.local/llm-budget",
 		LLMBudgetToken:  "tok",
 	}
 	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -17,12 +17,12 @@ import (
 )
 
 // CommonParams are the per-tenant inputs the shared agent wiring consumes,
-// independent of where they were sourced (env for the dedicated CLI, the
+// independent of where they were sourced (env for the single-instance CLI, the
 // tenant feed for the pooled runtime) and independent of transport (port-bound
-// vs listenerless bouncer/gateway, sidecar-PUT vs control-plane-POST state).
+// vs listenerless bouncer/gateway, PUT vs POST state).
 //
 // It carries the wiring that historically drifted between the two runtimes:
-// the dedicated path built it in runtime.Build, the pooled path hand-rolled a
+// the single-instance path built it in runtime.Build, the pooled path hand-rolled a
 // subset in server.Tenant.buildConnectors, so connector features wired in one
 // place silently went missing in the other. WireCommon is now the single
 // owner of all of it.
@@ -60,7 +60,7 @@ type CommonParams struct {
 
 	// LLM provider powering LLM-type commands. Nil → those commands are
 	// skipped at build time. Shared across pooled tenants (a stateless HTTP
-	// client) and per-process for dedicated.
+	// client) and per-process for single-instance.
 	LLM llm.Provider
 
 	// LLMInputCap / LLMOutputCap are the rolling-24h token budget caps.
@@ -77,8 +77,8 @@ type CommonParams struct {
 
 	// ActivityHook fires on owner-presence signals the bouncer raises:
 	// a client attaching, and a periodic presence heartbeat while a client
-	// stays attached. Nil → the attach hook is not wired. Dedicated passes
-	// its Notifier.Hook (a per-event POST to the local sidecar); pooled
+	// stays attached. Nil → the attach hook is not wired. The single-instance
+	// path passes its Notifier.Hook (a per-event POST to ACTIVITY_URL); pooled
 	// passes a hook that marks the tenant active in the pool's coalescing
 	// aggregator (a per-event POST per tenant would hammer the control
 	// plane). The bot's own outbound traffic is NOT activity and has no
@@ -106,7 +106,7 @@ type GuardParams struct {
 }
 
 // WireCommon installs the connector-agnostic agent wiring shared by the
-// dedicated (cmd/turborg) and pooled (internal/server) runtimes onto an
+// single-instance (cmd/turborg) and pooled (internal/server) runtimes onto an
 // already-constructed agent + IRC connector: client limits, outbound throttle,
 // owner nudge, message store + event submitters, builtin commands, and the
 // command guard. It calls a.AddConnector itself.
@@ -115,7 +115,7 @@ type GuardParams struct {
 // gateway (listener vs router), bouncer listener mode, state-push transport —
 // and constructs the deps (LLM/activity/store) from its own config source.
 //
-// No process globals or shared mutable state: invoked once per dedicated
+// No process globals or shared mutable state: invoked once per single-instance
 // process and N times per pooled process, each call producing a fully
 // independent set of throttles/guards/submitters.
 func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slog.Logger) error {
@@ -184,7 +184,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 // into the agent's registry in place via ReplaceDynamic — an atomic, no-
 // reconnect hot reload. It is the single source of truth for turning command
 // Definitions into live handlers, shared by initial wiring (WireCommon), the
-// pooled runtime's feed-driven reload, and the dedicated runtime's command
+// pooled runtime's feed-driven reload, and the single-instance runtime's command
 // refresher, so the three can't drift in how a command is built or
 // access-gated. The registry-wide ignore/throttle guard set at wire time is
 // untouched; per-command access (owner / allowlist / everyone) is reapplied
@@ -201,7 +201,7 @@ func ApplyCommands(a *agent.Agent, defs []commands.Definition, provider llm.Prov
 
 // BuildBudgetedProvider wraps an llm.Provider with rolling-24h budget
 // enforcement when caps are set. The onUsage callback emits the
-// structured llm_usage log (scraped by the sidecar) and publishes
+// structured llm_usage log (for external scraping) and publishes
 // EventLLMUsage on the agent's bus (broadcast to WS clients).
 //
 // Idempotent: a provider that is already a *llm.BudgetedProvider is
@@ -253,7 +253,7 @@ func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outp
 
 // BuildLLMProvider mints an llm.Provider from a provider kind + endpoint +
 // key + default model. It is the single dispatcher both runtimes use so the
-// dedicated env loader and the pooled process select backends identically.
+// single-instance env loader and the pooled process select backends identically.
 //
 //   - "" / "anthropic": the Anthropic provider (back-compat default).
 //   - "openai_compat":  any OpenAI-Chat-Completions-compatible backend
@@ -285,7 +285,7 @@ func BuildLLMProvider(kind, baseURL, apiKey, model string) (llm.Provider, error)
 
 // NewAnthropicProvider builds the Anthropic LLM provider from an API key +
 // model. Returns (nil, nil) when the key is empty — the agent never fails for
-// lack of an LLM; !ask is simply not registered. Shared by the dedicated env
+// lack of an LLM; !ask is simply not registered. Shared by the single-instance env
 // loader and the pooled process so both mint the provider identically.
 func NewAnthropicProvider(apiKey, model string) (llm.Provider, error) {
 	if apiKey == "" {

--- a/internal/server/bouncer_router.go
+++ b/internal/server/bouncer_router.go
@@ -22,7 +22,7 @@ const proxyHeaderReadTimeout = 5 * time.Second
 // the pool and routes each to the tenant it belongs to. HAProxy terminates the
 // wildcard TLS and sends a PROXY v2 header whose AUTHORITY TLV carries the
 // original TLS SNI (`<turborg_id>.bouncer.<domain>`); the connection payload is
-// plaintext IRC from there on. This is the pooled counterpart to a dedicated
+// plaintext IRC from there on. This is the pooled counterpart to a single-instance
 // container's own bouncer port — one listener fronts every pooled tenant, so
 // the runtime doesn't reintroduce a per-tenant port pool.
 //

--- a/internal/server/bouncer_router_test.go
+++ b/internal/server/bouncer_router_test.go
@@ -27,7 +27,7 @@ func authorityHeader(authority string) *proxyproto.Header {
 }
 
 func TestTurborgIDFromAuthority(t *testing.T) {
-	id, err := turborgIDFromAuthority(authorityHeader("alice-7f3b.bouncer.irc.staging.xshellz.com"))
+	id, err := turborgIDFromAuthority(authorityHeader("alice-7f3b.bouncer.irc.example.test"))
 	require.NoError(t, err)
 	assert.Equal(t, "alice-7f3b", id, "turborg_id is the first DNS label of the SNI authority")
 
@@ -38,7 +38,7 @@ func TestTurborgIDFromAuthority(t *testing.T) {
 	_, err = turborgIDFromAuthority(authorityHeader(""))
 	require.Error(t, err, "a header with no AUTHORITY TLV is an error, not a silent empty id")
 
-	_, err = turborgIDFromAuthority(authorityHeader(".bouncer.irc.staging.xshellz.com"))
+	_, err = turborgIDFromAuthority(authorityHeader(".bouncer.irc.example.test"))
 	require.Error(t, err, "an authority with an empty leading label has no turborg_id")
 }
 
@@ -137,7 +137,7 @@ func TestBouncerRouterUnknownTenantClosesConn(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
-	_, err = authorityHeader("ghost-tenant.bouncer.irc.staging.xshellz.com").WriteTo(conn)
+	_, err = authorityHeader("ghost-tenant.bouncer.irc.example.test").WriteTo(conn)
 	require.NoError(t, err)
 
 	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))

--- a/internal/server/connector_irc.go
+++ b/internal/server/connector_irc.go
@@ -8,10 +8,10 @@ import (
 	"github.com/turborg/turborg/internal/connector/irc"
 )
 
-// settingsFromConnectorSpec maps a tenant's IRC ConnectorSpec (the
-// accounts-api/sidecar wire shape: config map + secrets map) onto irc.Settings.
-// Pure — no IO. The single-tenant binary derives the same struct from env via
-// irc.LoadSettings; this is the pooled-mode equivalent sourced from a spec.
+// settingsFromConnectorSpec maps a tenant's IRC ConnectorSpec (the feed wire
+// shape: config map + secrets map) onto irc.Settings. Pure — no IO. The
+// single-tenant binary derives the same struct from env via irc.LoadSettings;
+// this is the pooled-mode equivalent sourced from a spec.
 //
 // The bouncer is wired listenerless: it never binds a host port (N tenants in
 // one process can't), and the pool's PROXY-v2 SNI router (M6) feeds it accepted
@@ -50,7 +50,7 @@ func settingsFromConnectorSpec(cs ConnectorSpec) (*irc.Settings, error) {
 		BouncerPassword: stringField(cs.Secrets, "bouncer_password"),
 	}
 
-	// Apply the same operational defaults the env loader gives the dedicated
+	// Apply the same operational defaults the env loader gives the single-instance
 	// path, so pooled tenants get CTCP auto-reply, liveness probing, reconnect
 	// escalation, etc. — not the Go zero values a spec-built struct starts with.
 	s.ApplyDefaults()
@@ -61,7 +61,7 @@ func settingsFromConnectorSpec(cs ConnectorSpec) (*irc.Settings, error) {
 	return s, nil
 }
 
-// splitNetwork parses "host:port" (the wire shape accounts-api emits). A bare
+// splitNetwork parses "host:port" (the wire shape the feed emits). A bare
 // host defaults to 6697 (TLS IRC). Returns an error for an empty host.
 func splitNetwork(network string) (string, int, error) {
 	network = strings.TrimSpace(network)

--- a/internal/server/hot_reload_test.go
+++ b/internal/server/hot_reload_test.go
@@ -125,7 +125,7 @@ func TestLiveUpdatableOnlyChangeIgnoresTokenUsageBaseline(t *testing.T) {
 	capChange := specWithChannel("x", "#one")
 	capChange.PlanCapabilities = &PlanCapabilities{LLMInputTokensPerDay: 40000, LLMInputTokensUsed: 3900}
 	require.False(t, liveUpdatableOnlyChange(base, capChange),
-		"a plan-cap change is not a live-updatable-only change")
+		"a capability change is not a live-updatable-only change")
 
 	// A channel change alongside a baseline move must still force a restart.
 	chChange := specWithChannel("x", "#two")

--- a/internal/server/http_source.go
+++ b/internal/server/http_source.go
@@ -13,18 +13,18 @@ import (
 	"github.com/turborg/turborg/internal/safe"
 )
 
-// HTTPSource feeds tenants from the hosted control plane (accounts-api),
-// the xshellz production TenantSource (plan WS1 F2 / WS2 M5). It fetches the
-// snapshot of pooled tenants assigned to this host and watches for changes.
+// HTTPSource feeds tenants from a control plane over HTTP — the production
+// TenantSource. It fetches the snapshot of pooled tenants assigned to this host
+// and watches for changes.
 //
 // Watch is poll-and-diff rather than SSE: it re-fetches the snapshot every
 // Interval and emits the delta. That trades a few seconds of propagation
 // latency for far less moving infrastructure (no long-lived stream or
-// server-side broadcast) and trivially survives accounts-api restarts. An
+// server-side broadcast) and trivially survives control-plane restarts. An
 // SSE/long-poll upgrade can replace the poll loop later without changing the
 // TenantSource contract.
 type HTTPSource struct {
-	// BaseURL is the internal API root, e.g. https://accounts-api/v1/internal
+	// BaseURL is the internal API root, e.g. https://control-plane/v1/internal
 	BaseURL string
 	Bearer  string
 	HostID  string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,8 +32,8 @@ type Server struct {
 	workFactory func(*Tenant) func(context.Context) error
 
 	// controlPlaneURL/Token point each pooled tenant's connector-state emitter
-	// at accounts-api's /v1/internal/turborgs/<id>/state receiver. Empty URL
-	// (the OSS/file-source path) leaves state-sync off — the emitter is inert.
+	// at the control plane's per-tenant state receiver. Empty URL (the
+	// file-source path) leaves state-sync off — the emitter is inert.
 	controlPlaneURL   string
 	controlPlaneToken string
 
@@ -48,7 +48,7 @@ type Server struct {
 	activity *activityAggregator
 
 	// idents maps each tenant's upstream source port to its IRC ident, shared
-	// across all tenants and served to the sidecar's RFC-1413 responder by the
+	// across all tenants and served to an external RFC-1413 responder by the
 	// ident router. Always non-nil so connectors report into it unconditionally;
 	// the router is only bound when TURBORG_IDENT_ROUTER_ADDR is set.
 	idents *ident.Registry
@@ -74,9 +74,9 @@ func New(source TenantSource, log *slog.Logger) *Server {
 func (s *Server) Idents() *ident.Registry { return s.idents }
 
 // SetControlPlane configures where pooled tenants POST their connector-state
-// snapshots — accounts-api's internal receiver (TURBORG_CONTROL_PLANE_URL).
+// snapshots — the control plane's internal receiver (TURBORG_CONTROL_PLANE_URL).
 // Call before Run. An empty url leaves state-sync off (each tenant's emitter is
-// inert), matching the OSS/file-source deployment that has no control plane.
+// inert), matching the file-source deployment that has no control plane.
 func (s *Server) SetControlPlane(url, token string) {
 	s.controlPlaneURL = url
 	s.controlPlaneToken = token

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -99,9 +99,10 @@ type Tenant struct {
 	// inbound WS request is closed with 404.
 	gateway *web.Gateway
 	// stateEmitter mirrors this tenant's connector state (upstream status,
-	// channels, nick) to the control plane on every transition, so accounts-api
-	// drives appui's connector pill for pooled tenants the same way it does for
-	// dedicated. Inert when no control plane is configured; Stop()ped at run end.
+	// channels, nick) to the control plane on every transition, so a downstream
+	// UI can reflect connection status for pooled tenants the same way it does
+	// for single-instance ones. Inert when no control plane is configured;
+	// Stop()ped at run end.
 	stateEmitter *statepush.Emitter
 
 	// controlPlaneURL/Token are where the state emitter POSTs (per tenant:
@@ -118,7 +119,7 @@ type Tenant struct {
 	activity *activityAggregator
 
 	// idents is the shared (pool-wide) source-port → ident registry the
-	// connector reports into so the sidecar's RFC-1413 responder can name this
+	// connector reports into so an external RFC-1413 responder can name this
 	// tenant. Never nil (the Server always builds one).
 	idents *ident.Registry
 
@@ -275,7 +276,7 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 		t.mu.Lock()
 		prefix := t.spec.CommandPrefix
 		t.mu.Unlock()
-		// NewWithPrefix defaults an empty prefix to "!", matching the dedicated
+		// NewWithPrefix defaults an empty prefix to "!", matching the single-instance
 		// path (where the env default fills it) so free tenants behave the same.
 		a := agent.NewWithPrefix(t.log, prefix)
 		t.buildConnectors(a)
@@ -334,8 +335,8 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 				t.log.Error("skipping invalid irc connector", "err", err)
 				continue
 			}
-			// Override the connector's ApplyDefaults with the per-tier values
-			// dedicated gets from the sidecar env (QUIT brand + CTCP / bouncer
+			// Override the connector's ApplyDefaults with the per-instance values
+			// the single-instance binary gets from env (QUIT brand + CTCP / bouncer
 			// auth-failure tightening) — all sourced from the tenant feed's caps.
 			t.applyTierSettings(settings, caps)
 			// Wire the connector to the tenant-owned agent bus: the bouncer's
@@ -348,7 +349,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// router feeds it connections via ServeBouncerConn after PROXY-v2
 			// tenant resolution. Set before WireCommon adds the connector.
 			conn.SetBouncerListenerless(true)
-			// Report this tenant's upstream source port → ident so the sidecar's
+			// Report this tenant's upstream source port → ident so an external
 			// RFC-1413 responder can name it (kills the ~ prefix + satisfies
 			// "identd required" networks). Shared registry across all tenants.
 			conn.SetIdentReporter(t.idents)
@@ -363,13 +364,13 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			t.messageSink = sink
 			t.mu.Unlock()
 
-			// The shared, connector-agnostic wiring — identical to the dedicated
+			// The shared, connector-agnostic wiring — identical to the single-instance
 			// runtime, which calls the same runtime.WireCommon. Gives pooled
 			// tenants builtins (!ping/!version/!ask), the owner command guard,
 			// plan limits + outbound throttle, owner nudge, activity reporting,
 			// and message-store submitters, so the two modes can't drift. Owner-
 			// trust config travels in the connector config (the feed reuses the
-			// same connectorList() shape the dedicated spawn payload does).
+			// same connectorList() shape the single-instance spawn payload does).
 			// Build the budgeted provider once so the same budget instance is
 			// shared by the connector/commands (WireCommon) and the web gateway
 			// below. WireCommon's own wrap is idempotent on this.
@@ -387,9 +388,9 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			t.mu.Unlock()
 
 			// Connector-state sync: mirror upstream status / channels / nick to
-			// the control plane on every transition, so appui's connector pill
-			// works for pooled tenants the same way dedicated does (via the
-			// single-tenant runtime emitter). Inert + nil when no control plane.
+			// the control plane on every transition, so a downstream UI reflects
+			// connection status for pooled tenants the same way it does for
+			// single-instance ones. Inert + nil when no control plane.
 			if em := buildTenantStateEmitter(conn, t.ID, t.controlPlaneURL, t.controlPlaneToken, t.log); em != nil {
 				t.mu.Lock()
 				t.stateEmitter = em
@@ -397,8 +398,8 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			}
 
 			// Web shell: built only when the tenant carries a gateway token (the
-			// plan's `gatewayEnabled` capability is expressed by accounts-api
-			// emitting the token at all). Listenerless like the bouncer — the web
+			// feed expresses the "web shell enabled" capability by emitting the
+			// token at all). Listenerless like the bouncer — the web
 			// router dispatches `/c/<id>` to the shared Handler via ServeWS, so the
 			// gateway never binds its own port.
 			if gatewayToken != "" {
@@ -428,9 +429,9 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 }
 
 // applyTierSettings overrides the connector defaults ApplyDefaults filled with
-// the per-tier values dedicated receives from the sidecar env — all sourced
-// from the tenant feed's plan caps: the IRC QUIT brand, the CTCP throttle, and
-// the bouncer auth-failure ceiling. Each guard keeps an unset value on the
+// the per-instance values the single-instance binary receives from env — all
+// sourced from the tenant feed's caps: the IRC QUIT brand, the CTCP throttle,
+// and the bouncer auth-failure ceiling. Each guard keeps an unset value on the
 // ApplyDefaults default rather than zeroing it.
 func (t *Tenant) applyTierSettings(s *irc.Settings, caps *PlanCapabilities) {
 	if caps == nil {
@@ -452,15 +453,15 @@ func (t *Tenant) applyTierSettings(s *irc.Settings, caps *PlanCapabilities) {
 
 // commonParams maps a tenant's IRC connector spec + plan caps onto the
 // runtime.CommonParams the shared agent wiring consumes — the single place
-// pooled inputs become the same struct the dedicated runtime builds from env.
+// pooled inputs become the same struct the single-instance runtime builds from env.
 // Owner-trust fields live in the connector config (the feed reuses the
-// dedicated connectorList() shape); identity limits, throttles, and the nudge
+// single-instance connectorList() shape); identity limits, throttles, and the nudge
 // interval come from the plan caps; ignored nicks + the LLM provider + the
 // store + the activity hook are threaded from the tenant.
 //
 // CustomCommandsMax + Commands carry the tenant's data-driven command set
 // and its cap, so pooled tenants get user-defined commands the same way the
-// dedicated runtime does (from TURBORG_COMMANDS).
+// single-instance runtime does (from TURBORG_COMMANDS).
 func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick string, store messages.Store, ignoredNicks []string, cmds []commands.Definition) runtime.CommonParams {
 	var limits irc.ClientLimits
 	var outMax, outWin, nudge, cmdMax, cmdWin, customCmdMax, llmInCap, llmOutCap, llmInUsed, llmOutUsed int
@@ -657,7 +658,7 @@ func (t *Tenant) reloadCommands(defs []commands.Definition) bool {
 	// {platform} echoes the IRC server hostname; the connector spec carries it
 	// as "host:port", so reuse the same split the spec→settings mapping does.
 	platform, _, _ := splitNetwork(stringField(cs.Config, "network"))
-	// Same in-place swap the dedicated runtime's command refresher uses.
+	// Same in-place swap the single-instance runtime's command refresher uses.
 	runtime.ApplyCommands(a, defs, t.llmProvider, owner, platform, t.log)
 	return true
 }
@@ -695,8 +696,8 @@ func (t *Tenant) ServeBouncerConn(conn net.Conn) {
 	c.ServeBouncerConn(conn)
 }
 
-// ServeWS hands one HTTP request (the appui web shell's `/ws` upgrade, addressed
-// as `/c/<turborg_id>`) to this tenant's live web gateway. The web router calls
+// ServeWS hands one HTTP request (the web shell's `/ws` upgrade, addressed
+// as `/c/<id>`) to this tenant's live web gateway. The web router calls
 // it after resolving the tenant from the request path. Returns 404 when the
 // tenant has no running gateway (between runs / quarantined / no web shell
 // configured); the browser reconnects and the router retries. The request's

--- a/internal/server/tenant_activity.go
+++ b/internal/server/tenant_activity.go
@@ -29,12 +29,12 @@ type httpDoer interface {
 // activityAggregator coalesces per-tenant activity signals into a coarse
 // periodic bulk POST to the control plane's /turborgs/activity endpoint.
 //
-// Dedicated containers report activity to their host's sidecar (in-memory),
-// which accounts-api pulls onto last_active_at. Pooled tenants have no sidecar
-// hop, so the pool batches active tenant IDs here and flushes them on a timer.
-// Without it a pooled tenant's last_active_at would never refresh and the idle
-// reaper would kill an actively-used free tenant. Inert (Mark is a no-op, run
-// returns immediately) when no control plane is configured.
+// The single-instance runtime reports activity to a co-located endpoint. Pooled
+// tenants have no such per-tenant hop, so the pool batches active tenant IDs
+// here and flushes them on a timer. Without it a pooled tenant's last_active_at
+// would never refresh and the idle reaper could kill an actively-used tenant.
+// Inert (Mark is a no-op, run returns immediately) when no control plane is
+// configured.
 type activityAggregator struct {
 	url      string
 	token    string

--- a/internal/server/tenant_gateway.go
+++ b/internal/server/tenant_gateway.go
@@ -12,9 +12,9 @@ import (
 )
 
 // Web-shell brute-force defaults. The pooled gateway has no env layer of its
-// own (the dedicated path sources these from config.Settings in
-// runtime.buildGateway); a tenant's token is a strong per-turborg secret, but
-// the router faces the public sidecar proxy, so a lockout still gates guessing.
+// own (the single-instance path sources these from config.Settings in
+// runtime.buildGateway); a tenant's token is a strong per-tenant secret, but
+// the router faces a public proxy, so a lockout still gates guessing.
 // Mirrors the GATEWAY_* config defaults so both modes behave the same.
 const (
 	gatewayMaxFailedAttempts = 5
@@ -25,12 +25,11 @@ const (
 // buildTenantGateway constructs a pooled tenant's web shell around its live IRC
 // connector. The connector is both the gateway's IRC bridge and its outbound
 // Sender (same wiring as runtime.buildGateway's web.New(ircConn, ircConn, …) —
-// kept in lockstep so the dedicated and pooled web shells stay one behaviour).
+// kept in lockstep so the single-instance and pooled web shells stay one behaviour).
 //
 // No Host/Port: the pooled gateway never binds its own listener — the web
-// router serves the shared Handler() per request. No MessageStore: pooled
-// scrollback lives in accounts-api and is a follow-up; live streaming works
-// without it.
+// router serves the shared Handler() per request. No MessageStore: durable
+// pooled scrollback is a follow-up; live streaming works without it.
 func buildTenantGateway(bridge *irc.Connector, token string, log *slog.Logger, store messages.Store, llmProvider llm.Provider, tbSummarizeCap int, onActivity func(reason string)) (*web.Gateway, error) {
 	verifier, err := web.NewStaticPasswordVerifier(token)
 	if err != nil {

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -1,12 +1,11 @@
-// Package server hosts the multi-tenant ("pooled") turborg runtime: one
+// Package server hosts the pooled (multi-instance) turborg runtime: one
 // long-lived process that holds N tenants, each an isolated agent. It runs
-// alongside the existing single-tenant binary (cmd/turborg), which stays the
-// default for hobbyist/OSS env-driven deployments.
+// alongside the single-instance binary (cmd/turborg), which stays the default
+// for env-driven single-bot deployments.
 //
-// M1 (this milestone) is lifecycle-only: the Server attaches and detaches
-// tenants from a TenantSource and supervises their goroutines. Real connector
-// behaviour, crash isolation, per-tenant limits, and the SNI bouncer router
-// land in later milestones (see accounts-api/dev/PLAN-multi-tenancy.md WS2).
+// The Server attaches and detaches tenants from a TenantSource and supervises
+// their goroutines, with crash isolation, per-tenant limits, and SNI-based
+// ingress routing.
 package server
 
 import (
@@ -19,8 +18,8 @@ import (
 	"github.com/turborg/turborg/internal/safe"
 )
 
-// ConnectorSpec describes one connector instance a tenant runs. Mirrors the
-// sidecar/accounts-api wire shape; Type matches turborg's connector names.
+// ConnectorSpec describes one connector instance a tenant runs. The Type field
+// matches turborg's connector names.
 type ConnectorSpec struct {
 	Type    string         `json:"type"`
 	Config  map[string]any `json:"config"`
@@ -28,8 +27,8 @@ type ConnectorSpec struct {
 }
 
 // TenantSpec is the desired state of a single tenant. Keyed by the logical
-// TurborgID — never a runtime identifier. Wire-compatible with the sidecar
-// TenantSpec so an HTTPSource (M5) can decode the same JSON.
+// TurborgID — never a runtime identifier. Both the FileSource and the
+// HTTPSource decode the same JSON shape.
 type TenantSpec struct {
 	TurborgID        string            `json:"turborg_id"`
 	ShardID          int               `json:"shard_id,omitempty"`
@@ -40,29 +39,27 @@ type TenantSpec struct {
 	Connectors       []ConnectorSpec   `json:"connectors"`
 	PlanCapabilities *PlanCapabilities `json:"plan_capabilities,omitempty"`
 
-	// IgnoredNicks is the owner's per-user ignore list: the command guard drops
-	// !commands from these nicks. Mirrors the dedicated spawn payload's field.
+	// IgnoredNicks is the owner's ignore list: the command guard drops
+	// !commands from these nicks. Mirrors the single-instance TURBORG_IGNORED_NICKS.
 	IgnoredNicks []string `json:"ignored_nicks,omitempty"`
 
 	// Commands is the tenant's data-driven command set (the same wire shape
-	// the dedicated payload carries as TURBORG_COMMANDS). The pooled runtime
+	// the single-instance runtime carries as TURBORG_COMMANDS). The pooled runtime
 	// swaps it into the agent's registry, and — uniquely — a change to ONLY
 	// this field is applied in place without dropping the IRC connection
 	// (see Tenant.update). Ordered; an empty slice means no commands.
 	Commands []commands.Definition `json:"commands,omitempty"`
 
-	// GatewayToken authorizes the per-tenant web shell (the appui `/ws`
-	// surface). It's the turborg's existing container_token, threaded through
-	// by accounts-api; an empty token means "no web shell for this tenant" and
-	// the pooled gateway is not built. The web router's StaticPasswordVerifier
-	// checks the `?token=` query against it.
+	// GatewayToken authorizes the per-tenant web shell (the `/ws` surface).
+	// An empty token means "no web shell for this tenant" and the pooled
+	// gateway is not built. The web router's StaticPasswordVerifier checks the
+	// `?token=` query against it.
 	GatewayToken string `json:"gateway_token,omitempty"`
 }
 
-// PlanCapabilities is the subset of accounts-api's plan-tier caps the pooled
-// runtime enforces per tenant (M4). Mirrors the sidecar PlanCapabilities wire
-// shape; container mode delegates these to cgroups + the connector's env,
-// pooled mode enforces them in-process. 0 = unrestricted by convention.
+// PlanCapabilities is the per-tenant capability limits the pooled runtime
+// enforces in-process. The single-instance binary expresses the same limits via
+// env vars; here they arrive in the tenant feed. 0 = unrestricted by convention.
 type PlanCapabilities struct {
 	NickLocked            bool `json:"nick_locked"`
 	RealnameLocked        bool `json:"realname_locked"`
@@ -70,21 +67,20 @@ type PlanCapabilities struct {
 	OutboundMsgsPerWindow int  `json:"outbound_msgs_per_window"`
 	OutboundWindowSeconds int  `json:"outbound_window_seconds"`
 	// OwnerDMNudgeEvery: DM the owner every N outbound PRIVMSGs with a usage
-	// summary (free=100). Fires only when an owner nick is configured.
+	// summary. Fires only when an owner nick is configured.
 	OwnerDMNudgeEvery int `json:"owner_dm_nudge_every"`
-	// CommandMaxPerWindow/WindowSeconds: per-sender !command throttle (free=3
-	// per 30s). 0 = unthrottled by convention.
+	// CommandMaxPerWindow/WindowSeconds: per-sender !command throttle.
+	// 0 = unthrottled by convention.
 	CommandMaxPerWindow  int `json:"command_max_per_window"`
 	CommandWindowSeconds int `json:"command_window_seconds"`
-	// CTCPMaxPerWindow/WindowSeconds: per-sender CTCP throttle (free=2/30).
-	// BouncerMaxFailedAttempts: bouncer auth-failure ceiling (free=3). All
+	// CTCPMaxPerWindow/WindowSeconds: per-sender CTCP throttle.
+	// BouncerMaxFailedAttempts: bouncer auth-failure ceiling. All
 	// 0 = fall back to the connector's ApplyDefaults values.
 	CTCPMaxPerWindow         int `json:"ctcp_max_per_window"`
 	CTCPWindowSeconds        int `json:"ctcp_window_seconds"`
 	BouncerMaxFailedAttempts int `json:"bouncer_max_failed_attempts"`
-	// QuitMessage is the per-tier IRC QUIT brand (e.g. "turborg.com — free,
-	// xshellz.com"), applied to the tenant's connector. Empty → the connector
-	// default. Mirrors the value the sidecar emits for dedicated.
+	// QuitMessage is the IRC QUIT brand applied to the tenant's connector.
+	// Empty → the connector default.
 	QuitMessage string `json:"quit_message"`
 
 	// CustomCommandsMax caps how many data-driven commands the tenant's
@@ -112,14 +108,13 @@ type PlanCapabilities struct {
 	// LLM carries the OpenAI-compatible router config for LLM-type commands.
 	// Documentation-only on the turborg side: the pooled process builds one
 	// shared provider from its own env (the API key is a server-side secret,
-	// never in the feed) and the model catalog is enforced upstream at
-	// attach time. Mirrors the block the sidecar emits as TURBORG_LLM_* for
-	// dedicated.
+	// never in the feed) and the model catalog is enforced upstream at attach
+	// time. Mirrors the single-instance TURBORG_LLM_* env.
 	LLM *LLMRouterConfig `json:"llm,omitempty"`
 }
 
 // LLMRouterConfig is the OpenAI-compatible LLM router block. It travels in
-// the plan capabilities for documentation + parity with the dedicated
+// the capability config for documentation + parity with the single-instance
 // TURBORG_LLM_* env; the secret API key is never carried here.
 type LLMRouterConfig struct {
 	Provider      string   `json:"provider"`
@@ -148,9 +143,9 @@ type TenantEvent struct {
 }
 
 // TenantSource feeds the Server its desired tenant set. Initial returns the
-// full snapshot at boot; Watch streams subsequent changes. Three
-// implementations are planned (plan WS1 F1): env (single tenant), file
-// (this package), and HTTP long-poll against accounts-api (M5).
+// full snapshot at boot; Watch streams subsequent changes. Implementations
+// include a JSON file (FileSource) and an HTTP poll against a control plane
+// (HTTPSource).
 type TenantSource interface {
 	Initial(ctx context.Context) ([]TenantSpec, error)
 	Watch(ctx context.Context) (<-chan TenantEvent, error)
@@ -161,12 +156,9 @@ type fileDoc struct {
 	Tenants []TenantSpec `json:"tenants"`
 }
 
-// FileSource loads tenants from a JSON file. M1 reads the snapshot once at
-// boot; live reload on file change lands in a later milestone (the Watch
-// channel simply stays open until ctx is cancelled for now).
-//
-// JSON rather than the plan's YAML to avoid promoting the indirect yaml.v3
-// dependency to a direct one without sign-off; the wire shape is identical.
+// FileSource loads tenants from a JSON file. It reads the snapshot once at
+// boot; the Watch channel stays open until ctx is cancelled (no live reload on
+// file change yet).
 type FileSource struct {
 	Path string
 }

--- a/internal/server/tenant_statepush.go
+++ b/internal/server/tenant_statepush.go
@@ -15,12 +15,12 @@ import (
 const tenantStateDebounce = 250 * time.Millisecond
 
 // buildTenantStateEmitter wires a connector-state emitter for one pooled tenant.
-// Unlike the dedicated path (which PUTs to the sidecar, which re-POSTs), the
-// pool POSTs each tenant's snapshot straight to accounts-api's per-turborg
+// Unlike the single-instance path (which PUTs to STATE_WEBHOOK_URL), the pool
+// POSTs each tenant's snapshot straight to the control plane's per-tenant
 // receiver — it already holds the control-plane URL + token (it polls the feed
-// from there), and the receiver authorizes it via the host token + host-owns
-// check. Returns nil when no control plane is configured (OSS/file-source), so
-// state-sync is simply off.
+// from there), and the receiver authorizes it via the host token. Returns nil
+// when no control plane is configured (the file-source path), so state-sync is
+// simply off.
 func buildTenantStateEmitter(conn *irc.Connector, turborgID, controlPlaneURL, token string, log *slog.Logger) *statepush.Emitter {
 	if controlPlaneURL == "" || turborgID == "" {
 		return nil

--- a/internal/server/tenant_statepush_test.go
+++ b/internal/server/tenant_statepush_test.go
@@ -16,7 +16,8 @@ import (
 // TestPooledTenantPostsConnectorState: with a control plane configured, a
 // pooled tenant POSTs its connector-state snapshot (to
 // /turborgs/<id>/state, bearer-authed) on upstream transitions — the path that
-// drives appui's connector pill for pooled the way dedicated already does.
+// drives a downstream UI's connector status for pooled tenants the way the
+// single-instance path already does.
 func TestPooledTenantPostsConnectorState(t *testing.T) {
 	fs := fakeirc.New(t)
 	defer fs.Close()

--- a/internal/server/tenant_wire_test.go
+++ b/internal/server/tenant_wire_test.go
@@ -142,23 +142,23 @@ func TestCommonParamsMapsCapsAndOwner(t *testing.T) {
 	require.Nil(t, p.ActivityHook, "no aggregator on a directly-built tenant → no activity hook")
 }
 
-// TestApplyTierSettings: the per-tier QUIT brand + CTCP / bouncer-failed caps
+// TestApplyTierSettings: the per-instance QUIT brand + CTCP / bouncer-failed caps
 // (all from the tenant feed) override the connector's ApplyDefaults — closing
-// the last drifts where pooled fell back to defaults dedicated overrode from
-// the sidecar env.
+// the last drifts where pooled fell back to defaults the single-instance path
+// overrode from env.
 func TestApplyTierSettings(t *testing.T) {
 	tn := &Tenant{}
 	s := &irc.Settings{Hostname: "irc.example", Nick: "bot"}
 	s.ApplyDefaults() // quit "bye from turborg", CTCP 3/30, bouncer-failed 5
 
 	tn.applyTierSettings(s, &PlanCapabilities{
-		QuitMessage:              "turborg.com — free, xshellz.com",
+		QuitMessage:              "turborg @ www.xshellz.com",
 		CTCPMaxPerWindow:         2,
 		CTCPWindowSeconds:        30,
 		BouncerMaxFailedAttempts: 3,
 	})
 
-	require.Equal(t, "turborg.com — free, xshellz.com", s.QuitMessage)
+	require.Equal(t, "turborg @ www.xshellz.com", s.QuitMessage)
 	require.Equal(t, 2, s.CTCPMaxPerWindow)
 	require.Equal(t, 30, s.CTCPWindowSeconds)
 	require.Equal(t, 3, s.BouncerMaxFailedAttempts)

--- a/internal/server/web_router.go
+++ b/internal/server/web_router.go
@@ -13,13 +13,13 @@ import (
 // slow client can't pin a connection before the WS upgrade.
 const webRouterReadHeaderTimeout = 10 * time.Second
 
-// ServeWebGatewayRouter accepts the appui web-shell requests the sidecar proxy
+// ServeWebGatewayRouter accepts the web-shell requests an upstream proxy
 // forwards to the pool and routes each to the tenant it addresses. The path
-// carries the tenant id (`/c/<turborg_id>`) and the `?token=` query authorizes
+// carries the tenant id (`/c/<id>`) and the `?token=` query authorizes
 // the upgrade — unlike the bouncer router there's no PROXY-v2 / SNI to parse,
-// so this is a plain HTTP server. This is the pooled counterpart to a dedicated
-// container's own gateway port: one listener fronts every pooled tenant's web
-// shell, so the runtime doesn't reintroduce a per-tenant port pool.
+// so this is a plain HTTP server. This is the pooled counterpart to a
+// single-instance process's own gateway port: one listener fronts every pooled
+// tenant's web shell, so the runtime doesn't reintroduce a per-tenant port pool.
 //
 // Blocks until ctx is cancelled or the listener fails.
 func (s *Server) ServeWebGatewayRouter(ctx context.Context, addr string) error {

--- a/internal/statepush/client.go
+++ b/internal/statepush/client.go
@@ -78,10 +78,10 @@ func NewClient(url, token string, log *slog.Logger) *Client {
 	return NewClientWithMethod(url, token, http.MethodPut, log)
 }
 
-// NewClientWithMethod is NewClient with an explicit HTTP method. The dedicated
-// path PUTs to the sidecar (which re-POSTs to accounts-api), but the pooled
-// runtime POSTs per-tenant state straight to accounts-api's
-// /v1/internal/turborgs/<id>/state receiver (a POST route), so it needs POST.
+// NewClientWithMethod is NewClient with an explicit HTTP method. The
+// single-instance path PUTs to STATE_WEBHOOK_URL, but the pooled runtime POSTs
+// per-tenant state straight to the control plane's per-tenant state receiver
+// (a POST route), so it needs POST.
 func NewClientWithMethod(url, token, method string, log *slog.Logger) *Client {
 	if log == nil {
 		log = slog.Default()

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,9 +1,8 @@
-// Package web is turborg's control-plane gateway: a JSON-over-WS protocol
-// that streams the agent's events to browser clients and accepts command
-// ops, plus the bundled vanilla-JS reference UI served from the same HTTP
-// server. SaaS deployments replace the TokenVerifier with their own auth
-// backend; self-host uses a single shared password from
-// TURBORG_GATEWAY_PASSWORD.
+// Package web is turborg's web gateway: a JSON-over-WS protocol that streams
+// the agent's events to browser clients and accepts command ops, plus the
+// bundled vanilla-JS reference UI served from the same HTTP server. The
+// default uses a single shared password from TURBORG_GATEWAY_PASSWORD;
+// embedders can replace the TokenVerifier with their own auth backend.
 package web
 
 import (

--- a/internal/web/embed.go
+++ b/internal/web/embed.go
@@ -3,8 +3,8 @@ package web
 import "embed"
 
 // staticFS is the bundled reference UI. Single vanilla-JS file, no build
-// step. Polished Angular UI lives in xshellz's client repo; this is the
-// frozen contract reference the team builds against.
+// step. It's a reference client with a stable wire protocol — embedders
+// can build their own UI against the same protocol.
 //
 //go:embed static
 var staticFS embed.FS

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -29,7 +29,7 @@ const (
 )
 
 // activityHeartbeatInterval is how often an engaged web session
-// re-asserts owner presence. Well under any free-tier idle window (4h),
+// re-asserts owner presence. Well under any reasonable idle window,
 // so an engaged, open dashboard never lets the bot idle-pause. A var,
 // not a const, so tests can shorten it.
 var activityHeartbeatInterval = 10 * time.Minute
@@ -77,11 +77,10 @@ type Options struct {
 	RateLimiter *irc.RateLimiter
 	Log         *slog.Logger
 
-	// IdleShutdownSeconds + OnIdleShutdown wire the free-tier auto-pause
-	// path: when both are set and the client count drops to zero, the
-	// gateway starts a timer; if no client reconnects within the window,
-	// OnIdleShutdown fires (the SaaS sidecar maps that to a docker
-	// stop).
+	// IdleShutdownSeconds + OnIdleShutdown wire an auto-pause path: when
+	// both are set and the client count drops to zero, the gateway starts
+	// a timer; if no client reconnects within the window, OnIdleShutdown
+	// fires (an embedder can map that to a process/container stop).
 	IdleShutdownSeconds int
 	OnIdleShutdown      func()
 
@@ -230,7 +229,7 @@ func (g *Gateway) Subscribe(bus *agent.EventBus) {
 
 // Handler returns the gateway's HTTP routes — /ws (WebSocket), /health,
 // /metrics, and the static UI. Serve mounts it on the gateway's own listener
-// (dedicated / single-tenant); the pooled runtime mounts the SAME handler
+// (single-instance / single-tenant); the pooled runtime mounts the SAME handler
 // behind its per-tenant router. One route set + one handler chain for both
 // modes — a change here affects both, no reimplementation.
 func (g *Gateway) Handler() http.Handler {
@@ -366,7 +365,7 @@ func (g *Gateway) handleWS(w http.ResponseWriter, r *http.Request) {
 	g.metMu.Unlock()
 	g.log.Info("web auth success", "ip", ip)
 	// A bare handshake is NOT activity — opening the dashboard (or a tab
-	// left sitting for hours) must not keep a free-tier bot alive. The
+	// left sitting for hours) must not keep an idle-pausing bot alive. The
 	// session only starts counting once the owner actually sends a
 	// message or /tb (see readLoop), after which this heartbeat keeps it
 	// active for the session's duration.
@@ -607,7 +606,7 @@ func (g *Gateway) allowByPolicy(ircCmd string) (allow bool, reason string, kind 
 
 // denyAction sends a policy_denied event to the originating client and
 // emits a cap_hit structured log line for telemetry pipelines. The log
-// line is the canonical signal a sidecar log-watcher (or any future
+// line is the canonical signal a log-watcher (or any future
 // metrics scraper) consumes — never log the user-facing reason from any
 // other path, so cap_hit stays the single source of truth.
 //
@@ -823,9 +822,8 @@ func (g *Gateway) dispatchInbound(ctx context.Context, c *client, p map[string]a
 }
 
 // handleHistoryOp answers a `{op: "history", channel, before, limit}`
-// scrollback request from a WS client. The infinite-scroll UI in the
-// reference + appui front-ends fires this when the user nears the top
-// of the channel pane. Wire shape:
+// scrollback request from a WS client. An infinite-scroll UI fires
+// this when the user nears the top of the channel pane. Wire shape:
 //
 //	inbound:  {op:"history", channel:"#x", before:"2026-05-21T12:00:00.000Z", limit:200}
 //	outbound: {op:"history_result", channel, messages:[{nick,text,ts,id}], has_more:bool}
@@ -983,7 +981,7 @@ func (g *Gateway) handleTBSummarize(ctx context.Context, c *client, channel stri
 		return
 	}
 	if cap <= 0 {
-		g.sendTo(ctx, c, map[string]any{"op": "tb_error", "message": "/tb summarize is not available on your plan."})
+		g.sendTo(ctx, c, map[string]any{"op": "tb_error", "message": "/tb summarize is not enabled."})
 		return
 	}
 

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -1250,7 +1250,7 @@ func TestTBOpSummarizeZeroCap(t *testing.T) {
 
 	got := readJSON(t, conn)
 	assert.Equal(t, "tb_error", got["op"])
-	assert.Contains(t, got["message"], "not available on your plan")
+	assert.Contains(t, got["message"], "not enabled")
 }
 
 func TestTBOpTLDRSuccess(t *testing.T) {


### PR DESCRIPTION
Rewords internal comments and a couple of user-facing strings to operator-neutral, framework-generic language so the codebase reads as a standalone Go framework with no deployment-specific references. **Behaviour is unchanged** — comments, docs, and strings only.

## Changes
- **Comments/strings**: vendor-neutral, framework-generic wording across `internal/` and `cmd/`. The pooled runtime is described as a generic "run N bots in one process" feature; webhook/feed endpoints are described by their role, not by a specific backend.
- **README**: refreshed the stale "Project layout" to match the current package tree (`server`, `ident`, `statepush`, `messages`, `messagesink`, `activity`, command/budget refresh) and all `cmd/` binaries. Coverage badge/text aligned with the real 94% gate.
- **.env.example**: set `TURBORG_CUSTOM_COMMANDS_MAX=-1` so a copied `.env` actually loads `TURBORG_COMMANDS` — the default `0` rejects every command (self-host footgun).
- **docs/**: neutral wording in `gateway.md` and `connectors/irc.md`.
- **Tests**: neutral fixtures (generic hostnames) + assertions updated for the reworded strings. Minor gofmt.

## Verification
`gofmt` clean · `go vet` · `go build` · `make test` (race + goleak) · `make cover-gate` 94.4% (gate 94%) · `make lint` 0 issues.