### PR TITLE
fix(web): set Prometheus exposition Content-Type on /metrics

### DIFF
--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -474,7 +474,7 @@ func (g *Gateway) handleHealth(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (g *Gateway) handleMetrics(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 	g.metMu.Lock()
 	conns := g.metrics.connections
 	fails := g.metrics.authFailures


### PR DESCRIPTION
## Summary

  Sets the `/metrics` handler to send the Prometheus text exposition Content-Type
  (`text/plain; version=0.0.4; charset=utf-8`) instead of plain `text/plain`, so
  Prometheus scrapers and format validators accept the endpoint.

  Closes #93

  ## Type of change

  - [ ] `feat` — new feature
  - [x] `fix` — bug fix
  - [ ] `refactor` — internal change, no user-visible behavior change
  - [ ] `docs` — documentation only
  - [ ] `test` — tests only
  - [ ] `chore` — tooling, CI, deps
  - [ ] `perf` — performance improvement
  - [ ] `breaking change` — incompatible API change (mark in commit footer)

  ## Test plan

  - Start the gateway and request the endpoint: `curl -i http://<host>:8765/metrics`
  - Confirm the response header reads
    `Content-Type: text/plain; version=0.0.4; charset=utf-8`
  - Confirm the metric body is unchanged (same counters/gauges as before)

  ## Checklist

  - [ ] Tests added or updated — not yet; offering to add a header assertion if wanted
  - [ ] Coverage is still ≥ 90% (`make cover-gate`) — relying on CI to confirm
  - [ ] `make lint test` is green locally — edited in browser; relying on CI
  - [x] Documentation updated if user-facing behavior changed — N/A (no doc-facing change)
