### PR TITLE
feat(statepush): include server-supplied reason in connector snapshot

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -625,6 +625,7 @@ func buildIRCSnapshot(ircConn *irc.Connector) statepush.SnapshotBuilder {
 					Since:    machine.EnteredAt().UTC(),
 					Channels: channels,
 					Nick:     nick,
+					Reason:   machine.ServerReason(),
 				},
 			},
 		}

--- a/internal/server/tenant_statepush.go
+++ b/internal/server/tenant_statepush.go
@@ -55,6 +55,7 @@ func buildIRCSnapshot(conn *irc.Connector) statepush.SnapshotBuilder {
 					Since:    machine.EnteredAt().UTC(),
 					Channels: channels,
 					Nick:     nick,
+					Reason:   machine.ServerReason(),
 				},
 			},
 		}

--- a/internal/statepush/state_emitter.go
+++ b/internal/statepush/state_emitter.go
@@ -29,7 +29,8 @@ type SnapshotBuilder func() Snapshot
 //	      "state": "registered",
 //	      "since": "2026-05-17T15:30:00Z",
 //	      "channels": [{"name": "#x", "key": null}, ...],
-//	      "nick": "stefan"
+//	      "nick": "stefan",
+//	      "reason": ""
 //	    }
 //	  }
 //	}
@@ -47,6 +48,10 @@ type ConnectorSnapshot struct {
 	Since    time.Time         `json:"since"`
 	Channels []ChannelSnapshot `json:"channels"`
 	Nick     string            `json:"nick"`
+	// Reason is the last server-supplied human-readable explanation for
+	// the current state — e.g. the disconnect/ban text an upstream sent.
+	// Empty for healthy states or when the server gave no reason.
+	Reason string `json:"reason"`
 }
 
 // ChannelSnapshot is one wanted-channel entry. Key is nullable on the

--- a/internal/statepush/state_emitter_test.go
+++ b/internal/statepush/state_emitter_test.go
@@ -113,10 +113,11 @@ func TestStateEmitter_NotifyChangeFiresPutWithZeroDebounce(t *testing.T) {
 		return statepush.Snapshot{
 			Connectors: map[string]statepush.ConnectorSnapshot{
 				"irc": {
-					State:    "registered",
+					State:    "disconnected_banned",
 					Since:    time.Unix(0, 0).UTC(),
 					Channels: []statepush.ChannelSnapshot{statepush.NewChannelSnapshot("#a", "")},
 					Nick:     "stefan",
+					Reason:   "Unsolicited advertisements/mass abuse.",
 				},
 			},
 		}
@@ -134,8 +135,9 @@ func TestStateEmitter_NotifyChangeFiresPutWithZeroDebounce(t *testing.T) {
 	var got statepush.Snapshot
 	require.NoError(t, json.Unmarshal(rec.bodyAt(0), &got))
 	require.Contains(t, got.Connectors, "irc")
-	assert.Equal(t, "registered", got.Connectors["irc"].State)
+	assert.Equal(t, "disconnected_banned", got.Connectors["irc"].State)
 	assert.Equal(t, "stefan", got.Connectors["irc"].Nick)
+	assert.Equal(t, "Unsolicited advertisements/mass abuse.", got.Connectors["irc"].Reason)
 	require.Len(t, got.Connectors["irc"].Channels, 1)
 	assert.Equal(t, "#a", got.Connectors["irc"].Channels[0].Name)
 }


### PR DESCRIPTION
## What

The IRC connector's state machine already tracks the last server-supplied reason (`ServerReason`) and surfaces it on the realtime gateway path, but the state-webhook snapshot (`statepush`) dropped it. Downstream consumers of the webhook therefore only saw a bare state string (e.g. `disconnected_banned`) with no explanation of *why*.

## Change

- Add a `reason` field to `ConnectorSnapshot` (`internal/statepush/state_emitter.go`).
- Populate it from `machine.ServerReason()` in `buildIRCSnapshot` (`internal/runtime/runtime.go`).
- Extend the emitter round-trip test to lock the new wire field.

The field is additive and defaults to an empty string for healthy states or when the server gave no reason, so existing receivers that ignore unknown fields are unaffected.

## Test

`go build ./... && go vet ./... && go test ./internal/statepush/... ./internal/runtime/...` all pass.