### PR TITLE
feat(egress): per-tenant source-IP bind for pooled egress round-robin

### DIFF
--- a/internal/connector/irc/client.go
+++ b/internal/connector/irc/client.go
@@ -50,16 +50,24 @@ func (c *Client) LocalPort() int {
 	return 0
 }
 
-func Dial(ctx context.Context, host string, port int, useTLS bool) (*Client, error) {
-	return dial(ctx, host, port, useTLS, nil)
+func Dial(ctx context.Context, host string, port int, useTLS bool, sourceIP string) (*Client, error) {
+	return dial(ctx, host, port, useTLS, sourceIP, nil)
 }
 
 // dial is the internal Dial that accepts a custom *tls.Config. Tests
 // supply one with InsecureSkipVerify against a self-signed listener so
 // the TLS path can be exercised without setting up a real cert chain.
 // Production callers go through Dial, which passes nil → defaults.
-func dial(ctx context.Context, host string, port int, useTLS bool, tlsCfg *tls.Config) (*Client, error) {
+//
+// sourceIP, when a valid IP, is bound as the connection's local address so the
+// host SNAT egresses on the tenant's assigned public IP (pooled per-tenant
+// egress). Empty / unparseable → default route.
+func dial(ctx context.Context, host string, port int, useTLS bool, sourceIP string, tlsCfg *tls.Config) (*Client, error) {
 	addr := fmt.Sprintf("%s:%d", host, port)
+	nd := net.Dialer{}
+	if ip := net.ParseIP(sourceIP); ip != nil {
+		nd.LocalAddr = &net.TCPAddr{IP: ip}
+	}
 	var conn net.Conn
 	var err error
 	if useTLS {
@@ -67,10 +75,9 @@ func dial(ctx context.Context, host string, port int, useTLS bool, tlsCfg *tls.C
 		if cfg == nil {
 			cfg = &tls.Config{MinVersion: tls.VersionTLS12}
 		}
-		d := &tls.Dialer{Config: cfg}
+		d := &tls.Dialer{NetDialer: &nd, Config: cfg}
 		conn, err = d.DialContext(ctx, "tcp", addr)
 	} else {
-		var nd net.Dialer
 		conn, err = nd.DialContext(ctx, "tcp", addr)
 	}
 	if err != nil {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -661,7 +661,7 @@ func (c *Connector) bringUp(ctx context.Context) error {
 		dialTimeout = 20 * time.Second
 	}
 	dctx, cancel := context.WithTimeout(ctx, dialTimeout)
-	cli, err := Dial(dctx, c.settings.Hostname, c.settings.Port, c.settings.UseTLS)
+	cli, err := Dial(dctx, c.settings.Hostname, c.settings.Port, c.settings.UseTLS, c.settings.SourceIP)
 	cancel()
 	if err != nil {
 		c.classifyFallback(ctx, err)

--- a/internal/connector/irc/dial_sourceip_test.go
+++ b/internal/connector/irc/dial_sourceip_test.go
@@ -1,0 +1,56 @@
+package irc_test
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+func listenLocal(t *testing.T) (int, <-chan string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+	remote := make(chan string, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			remote <- ""
+			return
+		}
+		defer func() { _ = c.Close() }()
+		host, _, _ := net.SplitHostPort(c.RemoteAddr().String())
+		remote <- host
+	}()
+	_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	return port, remote
+}
+
+func TestDialBindsSourceIP(t *testing.T) {
+	port, remote := listenLocal(t)
+
+	cli, err := irc.Dial(context.Background(), "127.0.0.1", port, false, "127.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, cli)
+
+	select {
+	case host := <-remote:
+		require.Equal(t, "127.0.0.1", host, "server must see the bound source IP")
+	case <-time.After(2 * time.Second):
+		t.Fatal("no connection accepted")
+	}
+}
+
+func TestDialIgnoresInvalidSourceIP(t *testing.T) {
+	port, _ := listenLocal(t)
+	// An unparseable source IP must be ignored (no bind), not fail the dial.
+	cli, err := irc.Dial(context.Background(), "127.0.0.1", port, false, "not-an-ip")
+	require.NoError(t, err)
+	require.NotNil(t, cli)
+}

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -484,7 +484,7 @@ func TestDialTLSPathRoundtrips(t *testing.T) {
 	// InsecureSkipVerify since this is a test-only path. Production
 	// callers go through Dial() which never sets this flag.
 	insecure := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true} //nolint:gosec
-	client, err := dial(context.Background(), host, port, true, insecure)
+	client, err := dial(context.Background(), host, port, true, "", insecure)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 	require.NoError(t, client.Close())

--- a/internal/connector/irc/settings.go
+++ b/internal/connector/irc/settings.go
@@ -19,6 +19,13 @@ type Settings struct {
 	Port     int    `env:"PORT"     envDefault:"6697"`
 	UseTLS   bool   `env:"USE_TLS"  envDefault:"true"`
 
+	// SourceIP, when set, is bound as the local address of the outbound IRC
+	// connection so the host SNAT (matched by source subnet) egresses on the
+	// tenant's assigned public IP. Empty = default route (single-IP hosts,
+	// unconfigured). Set by the pooled runtime per-tenant; also overridable via
+	// env for a dedicated/self-host bind.
+	SourceIP string `env:"SOURCE_IP"`
+
 	Nick     string `env:"NICK,required"`
 	Username string `env:"USERNAME"`
 	RealName string `env:"REAL_NAME" envDefault:"turborg agent"`

--- a/internal/server/egress.go
+++ b/internal/server/egress.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"net"
+	"os"
+	"strings"
+	"sync"
+)
+
+// egressResolver maps a tenant's assigned public egress IP to the pool
+// container's own local source IP on the matching egress network, so the IRC
+// connector can bind it (the host SNAT then egresses on the public IP).
+//
+// TURBORG_EGRESS_MAP is a static `<public-ip>=<subnet-cidr>` list the sidecar
+// injects (one entry per egress network the pool is attached to). The pool's
+// own address inside that subnet is discovered at runtime from its interfaces —
+// so the map needs only the subnets (known at create time), not the pool's
+// per-network IPs (assigned after the extra networks are connected).
+type egressResolver struct {
+	once    sync.Once
+	subnets map[string]*net.IPNet // public IP -> subnet
+}
+
+// defaultEgressResolver reads TURBORG_EGRESS_MAP once, lazily.
+var defaultEgressResolver = &egressResolver{}
+
+// resolveSourceIP returns the local source IP to bind for a tenant assigned
+// publicIP, or "" to use the default route — the graceful path when egress
+// mapping is unconfigured, the public IP is unknown, or the pool has no
+// interface in that subnet (e.g. it wasn't attached to that egress network).
+func (r *egressResolver) resolveSourceIP(publicIP string) string {
+	if publicIP == "" {
+		return ""
+	}
+	r.once.Do(r.parse)
+	subnet := r.subnets[publicIP]
+	if subnet == nil {
+		return ""
+	}
+	return localIPInSubnet(subnet)
+}
+
+func (r *egressResolver) parse() {
+	r.subnets = map[string]*net.IPNet{}
+	for _, pair := range strings.Split(os.Getenv("TURBORG_EGRESS_MAP"), ",") {
+		pub, cidr, ok := strings.Cut(strings.TrimSpace(pair), "=")
+		if !ok {
+			continue
+		}
+		if _, ipnet, err := net.ParseCIDR(strings.TrimSpace(cidr)); err == nil {
+			r.subnets[strings.TrimSpace(pub)] = ipnet
+		}
+	}
+}
+
+// localIPInSubnet returns this process's IPv4 address that falls inside subnet,
+// or "" when none does.
+func localIPInSubnet(subnet *net.IPNet) string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if ip := ipnet.IP.To4(); ip != nil && subnet.Contains(ip) {
+			return ip.String()
+		}
+	}
+	return ""
+}

--- a/internal/server/egress_test.go
+++ b/internal/server/egress_test.go
@@ -1,0 +1,42 @@
+package server
+
+import "testing"
+
+func TestEgressResolverResolvesToLocalIPInSubnet(t *testing.T) {
+	// Map a (documentation-range) public IP to the loopback subnet; the resolver
+	// must discover this process's 127.0.0.1 inside it. A second entry points at a
+	// subnet this host has no interface in → no source IP.
+	t.Setenv("TURBORG_EGRESS_MAP", "203.0.113.7=127.0.0.0/8,198.51.100.9=10.255.255.0/24")
+	r := &egressResolver{}
+
+	if got := r.resolveSourceIP("203.0.113.7"); got != "127.0.0.1" {
+		t.Fatalf("resolveSourceIP(mapped→loopback) = %q; want 127.0.0.1", got)
+	}
+	if got := r.resolveSourceIP("198.51.100.9"); got != "" {
+		t.Fatalf("resolveSourceIP(no local iface in subnet) = %q; want empty", got)
+	}
+}
+
+func TestEgressResolverGracefulMisses(t *testing.T) {
+	t.Setenv("TURBORG_EGRESS_MAP", "203.0.113.7=127.0.0.0/8,bad-entry,=skip,nope=not-a-cidr")
+	r := &egressResolver{}
+
+	if got := r.resolveSourceIP(""); got != "" {
+		t.Fatalf("empty public IP = %q; want empty", got)
+	}
+	if got := r.resolveSourceIP("9.9.9.9"); got != "" {
+		t.Fatalf("unmapped public IP = %q; want empty", got)
+	}
+	// Malformed entries are skipped, the valid one still resolves.
+	if got := r.resolveSourceIP("203.0.113.7"); got != "127.0.0.1" {
+		t.Fatalf("valid entry alongside malformed = %q; want 127.0.0.1", got)
+	}
+}
+
+func TestEgressResolverEmptyMap(t *testing.T) {
+	t.Setenv("TURBORG_EGRESS_MAP", "")
+	r := &egressResolver{}
+	if got := r.resolveSourceIP("203.0.113.7"); got != "" {
+		t.Fatalf("no map configured = %q; want empty", got)
+	}
+}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -325,6 +325,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 	gatewayToken := t.spec.GatewayToken
 	ignoredNicks := t.spec.IgnoredNicks
 	cmds := t.spec.Commands
+	egressIP := t.spec.EgressIP
 	t.mu.Unlock()
 
 	for _, cs := range connectors {
@@ -339,6 +340,14 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// the single-instance binary gets from env (QUIT brand + CTCP / bouncer
 			// auth-failure tightening) — all sourced from the tenant feed's caps.
 			t.applyTierSettings(settings, caps)
+			// Bind the tenant's assigned egress IP so its outbound IRC leaves on
+			// the right public IP (per-tenant egress round-robin). Empty/unresolved
+			// → default route; see egress.go.
+			if egressIP != "" {
+				if src := defaultEgressResolver.resolveSourceIP(egressIP); src != "" {
+					settings.SourceIP = src
+				}
+			}
 			// Wire the connector to the tenant-owned agent bus: the bouncer's
 			// outbound observer and the connector's join/part/topic/state events
 			// publish here, and the web gateway subscribes to the same bus so the

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -55,6 +55,13 @@ type TenantSpec struct {
 	// gateway is not built. The web router's StaticPasswordVerifier checks the
 	// `?token=` query against it.
 	GatewayToken string `json:"gateway_token,omitempty"`
+
+	// EgressIP is the tenant's assigned public egress IP (accounts-api's
+	// host_ip_id). The pool resolves it to its own local source IP on the
+	// matching egress network (via TURBORG_EGRESS_MAP) and binds the IRC dial to
+	// it, so the host SNAT egresses on this IP. Empty → default route (single-IP
+	// hosts / unconfigured).
+	EgressIP string `json:"egress_ip,omitempty"`
 }
 
 // PlanCapabilities is the per-tenant capability limits the pooled runtime


### PR DESCRIPTION
Pooled tenants all egressed the pool's single network IP, so one abuse G-line could take a whole free tier down. accounts-api already pins each pooled tenant to a tier IP (`host_ip_id`); this makes the pool honor it.

- `TenantSpec.EgressIP`; `buildConnectors` resolves it to the pool's own local IP in that subnet (`TURBORG_EGRESS_MAP`, self-discovered from interfaces) → `Settings.SourceIP`.
- `dial` binds `net.Dialer.LocalAddr` (+ `tls.Dialer.NetDialer`); the host SNAT (by source subnet) egresses on the assigned public IP.
- Empty/unresolved `egress_ip` → default route (single-IP hosts / unconfigured pools unchanged).

**Validated on prod**: binding the us1b pool IP egresses `15.204.165.51`. Coverage gate + lint pass. Pairs with sidecar `feat/pooled-egress-multihome`, accounts-api `feat/pooled-egress-emit`, infra `feat/pooled-egress-infra`. Gated: no-op until the sidecar multi-homes + accounts-api emits.