### PR TITLE
fix(server): apply ignore-list edits in place without a reconnect

### DIFF
--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -199,6 +199,18 @@ func ApplyCommands(a *agent.Agent, defs []commands.Definition, provider llm.Prov
 	a.Commands.ReplaceDynamic(built)
 }
 
+// ApplyRegistryGuard rebuilds the registry-wide guard (ignore list + per-sender
+// command throttle) from p and swaps it onto a running agent. It lets an
+// operator's ignore-list edit take effect in place — no connection teardown —
+// the same way ApplyCommands hot-swaps the command set. The swap is atomic via
+// the registry's internal lock, so it is safe to call while the agent
+// dispatches. The throttle is rebuilt from p, so its window counters reset;
+// that is acceptable for an infrequent settings change and avoids threading a
+// live throttle through the swap.
+func ApplyRegistryGuard(a *agent.Agent, p GuardParams) {
+	a.Commands.SetGuard(buildRegistryGuard(p))
+}
+
 // BuildBudgetedProvider wraps an llm.Provider with rolling-24h budget
 // enforcement when caps are set. The onUsage callback emits the
 // structured llm_usage log (for external scraping) and publishes

--- a/internal/server/hot_reload_test.go
+++ b/internal/server/hot_reload_test.go
@@ -301,3 +301,133 @@ func waitStr(t *testing.T, ch <-chan string) string {
 		return ""
 	}
 }
+
+func TestLiveUpdatableOnlyChangeAllowsIgnoreEdit(t *testing.T) {
+	base := specWithChannel("x", "#one")
+	base.IgnoredNicks = []string{"alice"}
+
+	// Only the ignore list moved — applicable in place, no reconnect.
+	ignoreEdit := specWithChannel("x", "#one")
+	ignoreEdit.IgnoredNicks = []string{"alice", "spammer"}
+	require.True(t, liveUpdatableOnlyChange(base, ignoreEdit),
+		"an ignore-list edit must be applied without a reconnect")
+
+	// An ignore edit alongside a connector change must still force a restart.
+	ignoreAndChannel := specWithChannel("x", "#two")
+	ignoreAndChannel.IgnoredNicks = ignoreEdit.IgnoredNicks
+	require.False(t, liveUpdatableOnlyChange(base, ignoreAndChannel),
+		"a connector change alongside an ignore edit is not live-updatable-only")
+}
+
+func TestReloadGuardFallsBackWhenNotRunning(t *testing.T) {
+	tn := &Tenant{ID: "t1", log: testLogger()}
+	require.False(t, tn.reloadGuard(),
+		"no live agent → guard reload defers to a restart")
+}
+
+// TestReloadGuardSwapsIgnoreInPlace is the fix: toggling the ignore list swaps
+// the registry-wide guard on the live agent with no reconnect, so an ignored
+// sender is blocked and an un-ignored one is allowed again immediately.
+func TestReloadGuardSwapsIgnoreInPlace(t *testing.T) {
+	a := agent.NewWithPrefix(testLogger(), "!")
+	a.Commands.SetMaxDynamic(-1)
+	cfg := &irc.Settings{Hostname: "irc.example", Nick: "bot"}
+	cfg.ApplyDefaults()
+	conn := irc.New(cfg, testLogger(), a.Events)
+	tn := &Tenant{
+		ID:  "t1",
+		log: testLogger(),
+		spec: TenantSpec{
+			Connectors: []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "self"}}},
+		},
+		agentRef: a,
+		ircConn:  conn,
+	}
+	require.True(t, tn.reloadCommands([]commands.Definition{staticCmd("ping", "pong")}))
+
+	ctx := context.Background()
+	send := func(sender string) bool {
+		out, err := a.Commands.Dispatch(ctx, &agent.InboundEnvelope{Text: "!ping", Sender: sender})
+		require.NoError(t, err)
+		return out != nil
+	}
+
+	// No ignore list yet → the sender is allowed.
+	require.True(t, tn.reloadGuard())
+	require.True(t, send("spammer"), "no ignore list → sender is allowed")
+
+	// Operator ignores the sender: the guard swaps in place, no reconnect.
+	tn.mu.Lock()
+	tn.spec.IgnoredNicks = []string{"spammer"}
+	tn.mu.Unlock()
+	require.True(t, tn.reloadGuard())
+	require.False(t, send("spammer"), "after the in-place swap the ignored sender is blocked")
+	require.True(t, send("alice"), "a non-ignored sender stays allowed")
+
+	// Operator un-ignores: the guard swaps back, the sender is allowed again.
+	tn.mu.Lock()
+	tn.spec.IgnoredNicks = nil
+	tn.mu.Unlock()
+	require.True(t, tn.reloadGuard())
+	require.True(t, send("spammer"), "after un-ignore the sender is allowed again")
+}
+
+// TestUpdateIgnoreOnlyReloadsWithoutRestart is the no-reconnect deliverable for
+// ignore edits: changing ONLY the ignore list swaps the live guard in place; the
+// work loop is never re-run, so the IRC session (and attached clients) survive.
+func TestUpdateIgnoreOnlyReloadsWithoutRestart(t *testing.T) {
+	var runs atomic.Int32
+	base := TenantSpec{
+		TurborgID:   "x",
+		RuntimeMode: "pooled",
+		Connectors:  []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "self"}, Secrets: map[string]any{}}},
+	}
+
+	events := make(chan TenantEvent)
+	src := &StaticSource{Tenants: []TenantSpec{base}, Events: events}
+	srv := New(src, testLogger())
+	srv.workFactory = func(tn *Tenant) func(context.Context) error {
+		return func(ctx context.Context) error {
+			runs.Add(1)
+			// Publish a live agent so an in-place guard reload can find it.
+			a := agent.NewWithPrefix(tn.log, "!")
+			a.Commands.SetMaxDynamic(-1)
+			cfg := &irc.Settings{Hostname: "irc.example", Nick: "bot"}
+			cfg.ApplyDefaults()
+			conn := irc.New(cfg, tn.log, a.Events)
+			tn.mu.Lock()
+			tn.agentRef = a
+			tn.ircConn = conn
+			tn.mu.Unlock()
+			<-ctx.Done()
+			tn.mu.Lock()
+			tn.agentRef = nil
+			tn.ircConn = nil
+			tn.mu.Unlock()
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return runs.Load() == 1 }, 2*time.Second, 5*time.Millisecond)
+
+	// Ignore-only upsert: must reload the guard in place, not restart.
+	ignoreSpec := base
+	ignoreSpec.IgnoredNicks = []string{"spammer"}
+	events <- TenantEvent{Kind: TenantUpserted, Spec: ignoreSpec}
+	require.Never(t, func() bool { return runs.Load() != 1 }, 200*time.Millisecond, 20*time.Millisecond,
+		"an ignore-only change must never restart the work loop")
+
+	// A connector change still restarts.
+	chSpec := ignoreSpec
+	chSpec.Connectors = []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "self", "channels": []any{"#two"}}, Secrets: map[string]any{}}}
+	events <- TenantEvent{Kind: TenantUpserted, Spec: chSpec}
+	require.Eventually(t, func() bool { return runs.Load() == 2 }, 2*time.Second, 10*time.Millisecond,
+		"a connector change must restart the work loop")
+
+	cancel()
+	require.ErrorIs(t, <-done, context.Canceled)
+}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -577,15 +577,22 @@ func (t *Tenant) update(spec TenantSpec) {
 	// change to it alone is a no-op here. A command-set change still reloads in
 	// place. Anything else falls through to a restart.
 	if liveUpdatableOnlyChange(prev, spec) {
-		if commandSetsEqual(prev.Commands, spec.Commands) {
+		commandsChanged := !commandSetsEqual(prev.Commands, spec.Commands)
+		ignoresChanged := !reflect.DeepEqual(prev.IgnoredNicks, spec.IgnoredNicks)
+		if !commandsChanged && !ignoresChanged {
 			return // only the usage baseline moved — nothing to reconnect for
 		}
-		if t.reloadCommands(spec.Commands) {
-			t.log.Info("tenant commands reloaded in place", "commands", len(spec.Commands))
+		// Apply each changed facet in place. The command set swaps via
+		// ReplaceDynamic; the ignore list swaps the registry-wide guard. Either
+		// returning false means the tenant isn't running, so fall through to a
+		// restart that re-seeds everything from the new spec at build time.
+		okCommands := !commandsChanged || t.reloadCommands(spec.Commands)
+		okIgnores := !ignoresChanged || t.reloadGuard()
+		if okCommands && okIgnores {
+			t.log.Info("tenant settings reloaded in place",
+				"commands", len(spec.Commands), "ignored", len(spec.IgnoredNicks))
 			return
 		}
-		// Not currently running — fall through to a restart, which re-seeds the
-		// budget from the new spec at build time.
 	}
 
 	t.log.Info("tenant spec changed; restarting", "connectors", t.connectorTypes())
@@ -611,11 +618,14 @@ func commandsOnlyChange(a, b TenantSpec) bool {
 
 // liveUpdatableOnlyChange reports whether two differing specs differ in nothing
 // but fields that can be applied to a running tenant WITHOUT a reconnect: the
-// command set and the LLM-usage baseline (llm_*_tokens_used, which the feed
-// refreshes continuously). Both the command set and the baseline are zeroed
-// before comparison so a change confined to them returns true.
+// command set, the ignore list, and the LLM-usage baseline (llm_*_tokens_used,
+// which the feed refreshes continuously). The command set, the ignore list, and
+// the baseline are zeroed before comparison so a change confined to them returns
+// true. The ignore list only feeds the registry-wide command guard, which can be
+// hot-swapped in place, so an ignore edit must not drop the connection.
 func liveUpdatableOnlyChange(a, b TenantSpec) bool {
 	a.Commands, b.Commands = nil, nil
+	a.IgnoredNicks, b.IgnoredNicks = nil, nil
 	a.PlanCapabilities = capsWithoutTokenUsage(a.PlanCapabilities)
 	b.PlanCapabilities = capsWithoutTokenUsage(b.PlanCapabilities)
 	return reflect.DeepEqual(a, b)
@@ -669,6 +679,33 @@ func (t *Tenant) reloadCommands(defs []commands.Definition) bool {
 	platform, _, _ := splitNetwork(stringField(cs.Config, "network"))
 	// Same in-place swap the single-instance runtime's command refresher uses.
 	runtime.ApplyCommands(a, defs, t.llmProvider, owner, platform, t.log)
+	return true
+}
+
+// reloadGuard rebuilds the registry-wide guard (ignore list + per-sender
+// command throttle) and swaps it onto the live agent without a reconnect, so an
+// ignore-list edit takes effect in place. The throttle window is sourced from
+// the current caps so it is preserved across the swap. Returns false when the
+// tenant isn't running (no live agent), so the caller falls back to a restart.
+func (t *Tenant) reloadGuard() bool {
+	t.mu.Lock()
+	a := t.agentRef
+	caps := t.spec.PlanCapabilities
+	ignoredNicks := t.spec.IgnoredNicks
+	t.mu.Unlock()
+	if a == nil {
+		return false
+	}
+
+	var cmdMax, cmdWin int
+	if caps != nil {
+		cmdMax, cmdWin = caps.CommandMaxPerWindow, caps.CommandWindowSeconds
+	}
+	runtime.ApplyRegistryGuard(a, runtime.GuardParams{
+		IgnoredNicks:         ignoredNicks,
+		CommandMaxPerWindow:  cmdMax,
+		CommandWindowSeconds: cmdWin,
+	})
 	return true
 }
 


### PR DESCRIPTION
## Problem

Toggling an operator's ignore list on a running tenant dropped the IRC session: the work loop re-ran (reconnect), disturbing the connection and any attached clients. `update()` only treated a command-set change as live-updatable; any other spec delta — including `IgnoredNicks` — fell through to a restart.

The ignore list only feeds the registry-wide command guard (`buildRegistryGuard`), which is set via `CommandRegistry.SetGuard` and read under the registry's lock during dispatch — so it can be swapped while the agent runs, no reconnect needed.

## Change

- `runtime.ApplyRegistryGuard` — rebuilds the registry-wide guard (ignore list + per-sender command throttle) and atomically swaps it onto a running agent, mirroring how `ApplyCommands` hot-swaps the command set.
- `Tenant.reloadGuard` — sources the throttle window from the current caps so it is preserved across the swap; returns false when the tenant isn't running so the caller falls back to a restart.
- `update()` now applies a command and/or ignore-list delta in place; `liveUpdatableOnlyChange` treats an ignore-only delta as live-updatable. Connection-affecting changes still restart.

## Tests

- `TestLiveUpdatableOnlyChangeAllowsIgnoreEdit` — ignore-only delta is live-updatable; ignore + connector change still restarts.
- `TestReloadGuardSwapsIgnoreInPlace` — ignore then un-ignore both take effect on the live agent (sender blocked, then allowed again).
- `TestReloadGuardFallsBackWhenNotRunning` — defers to restart with no live agent.
- `TestUpdateIgnoreOnlyReloadsWithoutRestart` — an ignore-only upsert never re-runs the work loop; a connector change still does.

`make lint` clean, `make test` (`-race`) green, coverage gate PASS (94.2%).