### PR TITLE
fix(connector/irc): register ident before the TLS handshake

### DIFF
--- a/internal/connector/irc/client.go
+++ b/internal/connector/irc/client.go
@@ -17,6 +17,13 @@ type Client struct {
 	reader *bufio.Reader
 	wmu    sync.Mutex
 
+	// tlsCfg non-nil means the TLS handshake is deferred: Dial returned right
+	// after the bare TCP connect — so the local source port is already known —
+	// and Handshake completes the negotiation. nil means plaintext, or the
+	// handshake already ran. ServerName is filled in by dial so the deferred
+	// Handshake still verifies the cert hostname.
+	tlsCfg *tls.Config
+
 	logMu sync.RWMutex
 	log   *slog.Logger
 }
@@ -68,25 +75,55 @@ func dial(ctx context.Context, host string, port int, useTLS bool, sourceIP stri
 	if ip := net.ParseIP(sourceIP); ip != nil {
 		nd.LocalAddr = &net.TCPAddr{IP: ip}
 	}
-	var conn net.Conn
-	var err error
+	// Always establish the bare TCP connection first, even for TLS. The local
+	// source port is assigned at connect, and an IRC server probes our :113
+	// ident the moment it accepts the TCP connection — i.e. before our TLS
+	// handshake finishes. Returning here lets the caller register that port with
+	// the ident responder, then complete the handshake via Handshake(). Folding
+	// the handshake into the dial (the old tls.Dialer path) registered the port
+	// only after the handshake and lost the race, yielding a ~-prefixed ident.
+	conn, err := nd.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("irc dial %s: %w", addr, err)
+	}
+	c := &Client{
+		conn:   conn,
+		reader: bufio.NewReaderSize(conn, 4096),
+	}
 	if useTLS {
 		cfg := tlsCfg
 		if cfg == nil {
 			cfg = &tls.Config{MinVersion: tls.VersionTLS12}
 		}
-		d := &tls.Dialer{NetDialer: &nd, Config: cfg}
-		conn, err = d.DialContext(ctx, "tcp", addr)
-	} else {
-		conn, err = nd.DialContext(ctx, "tcp", addr)
+		// tls.Dialer auto-filled ServerName from the dial host; tls.Client does
+		// not, so set it ourselves or cert verification fails. Clone first to
+		// avoid mutating a caller-supplied config.
+		if cfg.ServerName == "" {
+			cfg = cfg.Clone()
+			cfg.ServerName = host
+		}
+		c.tlsCfg = cfg
 	}
-	if err != nil {
-		return nil, fmt.Errorf("irc dial %s: %w", addr, err)
+	return c, nil
+}
+
+// Handshake completes a deferred TLS handshake on a connection returned by Dial,
+// and is a no-op on a plaintext connection. Separating it from the TCP connect
+// is what lets the caller register the (already-assigned) local source port with
+// the ident responder before the IRC server's :113 probe — which arrives on
+// TCP-accept, ahead of this handshake — has to be answered.
+func (c *Client) Handshake(ctx context.Context) error {
+	if c.tlsCfg == nil {
+		return nil
 	}
-	return &Client{
-		conn:   conn,
-		reader: bufio.NewReaderSize(conn, 4096),
-	}, nil
+	tlsConn := tls.Client(c.conn, c.tlsCfg)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return fmt.Errorf("irc tls handshake %s: %w", c.tlsCfg.ServerName, err)
+	}
+	c.conn = tlsConn
+	c.reader = bufio.NewReaderSize(tlsConn, 4096)
+	c.tlsCfg = nil
+	return nil
 }
 
 func (c *Client) WriteLine(line string) error {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -296,11 +296,24 @@ func (c *Connector) SetIdentReporter(r IdentReporter) { c.identReporter = r }
 func (c *Connector) setClient(cli *Client) {
 	c.clientMu.Lock()
 	c.client = cli
-	oldPort := c.identPort
+	c.clientMu.Unlock()
+
 	newPort := 0
 	if cli != nil {
 		newPort = cli.LocalPort()
 	}
+	c.reportIdentPort(newPort)
+}
+
+// reportIdentPort updates the RFC-1413 source-port→ident mapping, clearing the
+// previously reported port if it changed. It is split out of setClient so the
+// connector can report the port right after the TCP connect — before the TLS
+// handshake — without installing the (not-yet-usable) client for writes.
+// bringUp calls it once early, then setClient calls it again on install; the
+// repeat Set for the same port is idempotent.
+func (c *Connector) reportIdentPort(newPort int) {
+	c.clientMu.Lock()
+	oldPort := c.identPort
 	c.identPort = newPort
 	c.clientMu.Unlock()
 
@@ -662,11 +675,29 @@ func (c *Connector) bringUp(ctx context.Context) error {
 	}
 	dctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	cli, err := Dial(dctx, c.settings.Hostname, c.settings.Port, c.settings.UseTLS, c.settings.SourceIP)
-	cancel()
 	if err != nil {
+		cancel()
 		c.classifyFallback(ctx, err)
 		return err
 	}
+
+	// Register the source port with the ident responder now — after the TCP
+	// connect (the port is already assigned) but before the TLS handshake. The
+	// IRC server probes :113 the instant it accepts the TCP connection, which is
+	// during, not after, our handshake; registering here is what lets the pooled
+	// responder answer with the verified ident instead of HIDDEN-USER. On
+	// handshake failure setClient(nil) clears it again.
+	c.reportIdentPort(cli.LocalPort())
+
+	if err := cli.Handshake(dctx); err != nil {
+		cancel()
+		_ = cli.Close()
+		c.setClient(nil)
+		c.classifyFallback(ctx, err)
+		return err
+	}
+	cancel()
+
 	cli.SetLog(c.log)
 	c.setClient(cli)
 

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -487,7 +487,51 @@ func TestDialTLSPathRoundtrips(t *testing.T) {
 	client, err := dial(context.Background(), host, port, true, "", insecure)
 	require.NoError(t, err)
 	require.NotNil(t, client)
+	// dial now returns after the bare TCP connect with the handshake deferred,
+	// so the local source port is known before TLS; the port is already valid here.
+	require.NotZero(t, client.LocalPort())
+	require.NoError(t, client.Handshake(context.Background()))
 	require.NoError(t, client.Close())
+}
+
+func TestHandshakeFailsOnVerificationAndClearsIdent(t *testing.T) {
+	// A real TLS server presenting a self-signed cert. dial() with no custom
+	// config (production path) verifies the chain, so the handshake fails — and
+	// bringUp's failure path must clear the ident it registered before the
+	// handshake, leaving no stale source-port mapping behind.
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.StartTLS()
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	host, portStr, err := net.SplitHostPort(u.Host)
+	require.NoError(t, err)
+
+	client, err := dial(context.Background(), host, mustAtoi(t, portStr), true, "", nil)
+	require.NoError(t, err, "TCP connect + deferred-handshake setup must succeed")
+	port := client.LocalPort()
+	require.NotZero(t, port)
+
+	// Simulate bringUp's ordering: report the ident, then fail the handshake.
+	rep := newRecordingReporter()
+	c := New(&Settings{Nick: "x", Username: "tf1dcv74w"}, nil, nil)
+	c.SetIdentReporter(rep)
+	c.reportIdentPort(port)
+	require.Equal(t, "tf1dcv74w", rep.set[port])
+
+	require.Error(t, client.Handshake(context.Background()), "self-signed cert must fail verification")
+	_ = client.Close()
+	c.setClient(nil) // bringUp's handshake-failure cleanup
+
+	require.Contains(t, rep.clear, port, "ident registered before a failed handshake must be cleared")
+}
+
+func mustAtoi(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	require.NoError(t, err)
+	return n
 }
 
 // --- Live-nick sync ---------------------------------------------------


### PR DESCRIPTION
## Problem

When connecting over TLS, the connector identified its local source port — and registered it with the ident responder — only **after** the TLS handshake completed. IRC servers, however, probe the client's `:113` ident the instant they accept the TCP connection, i.e. *during* the handshake. The probe therefore raced the registration: an RFC-1413 responder driven by `IdentReporter` had no mapping yet and fell back to `HIDDEN-USER`, leaving the user with a `~`-prefixed ident (and failing networks that require a verified ident).

The cause was `tls.Dialer`, which folds the TCP connect and the TLS handshake into a single call, so `LocalPort()` only became available once both were done.

## Fix

Split the dial:

- `dial()` now establishes the bare TCP connection (the source port is assigned at connect) and defers TLS to a new `Client.Handshake()`. It's a no-op on plaintext connections.
- `bringUp` reports the source port to the ident responder **between** the TCP connect and the handshake, so the mapping is live before the server's probe arrives.
- Ident reporting is extracted into `reportIdentPort` so the port can be registered without installing the not-yet-usable client for writes (installing it early would let attached bouncer clients write plaintext into the pre-handshake socket). On handshake failure, `setClient(nil)` clears the registration.

`tls.Client` needs `ServerName` set explicitly (`tls.Dialer` filled it in from the dial host automatically), so `dial` sets it — otherwise certificate verification would fail.

## Tests

- `TestDialTLSPathRoundtrips` updated to drive the two-phase connect → handshake flow and assert the local port is known before TLS.
- New `TestHandshakeFailsOnVerificationAndClearsIdent` covers the handshake-failure path and asserts the early registration is cleared.
- Existing `setClient` reporting tests unchanged and green.

Full suite green under `-race`; coverage gate and lint pass.