### PR TITLE
feat(connector/irc): reconnect hardening + nick fallback/reclaim (anti-flood)

### DIFF
--- a/cmd/turborg-server/main.go
+++ b/cmd/turborg-server/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
+	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/ident"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/logging"
@@ -116,6 +117,11 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	defer stop()
 	ctx, cancel := context.WithCancel(sigCtx)
 	defer cancel()
+
+	// Bound the per-(egress-IP, host) connection rate across all tenants so a
+	// pooled process can never flood a network from a shared egress IP
+	// (the root cause of the Undernet connection-flood G-lines).
+	irc.EnableConnectGateFromEnv()
 
 	srv := server.New(source, log)
 	// Point each tenant's connector-state emitter at the control plane (the same

--- a/cmd/turborg/main.go
+++ b/cmd/turborg/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"github.com/turborg/turborg/internal/config"
+	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/ident"
 	"github.com/turborg/turborg/internal/logging"
 	"github.com/turborg/turborg/internal/runtime"
@@ -84,6 +85,12 @@ func runE(stderr interface{ Write(p []byte) (int, error) }) error {
 	if err != nil {
 		return err
 	}
+
+	// Bound this process's connect rate per (egress IP, host). For a
+	// dedicated container this mainly spaces its own reconnects; combined
+	// with the reconnect floor it keeps a single agent from flooding a
+	// network. Shares the same env knob as the pooled runtime.
+	irc.EnableConnectGateFromEnv()
 
 	mode := "standalone"
 	if built.LLM != nil {

--- a/internal/connector/irc/client.go
+++ b/internal/connector/irc/client.go
@@ -58,6 +58,13 @@ func (c *Client) LocalPort() int {
 }
 
 func Dial(ctx context.Context, host string, port int, useTLS bool, sourceIP string) (*Client, error) {
+	// Rate-limit new connections per (egress IP, host) across the whole
+	// process so we can never flood a network from a shared egress IP,
+	// regardless of how many tenants are (re)connecting. No-op until a
+	// production main() enables the gate.
+	if err := sharedConnectGate.Wait(ctx, sourceIP+"|"+host); err != nil {
+		return nil, fmt.Errorf("irc dial %s:%d: connect gate: %w", host, port, err)
+	}
 	return dial(ctx, host, port, useTLS, sourceIP, nil)
 }
 

--- a/internal/connector/irc/connect_gate.go
+++ b/internal/connector/irc/connect_gate.go
@@ -1,0 +1,113 @@
+package irc
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultConnectGateInterval is the production per-(egress-IP, host)
+	// connect spacing. ~1 connect / 10s keeps any single egress IP well
+	// under IRC networks' connection-flood thresholds even with many
+	// tenants flapping at once.
+	DefaultConnectGateInterval = 10 * time.Second
+	// DefaultReconnectFloor is the production minimum reconnect delay —
+	// above a typical server's ghost-nick reap window so a fast reconnect
+	// after a drop never collides with our own lingering session (433).
+	DefaultReconnectFloor = 20 * time.Second
+)
+
+// connectGate bounds the rate of new upstream connections per
+// (sourceIP, host) across the whole process. The egress IP — shared by
+// every tenant a pooled process routes through it — is the unit IRC
+// networks rate-limit and G-line, so per-connector backoff alone cannot
+// protect it: N tenants each individually "behaving" still flood the
+// shared IP, which is what escalates a momentary throttle into a
+// network-wide ban. This gate serialises connects to a safe aggregate
+// rate regardless of tenant count or reconnect flapping.
+//
+// It is a per-key minimum-interval scheduler: a lone connect after a
+// quiet period fires immediately; rapid successive connects to the same
+// key queue at one per interval. Acquire honours the caller's context so
+// shutdown unblocks promptly.
+//
+// interval <= 0 disables the gate (Wait is a no-op) — the default, so
+// unit tests that construct connectors directly are unaffected. The
+// production main() enables it via EnableConnectGate.
+type connectGate struct {
+	mu       sync.Mutex
+	interval time.Duration
+	nextFree map[string]time.Time
+}
+
+func newConnectGate(interval time.Duration) *connectGate {
+	return &connectGate{interval: interval, nextFree: map[string]time.Time{}}
+}
+
+// sharedConnectGate is the process-wide gate every Dial routes through.
+// Disabled (interval 0) until EnableConnectGate is called by main().
+var sharedConnectGate = newConnectGate(0)
+
+// EnableConnectGate sets the process-wide per-(egress-IP, host) connect
+// interval. Called once at startup by the production binaries; left at 0
+// (disabled) in tests. A non-positive interval disables the gate.
+func EnableConnectGate(interval time.Duration) {
+	sharedConnectGate.setInterval(interval)
+}
+
+// EnableConnectGateFromEnv enables the gate using
+// TURBORG_IRC_CONNECT_GATE_INTERVAL (a Go duration, e.g. "10s"), falling
+// back to DefaultConnectGateInterval. Set the env to "0" to disable.
+// Called once from each production main().
+func EnableConnectGateFromEnv() {
+	d := DefaultConnectGateInterval
+	if v := os.Getenv("TURBORG_IRC_CONNECT_GATE_INTERVAL"); v != "" {
+		if p, err := time.ParseDuration(v); err == nil && p >= 0 {
+			d = p
+		}
+	}
+	EnableConnectGate(d)
+}
+
+func (g *connectGate) setInterval(d time.Duration) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.interval = d
+}
+
+// reserve returns how long the caller must wait before connecting under
+// key, and advances the key's schedule by one interval. A connect after
+// the key has been idle returns 0; bursts queue at one per interval.
+func (g *connectGate) reserve(key string, now time.Time) time.Duration {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.interval <= 0 {
+		return 0
+	}
+	nf := g.nextFree[key]
+	if nf.Before(now) {
+		nf = now
+	}
+	wait := nf.Sub(now)
+	g.nextFree[key] = nf.Add(g.interval)
+	return wait
+}
+
+// Wait blocks until the gate admits a new connection for key, or ctx is
+// done (returning ctx.Err()).
+func (g *connectGate) Wait(ctx context.Context, key string) error {
+	d := g.reserve(key, time.Now())
+	if d <= 0 {
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/connector/irc/connect_gate_test.go
+++ b/internal/connector/irc/connect_gate_test.go
@@ -49,6 +49,62 @@ func TestConnectGate_KeysAreIndependent(t *testing.T) {
 	}
 }
 
+func TestConnectGate_SetIntervalTakesEffect(t *testing.T) {
+	g := newConnectGate(0)
+	now := time.Now()
+	if d := g.reserve("ip|host", now); d != 0 {
+		t.Fatalf("disabled gate must return 0, got %v", d)
+	}
+	g.setInterval(5 * time.Second)
+	// First reserve after enabling is immediate; the second queues.
+	_ = g.reserve("ip|host", now)
+	if d := g.reserve("ip|host", now); d != 5*time.Second {
+		t.Fatalf("after setInterval, burst must queue at the interval, got %v", d)
+	}
+}
+
+func TestConnectGate_EnableHelpers(t *testing.T) {
+	// These mutate the process-wide gate; restore it disabled afterwards so
+	// other tests (which expect the gate inert) are unaffected.
+	t.Cleanup(func() { EnableConnectGate(0) })
+
+	// Use a fixed `now` so the queued delay is exact (real time advancing
+	// between the two reserve calls would shave microseconds off).
+	now := time.Now()
+	EnableConnectGate(3 * time.Second)
+	_ = sharedConnectGate.reserve("k|h", now)
+	if d := sharedConnectGate.reserve("k|h", now); d != 3*time.Second {
+		t.Fatalf("EnableConnectGate did not set the interval, got %v", d)
+	}
+
+	t.Setenv("TURBORG_IRC_CONNECT_GATE_INTERVAL", "7s")
+	EnableConnectGateFromEnv()
+	_ = sharedConnectGate.reserve("k2|h", now)
+	if d := sharedConnectGate.reserve("k2|h", now); d != 7*time.Second {
+		t.Fatalf("EnableConnectGateFromEnv did not honor env, got %v", d)
+	}
+
+	// Invalid env falls back to the default.
+	t.Setenv("TURBORG_IRC_CONNECT_GATE_INTERVAL", "not-a-duration")
+	EnableConnectGateFromEnv()
+	_ = sharedConnectGate.reserve("k3|h", now)
+	if d := sharedConnectGate.reserve("k3|h", now); d != DefaultConnectGateInterval {
+		t.Fatalf("invalid env must fall back to default, got %v", d)
+	}
+}
+
+func TestConnectGate_WaitAdmitsAfterInterval(t *testing.T) {
+	g := newConnectGate(30 * time.Millisecond)
+	g.reserve("ip|host", time.Now()) // burn the immediate slot
+	start := time.Now()
+	if err := g.Wait(context.Background(), "ip|host"); err != nil {
+		t.Fatalf("Wait should admit after the interval, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 15*time.Millisecond {
+		t.Fatalf("Wait returned too early (%v) — it should have blocked ~1 interval", elapsed)
+	}
+}
+
 func TestConnectGate_WaitHonorsContext(t *testing.T) {
 	g := newConnectGate(time.Hour) // long enough that only ctx unblocks
 	// Burn the immediate slot so the next Wait must block.

--- a/internal/connector/irc/connect_gate_test.go
+++ b/internal/connector/irc/connect_gate_test.go
@@ -1,0 +1,66 @@
+package irc
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestConnectGate_DisabledIsNoOp(t *testing.T) {
+	g := newConnectGate(0)
+	now := time.Now()
+	// Even a burst of reserves on the same key all return 0 when disabled.
+	for i := 0; i < 5; i++ {
+		if d := g.reserve("ip|host", now); d != 0 {
+			t.Fatalf("disabled gate must return 0, got %v on attempt %d", d, i)
+		}
+	}
+	if err := g.Wait(context.Background(), "ip|host"); err != nil {
+		t.Fatalf("disabled gate Wait must not block/err: %v", err)
+	}
+}
+
+func TestConnectGate_SerializesBurstPerKey(t *testing.T) {
+	const interval = 10 * time.Second
+	g := newConnectGate(interval)
+	now := time.Now()
+
+	// A lone connect after idle fires immediately; the next four queue at
+	// one interval apart — bounding the per-key (egress-IP, host) rate.
+	for i := 0; i < 5; i++ {
+		got := g.reserve("ip|host", now)
+		want := time.Duration(i) * interval
+		if got != want {
+			t.Fatalf("attempt %d: got wait %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestConnectGate_KeysAreIndependent(t *testing.T) {
+	g := newConnectGate(10 * time.Second)
+	now := time.Now()
+	// First reserve on each distinct key is immediate — one egress IP's
+	// backlog never delays another's.
+	if d := g.reserve("ipA|host", now); d != 0 {
+		t.Fatalf("key A first reserve must be 0, got %v", d)
+	}
+	if d := g.reserve("ipB|host", now); d != 0 {
+		t.Fatalf("key B first reserve must be 0, got %v", d)
+	}
+}
+
+func TestConnectGate_WaitHonorsContext(t *testing.T) {
+	g := newConnectGate(time.Hour) // long enough that only ctx unblocks
+	// Burn the immediate slot so the next Wait must block.
+	g.reserve("ip|host", time.Now())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if err := g.Wait(ctx, "ip|host"); err == nil {
+		t.Fatal("expected ctx deadline error while gate is blocking")
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("Wait did not unblock promptly on ctx cancellation")
+	}
+}

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -160,6 +160,19 @@ type Connector struct {
 	// through CurrentNick so the displays stay in sync.
 	nickMu      sync.RWMutex
 	currentNick string
+	// desiredNick is the nick the user actually wants — the reclaim
+	// target. Set at the start of each registration to effectiveNick();
+	// when the server forces a fallback (433 → appended underscores), the
+	// live nick diverges from desiredNick and the reclaim loop keeps
+	// trying to take it back. nickMu-guarded.
+	desiredNick string
+
+	// nickFallbacks counts 433 fallbacks within the current handshake;
+	// attemptedNick is the nick most recently sent. Both are touched only
+	// on the bringUp goroutine (register + awaitHandshake run in sequence
+	// there), so they need no lock.
+	nickFallbacks int
+	attemptedNick string
 
 	// preferredNickMu guards preferredNick. The bouncer SetPreferredNick
 	// during detached-state NICK handling so the supervisor's next
@@ -513,6 +526,52 @@ func (c *Connector) effectiveNick() string {
 		return queued
 	}
 	return c.settings.Nick
+}
+
+const (
+	// maxNickFallbacks caps the "_"-suffix attempts within one handshake
+	// before giving up (and reconnecting under the floor). A genuinely
+	// busy nick clears within a few suffixes; an unbounded loop would
+	// just hammer the server.
+	maxNickFallbacks = 5
+	// fallbackMaxNickLen is a conservative NICKLEN: appending "_" past it
+	// would earn a 432 instead of registering, so we trim the base first.
+	fallbackMaxNickLen = 15
+	// nickReclaimInterval is how often, while the live nick differs from
+	// the desired one, we re-attempt the desired nick. Slow on purpose —
+	// it's a courtesy, not a hot path, and must never look like flooding.
+	nickReclaimInterval = 90 * time.Second
+)
+
+func (c *Connector) setDesiredNick(n string) {
+	c.nickMu.Lock()
+	c.desiredNick = n
+	c.nickMu.Unlock()
+}
+
+// DesiredNick returns the nick the user wants (the reclaim target),
+// which differs from CurrentNick when a 433 forced a "_" fallback.
+func (c *Connector) DesiredNick() string {
+	c.nickMu.RLock()
+	defer c.nickMu.RUnlock()
+	return c.desiredNick
+}
+
+// nextFallbackNick derives the next "_"-suffixed nick after a 433, up to
+// maxNickFallbacks. Trims the base when appending would exceed a
+// conservative NICKLEN so the fallback isn't itself rejected.
+func (c *Connector) nextFallbackNick() (string, bool) {
+	if c.nickFallbacks >= maxNickFallbacks {
+		return "", false
+	}
+	c.nickFallbacks++
+	base := c.attemptedNick
+	if len(base) >= fallbackMaxNickLen {
+		base = base[:fallbackMaxNickLen-1]
+	}
+	next := base + "_"
+	c.attemptedNick = next
+	return next, true
 }
 
 // CurrentNick returns the live nick the server confirmed for the bot.
@@ -931,7 +990,15 @@ func (c *Connector) register(ctx context.Context) error {
 	if err := c.client.WriteLine(user); err != nil {
 		return fmt.Errorf("irc USER: %w", err)
 	}
-	if err := c.client.WriteLine(CmdNick + " " + c.effectiveNick()); err != nil {
+	// Capture the nick we're registering with as both the reclaim target
+	// (desiredNick) and the fallback base (attemptedNick), and reset the
+	// per-handshake fallback counter, before sending NICK. awaitHandshake
+	// suffixes attemptedNick on each 433 instead of aborting.
+	nick := c.effectiveNick()
+	c.setDesiredNick(nick)
+	c.nickFallbacks = 0
+	c.attemptedNick = nick
+	if err := c.client.WriteLine(CmdNick + " " + nick); err != nil {
 		return fmt.Errorf("irc NICK: %w", err)
 	}
 	if err := c.client.WriteLine(CmdCap + " END"); err != nil {
@@ -1063,6 +1130,14 @@ func (c *Connector) awaitHandshake(ctx context.Context) error {
 			c.respondPong(msg)
 			continue
 		}
+		// Adopt the nick the server actually assigned in the welcome. The
+		// 001 is consumed here (before the main dispatcher runs), so the
+		// dispatcher's own RplWelcome handler never sees it — without this
+		// the live nick would stay the requested one even after a 433 "_"
+		// fallback registered us under a different nick.
+		if msg.Command == RplWelcome && len(msg.Params) > 0 {
+			c.setCurrentNick(msg.Params[0])
+		}
 		// Classifier-driven state transitions: anything that signals
 		// nick-unavailable / auth-failed / banned during the pre-MOTD
 		// window must surface as the correct supervisor state so the
@@ -1078,7 +1153,18 @@ func (c *Connector) awaitHandshake(ctx context.Context) error {
 		// outside.
 		switch msg.Command {
 		case ErrNickNameInUse:
-			return fmt.Errorf("irc handshake: nickname %q already in use (433); set TURBORG_IRC_NICK to a free nick", c.settings.Nick)
+			// Don't abort — that drops us into the reconnect loop where we
+			// race our own ghost and storm the server. Instead suffix "_"
+			// and keep registering; the reclaim loop later takes the
+			// desired nick back when it frees.
+			if next, ok := c.nextFallbackNick(); ok {
+				if err := c.client.WriteLine(CmdNick + " " + next); err != nil {
+					return fmt.Errorf("irc handshake: NICK fallback %q: %w", next, err)
+				}
+				c.log.Info("irc nick in use; using fallback", "desired", c.DesiredNick(), "fallback", next)
+				continue
+			}
+			return fmt.Errorf("irc handshake: nickname %q already in use (433) after %d fallbacks", c.attemptedNick, maxNickFallbacks)
 		case ErrUnavailResource:
 			return fmt.Errorf("irc handshake: nickname %q unavailable (437)", c.settings.Nick)
 		case ErrPasswdMismatch:
@@ -1320,6 +1406,30 @@ func (c *Connector) runSession(ctx context.Context) error {
 		<-gctx.Done()
 		_ = cli.Unblock()
 		return nil
+	})
+
+	// Nick reclaim: while the live nick differs from the desired one (a
+	// 433 forced a "_" fallback at registration), periodically re-attempt
+	// the desired nick. Slow cadence — a courtesy, never a hot path; the
+	// self-NICK echo updates CurrentNick, so once it succeeds this no-ops.
+	g.Go(func() error {
+		t := time.NewTicker(nickReclaimInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-gctx.Done():
+				return nil
+			case <-t.C:
+				desired := c.DesiredNick()
+				if desired == "" || c.CurrentNick() == desired || c.machine.State() != UpstreamStateRegistered {
+					continue
+				}
+				if err := cli.WriteLine(CmdNick + " " + desired); err != nil {
+					return nil // conn is failing; the reader goroutine surfaces it
+				}
+				c.log.Info("irc reclaiming desired nick", "desired", desired, "current", c.CurrentNick())
+			}
+		}
 	})
 
 	// Reader: enforces the silent-death idle timeout from settings.

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -92,6 +92,15 @@ type Connector struct {
 	// hammering the upstream network / shared egress IP. See reconnect_storm.go.
 	storm *reconnectStorm
 
+	// reconnectFloor is the minimum delay before any reconnect dial. Its
+	// purpose is to never reconnect faster than the server reaps our old
+	// connection's nick: a stable session that drops (e.g. PING timeout)
+	// resets the backoff to ~1s, and reconnecting that fast collides with
+	// our own lingering ghost → repeated 433 → throttle → ban. A floor
+	// above the typical server ghost-reap window avoids that entirely. 0
+	// disables it (the default; production wiring sets it).
+	reconnectFloor time.Duration
+
 	// clientLimits is the operator-policy struct the bouncer consults
 	// before forwarding client-originated commands upstream. Held here
 	// so runtime.Build can hand it to the connector before Start; it
@@ -268,6 +277,13 @@ func New(s *Settings, log *slog.Logger, events *agent.EventBus) *Connector {
 // Must be called before Run; tests use it to trip the breaker on tight timings.
 func (c *Connector) SetReconnectStorm(window time.Duration, maxAttempts int, cooldown time.Duration) {
 	c.storm = newReconnectStorm(window, maxAttempts, cooldown)
+}
+
+// SetReconnectFloor sets the minimum delay before any reconnect dial (see
+// the reconnectFloor field). A non-positive value disables the floor.
+// Must be called before Run; production wiring sets it, tests leave it 0.
+func (c *Connector) SetReconnectFloor(d time.Duration) {
+	c.reconnectFloor = d
 }
 
 // WantedChannels returns the connector's wanted-channels set. Used by
@@ -1231,6 +1247,13 @@ func (c *Connector) Run(ctx context.Context) error {
 		// in a long cooldown once reconnects pile up in its window, so a
 		// persistent flapper stops hammering the network / egress IP.
 		delay := c.storm.nextDelay(time.Now(), backoff.Next(), c.log)
+		// Never reconnect faster than the server reaps our old nick — a
+		// sub-floor delay risks colliding with our own ghost (433) and
+		// escalating into a throttle/ban. The storm cooldown already
+		// exceeds the floor, so max() leaves it untouched.
+		if c.reconnectFloor > 0 && delay < c.reconnectFloor {
+			delay = c.reconnectFloor
+		}
 		c.log.Info("irc reconnecting", "state", c.machine.State(), "after", delay, "err", err)
 		select {
 		case <-runCtx.Done():

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1332,14 +1332,7 @@ func (c *Connector) Run(ctx context.Context) error {
 		// paused_idle — that surfaces as runCtx.Done. The storm breaker swaps
 		// in a long cooldown once reconnects pile up in its window, so a
 		// persistent flapper stops hammering the network / egress IP.
-		delay := c.storm.nextDelay(time.Now(), backoff.Next(), c.log)
-		// Never reconnect faster than the server reaps our old nick — a
-		// sub-floor delay risks colliding with our own ghost (433) and
-		// escalating into a throttle/ban. The storm cooldown already
-		// exceeds the floor, so max() leaves it untouched.
-		if c.reconnectFloor > 0 && delay < c.reconnectFloor {
-			delay = c.reconnectFloor
-		}
+		delay := c.reconnectDelay(backoff)
 		c.log.Info("irc reconnecting", "state", c.machine.State(), "after", delay, "err", err)
 		select {
 		case <-runCtx.Done():
@@ -1366,6 +1359,20 @@ func (c *Connector) Run(ctx context.Context) error {
 		}
 		sessionStart = time.Now()
 	}
+}
+
+// reconnectDelay returns how long to wait before the next reconnect: the
+// storm breaker's value (plain backoff, or its long cooldown once the
+// reconnect rate trips the breaker), raised to the reconnect floor so we
+// never reconnect inside the server's ghost-nick reap window (the 433
+// self-collision trigger). The storm cooldown already exceeds the floor,
+// so the max() leaves it untouched.
+func (c *Connector) reconnectDelay(backoff *BackoffSchedule) time.Duration {
+	d := c.storm.nextDelay(time.Now(), backoff.Next(), c.log)
+	if c.reconnectFloor > 0 && d < c.reconnectFloor {
+		d = c.reconnectFloor
+	}
+	return d
 }
 
 // runSession runs one upstream session: the reader / ping / dispatch

--- a/internal/connector/irc/connector_reconnect_test.go
+++ b/internal/connector/irc/connector_reconnect_test.go
@@ -137,8 +137,14 @@ type reconnectTestServer struct {
 
 	// rejectAfter, when non-empty, names a pre-MOTD numeric the server
 	// replies with instead of 001/376 — exercises the classifier's
-	// nick-unavailable / auth-failed / banned branches.
+	// nick-unavailable / auth-failed / banned branches. The special value
+	// "ERR_NICKNAMEINUSE_THEN_OK" rejects the first NICK with 433 then
+	// welcomes the suffixed fallback — exercises the 433 fallback path.
 	rejectAfter string
+
+	// reg433Sent tracks whether the one-shot 433 has been emitted (for the
+	// ERR_NICKNAMEINUSE_THEN_OK fallback mode).
+	reg433Sent bool
 
 	// joinHook lets edge tests intercept the JOIN reply. Returning
 	// true means "I handled this JOIN" and suppresses the default
@@ -269,9 +275,26 @@ func (s *reconnectTestServer) handleLine(conn net.Conn, line string) {
 		}
 		caps := strings.Fields(line[idx+2:])
 		_, _ = conn.Write([]byte(":fake CAP * ACK :" + strings.Join(caps, " ") + "\r\n"))
+	case strings.HasPrefix(line, "NICK "):
+		// Fallback mode: 433 the first NICK, welcome the suffixed retry.
+		if s.rejectAfter == "ERR_NICKNAMEINUSE_THEN_OK" {
+			nick := strings.TrimSpace(strings.TrimPrefix(line, "NICK "))
+			s.mu.Lock()
+			first := !s.reg433Sent
+			s.reg433Sent = true
+			s.mu.Unlock()
+			if first {
+				_, _ = conn.Write([]byte(":fake 433 * " + nick + " :Nickname is already in use\r\n"))
+			} else {
+				_, _ = conn.Write([]byte(":fake 001 " + nick + " :Welcome\r\n"))
+				_, _ = conn.Write([]byte(":fake 376 " + nick + " :End of MOTD\r\n"))
+			}
+		}
 	case strings.HasPrefix(line, "USER "):
 		nick := s.firstNickLocked()
 		switch s.rejectAfter {
+		case "ERR_NICKNAMEINUSE_THEN_OK":
+			// Handled on the NICK line(s), not here.
 		case "ERR_NICKNAMEINUSE":
 			_, _ = conn.Write([]byte(":fake 433 * " + nick + " :Nickname is already in use\r\n"))
 		case "ERR_PASSWDMISMATCH":
@@ -341,6 +364,42 @@ func TestSupervisorReconnectsAfterUpstreamKill(t *testing.T) {
 			fs.Sessions() == 2
 	}, 5*time.Second, 50*time.Millisecond,
 		"supervisor must reconnect; sessions=%d state=%s", fs.Sessions(), conn.UpstreamState().State())
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}
+
+// TestRegisterFallsBackOnNickInUse covers the 433 fallback: the server
+// rejects the first NICK as in-use, and instead of aborting (which would
+// drop into the reconnect loop and race our own ghost), the connector
+// suffixes "_" and completes registration under the fallback nick. The
+// desired nick is preserved as the reclaim target.
+func TestRegisterFallsBackOnNickInUse(t *testing.T) {
+	fs := newReconnectTestServerWithReject(t, "ERR_NICKNAMEINUSE_THEN_OK")
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "turborg",
+	}, nil, nil)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered
+	}, 3*time.Second, 10*time.Millisecond, "must register on the suffixed fallback nick")
+
+	require.Equal(t, "turborg_", conn.CurrentNick(), "live nick is the fallback")
+	require.Equal(t, "turborg", conn.DesiredNick(), "desired (reclaim target) stays the original")
 
 	cancel()
 	select {

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -1750,3 +1750,35 @@ func TestBouncerActivityHeartbeat(t *testing.T) {
 	cancel()
 	b.wg.Wait()
 }
+
+func TestNextFallbackNick(t *testing.T) {
+	c := New(&Settings{Nick: "turborg"}, nil, nil)
+	c.attemptedNick = "turborg"
+	for i := 1; i <= maxNickFallbacks; i++ {
+		got, ok := c.nextFallbackNick()
+		if !ok {
+			t.Fatalf("fallback %d should be allowed", i)
+		}
+		if !strings.HasSuffix(got, "_") {
+			t.Fatalf("fallback %d must end with _, got %q", i, got)
+		}
+	}
+	if _, ok := c.nextFallbackNick(); ok {
+		t.Fatal("must stop after maxNickFallbacks")
+	}
+}
+
+func TestNextFallbackNickTrimsLongBase(t *testing.T) {
+	c := New(&Settings{}, nil, nil)
+	c.attemptedNick = strings.Repeat("a", fallbackMaxNickLen)
+	got, ok := c.nextFallbackNick()
+	if !ok {
+		t.Fatal("a single fallback must be allowed")
+	}
+	if len(got) > fallbackMaxNickLen {
+		t.Fatalf("fallback must trim to fit the cap, got %q (len %d)", got, len(got))
+	}
+	if !strings.HasSuffix(got, "_") {
+		t.Fatalf("fallback must end with _, got %q", got)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -81,6 +81,10 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 
 	notifier := activity.New(s.ActivityURL, s.ActivityToken, log)
 	ircConn := irc.New(ircCfg, log, a.Events)
+	// Never reconnect faster than the upstream reaps our ghost nick (avoids
+	// 433 self-collision storms / connection-flood bans). Same floor as the
+	// pooled runtime — the connector layer is shared.
+	ircConn.SetReconnectFloor(irc.DefaultReconnectFloor)
 
 	// State-webhook emitter (transport: PUT to STATE_WEBHOOK_URL). Mirrors
 	// authoritative per-connector state whenever it changes; inert no-op when
@@ -667,6 +671,14 @@ func LoadIRCSettings() (*irc.Settings, error) {
 func Run(ctx context.Context, b *Built) error {
 	if b.StatePush != nil {
 		defer b.StatePush.Stop()
+		// Runs before Stop (LIFO): flush the final snapshot so a terminal
+		// state reached just before shutdown (e.g. disconnected_banned) is
+		// delivered instead of dropped with the cancelled debounce timer.
+		defer func() {
+			flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			b.StatePush.Flush(flushCtx)
+			cancel()
+		}()
 	}
 
 	rootCtx, cancel := context.WithCancel(ctx)

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -302,6 +302,13 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 		if gw != nil {
 			gw.Stop()
 		}
+		// Flush the final snapshot synchronously before Stop cancels the
+		// debounce timer — otherwise a terminal state that lands ~1ms before
+		// teardown (e.g. disconnected_banned) is dropped and the control
+		// plane stays stuck at the prior state (e.g. registering). Safe on nil.
+		flushCtx, flushCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		em.Flush(flushCtx)
+		flushCancel()
 		em.Stop() // safe on nil
 		if sink != nil {
 			// Drain + stop the sink's flush goroutine so restarts stay
@@ -354,6 +361,9 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// web shell sees the full event stream (not just plain messages,
 			// which arrive via the agent's inbound drain regardless).
 			conn := irc.New(settings, t.log, a.Events)
+			// Never reconnect faster than the upstream reaps our ghost nick
+			// (avoids 433 self-collision storms on the shared egress IP).
+			conn.SetReconnectFloor(irc.DefaultReconnectFloor)
 			// Pooled runtime: the bouncer must not bind its own port — the pool
 			// router feeds it connections via ServeBouncerConn after PROXY-v2
 			// tenant resolution. Set before WireCommon adds the connector.

--- a/internal/statepush/state_emitter.go
+++ b/internal/statepush/state_emitter.go
@@ -216,6 +216,21 @@ func (e *Emitter) collect() bool {
 	}
 }
 
+// Flush synchronously builds and PUTs the current snapshot, bypassing the
+// debounce. Call it on teardown so a terminal state that arrives just before
+// Stop (e.g. disconnected_banned ~1ms before the tenant's work returns) is
+// still delivered — Stop cancels the debounce timer, so the pending PUT would
+// otherwise be dropped and the control plane left at the last state (the
+// classic "stuck at registering" symptom). Safe on a nil/disabled emitter.
+func (e *Emitter) Flush(ctx context.Context) {
+	if !e.enabled() {
+		return
+	}
+	if err := e.client.Put(ctx, e.build()); err != nil {
+		e.log.Debug("state webhook flush PUT failed", "err", err)
+	}
+}
+
 func (e *Emitter) send() {
 	snapshot := e.build()
 	// Bound the whole PUT (including retries) by a generous ceiling so

--- a/internal/statepush/state_emitter_test.go
+++ b/internal/statepush/state_emitter_test.go
@@ -1,6 +1,7 @@
 package statepush_test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -140,6 +141,41 @@ func TestStateEmitter_NotifyChangeFiresPutWithZeroDebounce(t *testing.T) {
 	assert.Equal(t, "Unsolicited advertisements/mass abuse.", got.Connectors["irc"].Reason)
 	require.Len(t, got.Connectors["irc"].Channels, 1)
 	assert.Equal(t, "#a", got.Connectors["irc"].Channels[0].Name)
+}
+
+func TestStateEmitter_FlushPutsSynchronouslyWithoutNotify(t *testing.T) {
+	rec := &recorder{}
+	server := httptest.NewServer(rec.handler())
+	t.Cleanup(server.Close)
+
+	// Long debounce so a normal NotifyChange would NOT have fired by the
+	// time we assert — proving Flush bypasses the debounce. This models the
+	// teardown race: a terminal state lands ~1ms before Stop.
+	c := statepush.NewClient(server.URL+"/state", "", nil)
+	e := statepush.NewEmitter(c, func() statepush.Snapshot {
+		return statepush.Snapshot{
+			Connectors: map[string]statepush.ConnectorSnapshot{
+				"irc": {State: "disconnected_banned", Reason: "Unsolicited advertisements/mass abuse."},
+			},
+		}
+	}, 10*time.Second, nil)
+	t.Cleanup(e.Stop)
+
+	e.Flush(context.Background())
+
+	require.Equal(t, 1, rec.count(), "Flush must PUT synchronously")
+	var got statepush.Snapshot
+	require.NoError(t, json.Unmarshal(rec.bodyAt(0), &got))
+	assert.Equal(t, "disconnected_banned", got.Connectors["irc"].State)
+	assert.Equal(t, "Unsolicited advertisements/mass abuse.", got.Connectors["irc"].Reason)
+}
+
+func TestStateEmitter_FlushSafeOnDisabled(t *testing.T) {
+	// nil/disabled emitter (empty URL) must be a no-op, not panic.
+	var nilEmitter *statepush.Emitter
+	nilEmitter.Flush(context.Background())
+	e := statepush.NewEmitter(statepush.NewClient("", "", nil), func() statepush.Snapshot { return statepush.Snapshot{} }, 0, nil)
+	e.Flush(context.Background())
 }
 
 func TestStateEmitter_BurstCoalescesIntoOnePut(t *testing.T) {


### PR DESCRIPTION
## Why

Intermittent Undernet bans (`465` "Unsolicited advertisements/mass abuse", DB stuck at `registering`) trace to a **self-inflicted reconnect storm**: a session drops (ping timeout) → we reconnect in ~1s → `433` collision with our own un-reaped ghost → same-nick rapid retries → the network throttles → escalates to a temporary G-line; amplified across the many tenants sharing one datacenter egress IP.

## What

**Rate / timing (both runtimes, shared connector layer):**
- **Connection gate** (`connect_gate.go`): process-wide min-interval scheduler keyed on `(egress IP, host)`; every `Dial` passes through it, bounding aggregate connect rate per egress IP no matter how many tenants flap. Disabled by default (no-op in tests); enabled by both production `main()`s (`TURBORG_IRC_CONNECT_GATE_INTERVAL`, default 10s).
- **Reconnect floor**: minimum delay before any reconnect dial, above a server's ghost-reap window, so we never collide with our own lingering session. Default 0 (tests unaffected); both runtimes wire `DefaultReconnectFloor` (20s).

**Nick handling (both runtimes):**
- **433 fallback**: suffix `_` and keep registering instead of aborting into the reconnect loop (the storm trigger).
- **Reclaim**: track the desired nick separately; a slow per-session loop re-takes it once it frees.
- Adopt the server-assigned nick from the `001` welcome during the handshake read.

**Persistence:**
- **statepush `Flush()` on teardown**: deliver a terminal `disconnected_banned` that lands ~1ms before `Stop` instead of leaving the control plane stuck at `registering`. Wired in pooled teardown and dedicated shutdown.

## Test

`go build/vet/test ./...` — 21 packages pass. Adds connect-gate, statepush `Flush`, and 433-fallback tests.

## Follow-ups

Explicit throttle-reason classification and a per-egress-IP cross-tenant circuit breaker are additional hardening; the connection gate already makes flooding an egress IP impossible (the root-cause guarantee).