### PR TITLE
feat(connector/irc): apply nick + channel changes live, without a reconnect

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -165,6 +165,19 @@ type Settings struct {
 	// values below the floor are clamped up by the refresher.
 	CommandsRefreshSeconds int `env:"COMMANDS_REFRESH_SECONDS"`
 
+	// ConfigURL is an optional endpoint the agent polls to hot-reload its live
+	// IRC nick + channel set while it runs — no reconnect. Empty = no live
+	// reload (the boot TURBORG_IRC_NICK / CHANNELS are fixed). This gives a
+	// single-instance agent the same live nick/channel reconcile the pooled
+	// runtime does from its tenant feed.
+	ConfigURL string `env:"CONFIG_URL"`
+	// ConfigToken is the bearer sent on every config poll. Defaults to
+	// MessageSinkToken via normalize() when unset — same per-container endpoint.
+	ConfigToken string `env:"CONFIG_TOKEN"`
+	// ConfigRefreshSeconds is the poll interval. 0 uses the package default;
+	// values below the floor are clamped up by the refresher.
+	ConfigRefreshSeconds int `env:"CONFIG_REFRESH_SECONDS"`
+
 	// CustomCommandsMax caps the dynamic-command registry. 0 = no
 	// commands, -1 = unrestricted. Bounds the command set loaded from
 	// TURBORG_COMMANDS (and any later runtime registrations).
@@ -315,6 +328,11 @@ func (s *Settings) normalize() error {
 	// reuses that bearer unless overridden.
 	if s.CommandsToken == "" {
 		s.CommandsToken = s.MessageSinkToken
+	}
+	// The config (nick/channels) poll terminates at the same per-container
+	// endpoint, so it reuses that bearer unless overridden.
+	if s.ConfigToken == "" {
+		s.ConfigToken = s.MessageSinkToken
 	}
 	return nil
 }

--- a/internal/configrefresh/refresh.go
+++ b/internal/configrefresh/refresh.go
@@ -1,0 +1,143 @@
+// Package configrefresh keeps a single-instance agent's live IRC nick and
+// channel set current while it runs, without a reconnect.
+//
+// A single-instance agent boots with its nick + channels baked into
+// TURBORG_IRC_NICK / TURBORG_IRC_CHANNELS. This package polls an endpoint for
+// the current desired values and, when they change, applies them in place via
+// a caller-supplied callback (ApplyNick + ReconcileChannels on the live
+// connector). It is the single-instance mirror of what the pooled runtime
+// already does from its tenant feed, so both apply nick/channel changes with
+// no IRC reconnect.
+//
+// Wire contract the operator must serve at the configured URL:
+//
+//	GET <url>
+//	  Authorization: Bearer <token>
+//	  Status: 200 on success.
+//	  Body: {"nick": "<nick>", "channels": ["#a", "#b", ...]}
+//
+// Failures are non-fatal: the last applied config stays in force and the loop
+// retries on the next tick.
+package configrefresh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"time"
+)
+
+const (
+	defaultInterval = 15 * time.Second
+	minInterval     = 2 * time.Second
+	requestTimeout  = 10 * time.Second
+)
+
+// Config is the live-applicable IRC config the endpoint serves.
+type Config struct {
+	Nick     string   `json:"nick"`
+	Channels []string `json:"channels"`
+}
+
+// Apply installs a freshly-fetched config on the live connector. The runtime
+// supplies a closure that calls ApplyNick + ReconcileChannels.
+type Apply func(cfg Config)
+
+// Refresher periodically pulls the desired nick/channels and applies changes.
+type Refresher struct {
+	endpoint string
+	token    string
+	interval time.Duration
+	apply    Apply
+	client   *http.Client
+	log      *slog.Logger
+
+	last     Config
+	haveLast bool
+}
+
+// New returns nil when refresh is not configured (no endpoint/token or no
+// apply callback) so the caller can gate the feature with a single non-nil
+// check. intervalSeconds <= 0 uses the default; values below the floor are
+// clamped up.
+func New(endpoint, token string, intervalSeconds int, apply Apply, log *slog.Logger) *Refresher {
+	if endpoint == "" || token == "" || apply == nil {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	interval := time.Duration(intervalSeconds) * time.Second
+	switch {
+	case intervalSeconds <= 0:
+		interval = defaultInterval
+	case interval < minInterval:
+		interval = minInterval
+	}
+	return &Refresher{
+		endpoint: endpoint,
+		token:    token,
+		interval: interval,
+		apply:    apply,
+		client:   &http.Client{Timeout: requestTimeout},
+		log:      log.With("component", "config-refresh"),
+	}
+}
+
+// Run reloads once immediately, then on every interval tick, until ctx is
+// cancelled. Always returns nil (cancellation is the normal exit).
+func (r *Refresher) Run(ctx context.Context) error {
+	r.refreshOnce(ctx)
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			r.refreshOnce(ctx)
+		}
+	}
+}
+
+func (r *Refresher) refreshOnce(ctx context.Context) {
+	cfg, err := r.fetch(ctx)
+	if err != nil {
+		// Keep the last applied config; a brief stale nick/channel set is safe.
+		r.log.Debug("config refresh failed; keeping last", "err", err)
+		return
+	}
+	// Skip the apply when nothing changed, so an unchanged poll is a no-op.
+	if r.haveLast && reflect.DeepEqual(r.last, cfg) {
+		return
+	}
+	r.apply(cfg)
+	r.last = cfg
+	r.haveLast = true
+	r.log.Info("irc config reloaded in place", "nick", cfg.Nick, "channels", len(cfg.Channels))
+}
+
+func (r *Refresher) fetch(ctx context.Context) (Config, error) {
+	var cfg Config
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.endpoint, nil)
+	if err != nil {
+		return cfg, err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.token)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return cfg, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return cfg, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
+		return cfg, fmt.Errorf("decode body: %w", err)
+	}
+	return cfg, nil
+}

--- a/internal/configrefresh/refresh_test.go
+++ b/internal/configrefresh/refresh_test.go
@@ -1,0 +1,105 @@
+package configrefresh_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/turborg/turborg/internal/configrefresh"
+)
+
+func TestNewReturnsNilWhenUnconfigured(t *testing.T) {
+	apply := func(configrefresh.Config) {}
+	require.Nil(t, configrefresh.New("", "tok", 0, apply, nil), "no endpoint → nil")
+	require.Nil(t, configrefresh.New("http://x", "", 0, apply, nil), "no token → nil")
+	require.Nil(t, configrefresh.New("http://x", "tok", 0, nil, nil), "no apply → nil")
+}
+
+func TestRefresherAppliesAndSkipsUnchanged(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"nick":"alice","channels":["#a","#b"]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	var mu sync.Mutex
+	var applied []configrefresh.Config
+	apply := func(c configrefresh.Config) {
+		mu.Lock()
+		applied = append(applied, c)
+		mu.Unlock()
+	}
+
+	r := configrefresh.New(srv.URL, "tok", 1, apply, nil)
+	require.NotNil(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { _ = r.Run(ctx); close(done) }()
+
+	// First poll applies.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(applied) == 1
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Later identical polls must NOT re-apply (skip-unchanged). The interval
+	// floors at 2s, so wait past one tick to ensure a second poll happened
+	// and was skipped.
+	require.Never(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(applied) != 1
+	}, 2500*time.Millisecond, 100*time.Millisecond)
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, "alice", applied[0].Nick)
+	require.Equal(t, []string{"#a", "#b"}, applied[0].Channels)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(2), "should have polled more than once")
+}
+
+func TestRefresherKeepsLastOnError(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		payload string
+	}{
+		{"non-200", http.StatusInternalServerError, "boom"},
+		{"invalid-json", http.StatusOK, "not json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.payload))
+			}))
+			defer srv.Close()
+
+			var calls int32
+			r := configrefresh.New(srv.URL, "tok", 0, func(configrefresh.Config) {
+				atomic.AddInt32(&calls, 1)
+			}, slog.Default())
+			require.NotNil(t, r)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+			defer cancel()
+			_ = r.Run(ctx) // immediate poll errors, no apply; ctx ends the loop
+			require.Zero(t, atomic.LoadInt32(&calls), "apply must not fire on a fetch error")
+		})
+	}
+}

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -574,6 +574,63 @@ func (c *Connector) nextFallbackNick() (string, bool) {
 	return next, true
 }
 
+// ApplyNick changes the desired nick live, without a reconnect. It updates
+// the reclaim target and the queued preferred nick (so a later reconnect
+// registers with it), and — when currently registered — sends a live NICK
+// to the server. A collision (433) is then handled by the reclaim loop,
+// which keeps re-attempting the desired nick until it frees. No-op for an
+// empty or unchanged nick. Safe to call from any goroutine.
+func (c *Connector) ApplyNick(nick string) {
+	nick = strings.TrimSpace(nick)
+	if nick == "" || nick == c.DesiredNick() {
+		return
+	}
+	c.setDesiredNick(nick)
+	c.SetPreferredNick(nick)
+	if c.machine.State() == UpstreamStateRegistered {
+		if cli := c.getClient(); cli != nil {
+			_ = cli.WriteLine(CmdNick + " " + nick)
+		}
+	}
+}
+
+// ReconcileChannels brings the joined channels in line with the desired set:
+// PART channels no longer wanted and JOIN newly-wanted ones, live (when
+// registered) and in the wanted set so a reconnect replays the same set.
+// Idempotent — an unchanged set is a no-op. Channel keys are not part of the
+// desired list (they're learned from client JOINs and preserved by the set).
+// Safe to call from any goroutine.
+func (c *Connector) ReconcileChannels(desired []string) {
+	want := make(map[string]string, len(desired)) // lower(name) -> original casing
+	for _, ch := range desired {
+		ch = strings.TrimSpace(ch)
+		if ch != "" {
+			want[strings.ToLower(ch)] = ch
+		}
+	}
+	registered := c.machine.State() == UpstreamStateRegistered
+	cli := c.getClient()
+
+	for _, cur := range c.wanted.Snapshot() {
+		if _, keep := want[strings.ToLower(cur.Name)]; keep {
+			continue
+		}
+		c.wanted.Remove(cur.Name)
+		if registered && cli != nil {
+			_ = cli.WriteLine(CmdPart + " " + cur.Name)
+		}
+	}
+	for _, name := range want {
+		if _, ok := c.wanted.Get(name); ok {
+			continue
+		}
+		c.wanted.Add(name, "")
+		if registered && cli != nil {
+			_ = cli.WriteLine(CmdJoin + " " + name)
+		}
+	}
+}
+
 // CurrentNick returns the live nick the server confirmed for the bot.
 // Initially the requested TURBORG_IRC_NICK, then overwritten by the
 // 001 welcome's target field (the nick the server actually assigned)

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -1782,3 +1782,36 @@ func TestNextFallbackNickTrimsLongBase(t *testing.T) {
 		t.Fatalf("fallback must end with _, got %q", got)
 	}
 }
+
+func TestApplyNickUpdatesDesiredAndPreferred(t *testing.T) {
+	c := New(&Settings{Nick: "bot"}, nil, nil)
+	c.ApplyNick("newnick")
+	if c.DesiredNick() != "newnick" {
+		t.Fatalf("desired nick = %q, want newnick", c.DesiredNick())
+	}
+	if c.PreferredNick() != "newnick" {
+		t.Fatalf("preferred nick = %q, want newnick", c.PreferredNick())
+	}
+	// Empty + unchanged are no-ops (don't clobber the desired nick).
+	c.ApplyNick("")
+	c.ApplyNick("newnick")
+	if c.DesiredNick() != "newnick" {
+		t.Fatalf("no-op ApplyNick changed desired to %q", c.DesiredNick())
+	}
+}
+
+func TestReconcileChannelsUpdatesWantedSet(t *testing.T) {
+	c := New(&Settings{Nick: "bot", Channels: []string{"#a", "#b"}}, nil, nil)
+	// Not registered → reconcile updates the wanted set (replayed on connect).
+	c.ReconcileChannels([]string{"#b", "#c"})
+	got := map[string]bool{}
+	for _, w := range c.WantedChannels().Snapshot() {
+		got[strings.ToLower(w.Name)] = true
+	}
+	if got["#a"] {
+		t.Fatal("#a should have been parted from the wanted set")
+	}
+	if !got["#b"] || !got["#c"] {
+		t.Fatalf("wanted set should be {#b,#c}, got %v", got)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -27,6 +27,7 @@ import (
 	"github.com/turborg/turborg/internal/commandrefresh"
 	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/config"
+	"github.com/turborg/turborg/internal/configrefresh"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/messages"
@@ -49,6 +50,10 @@ type Built struct {
 	// BudgetRefresh keeps the token budget's account baseline current while the
 	// agent runs. Nil when the provider isn't budgeted or no endpoint is set.
 	BudgetRefresh *budgetrefresh.Refresher
+	// ConfigRefresh hot-reloads the live IRC nick + channel set in place while
+	// the agent runs (the single-instance mirror of the pooled feed-driven
+	// reconcile). Nil when CONFIG_URL is unset (self-host: boot config fixed).
+	ConfigRefresh *configrefresh.Refresher
 	// CommandRefresh hot-reloads the data-driven command set in place while the
 	// agent runs (the single-instance mirror of the pooled feed-driven reload). Nil
 	// when COMMANDS_URL is unset (self-host: the boot set is fixed).
@@ -212,6 +217,25 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		s.CommandsToken,
 		s.CommandsRefreshSeconds,
 		func(defs []commands.Definition) { ApplyCommands(a, defs, provider, owner, ircCfg.Hostname, log) },
+		log,
+	)
+
+	// Live nick/channel hot-reload: when CONFIG_URL is set, poll the
+	// per-container config endpoint and apply nick/channel changes in place —
+	// the same ApplyNick / ReconcileChannels the pooled runtime does from its
+	// feed, so a single-instance container picks up a /nick or /join edit
+	// without a respawn/reconnect.
+	built.ConfigRefresh = configrefresh.New(
+		s.ConfigURL,
+		s.ConfigToken,
+		s.ConfigRefreshSeconds,
+		func(cfg configrefresh.Config) {
+			if ircConn == nil {
+				return
+			}
+			ircConn.ApplyNick(cfg.Nick)
+			ircConn.ReconcileChannels(cfg.Channels)
+		},
 		log,
 	)
 
@@ -702,6 +726,9 @@ func Run(ctx context.Context, b *Built) error {
 	}
 	if b.CommandRefresh != nil {
 		startRefresher(b.CommandRefresh.Run)
+	}
+	if b.ConfigRefresh != nil {
+		startRefresher(b.ConfigRefresh.Run)
 	}
 	waitRefresh := func() {
 		for _, done := range refreshDones {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2,6 +2,8 @@ package runtime_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -866,4 +868,32 @@ func TestBuildIgnoresRealnameTemplateWithoutLock(t *testing.T) {
 	_, err := runtime.Build(s, ircCfg, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "user-supplied", ircCfg.RealName)
+}
+
+func TestBuildWiresConfigRefresh(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"nick":"newnick","channels":["#x"]}`))
+	}))
+	defer srv.Close()
+
+	s := &config.Settings{CommandPrefix: "!", ConfigURL: srv.URL, ConfigToken: "tok"}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, b.ConfigRefresh, "CONFIG_URL set → refresher wired")
+
+	// Run the refresher once: the apply closure calls ApplyNick + ReconcileChannels.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	_ = b.ConfigRefresh.Run(ctx)
+
+	assert.Equal(t, "newnick", b.IRC.DesiredNick(), "live config refresh applied the desired nick")
+}
+
+func TestBuildNoConfigRefreshWhenUnset(t *testing.T) {
+	s := &config.Settings{CommandPrefix: "!"}
+	ircCfg := &irc.Settings{Hostname: "fake", Nick: "turborg"}
+	b, err := runtime.Build(s, ircCfg, nil)
+	require.NoError(t, err)
+	assert.Nil(t, b.ConfigRefresh, "no CONFIG_URL → no refresher (boot config fixed)")
 }

--- a/internal/server/hot_reload_test.go
+++ b/internal/server/hot_reload_test.go
@@ -29,6 +29,21 @@ func specWithChannel(id, channel string) TenantSpec {
 	}
 }
 
+// specWithOwnerMode builds a spec that differs in a NON-live connector field
+// (owner_mode), used by tests that need a change which genuinely forces a
+// restart (nick/channels now apply live and never restart).
+func specWithOwnerMode(id, mode string) TenantSpec {
+	return TenantSpec{
+		TurborgID:   id,
+		RuntimeMode: "pooled",
+		Connectors: []ConnectorSpec{{
+			Type:    "irc",
+			Config:  map[string]any{"owner_mode": mode},
+			Secrets: map[string]any{},
+		}},
+	}
+}
+
 // TestUpdateRestartsTenantWithNewSpec is the M7 deliverable: changing a
 // running tenant's spec restarts its work with the new config, without losing
 // the tenant or disturbing the process.
@@ -37,15 +52,15 @@ func TestUpdateRestartsTenantWithNewSpec(t *testing.T) {
 	seen := make(chan string, 8)
 
 	events := make(chan TenantEvent)
-	src := &StaticSource{Tenants: []TenantSpec{specWithChannel("x", "#one")}, Events: events}
+	src := &StaticSource{Tenants: []TenantSpec{specWithOwnerMode("x", "self")}, Events: events}
 	srv := New(src, testLogger())
 	srv.workFactory = func(tn *Tenant) func(context.Context) error {
 		return func(ctx context.Context) error {
 			runs.Add(1)
 			tn.mu.Lock()
-			ch := fmt.Sprint(tn.spec.Connectors[0].Config["channels"])
+			mode := fmt.Sprint(tn.spec.Connectors[0].Config["owner_mode"])
 			tn.mu.Unlock()
-			seen <- ch
+			seen <- mode
 			<-ctx.Done()
 			return ctx.Err()
 		}
@@ -55,11 +70,12 @@ func TestUpdateRestartsTenantWithNewSpec(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- srv.Run(ctx) }()
 
-	require.Equal(t, "[#one]", waitStr(t, seen), "first run should see the initial channel")
+	require.Equal(t, "self", waitStr(t, seen), "first run should see the initial config")
 
-	// Change the channel — the tenant must restart and observe the new spec.
-	events <- TenantEvent{Kind: TenantUpserted, Spec: specWithChannel("x", "#two")}
-	require.Equal(t, "[#two]", waitStr(t, seen), "restart should see the updated channel")
+	// Change a non-live connector field — the tenant must restart and observe
+	// the new spec. (Nick/channel changes apply live; see the live-apply tests.)
+	events <- TenantEvent{Kind: TenantUpserted, Spec: specWithOwnerMode("x", "account")}
+	require.Equal(t, "account", waitStr(t, seen), "restart should see the updated config")
 	require.GreaterOrEqual(t, int(runs.Load()), 2)
 	require.Equal(t, 1, srv.Count(), "update must not duplicate the tenant")
 
@@ -127,11 +143,13 @@ func TestLiveUpdatableOnlyChangeIgnoresTokenUsageBaseline(t *testing.T) {
 	require.False(t, liveUpdatableOnlyChange(base, capChange),
 		"a capability change is not a live-updatable-only change")
 
-	// A channel change alongside a baseline move must still force a restart.
-	chChange := specWithChannel("x", "#two")
-	chChange.PlanCapabilities = movedBaseline.PlanCapabilities
-	require.False(t, liveUpdatableOnlyChange(base, chChange),
-		"a connector change is not a live-updatable-only change")
+	// A non-live connector change (owner_mode) alongside a baseline move must
+	// still force a restart.
+	ownerChange := specWithChannel("x", "#one")
+	ownerChange.Connectors[0].Config["owner_mode"] = "account"
+	ownerChange.PlanCapabilities = movedBaseline.PlanCapabilities
+	require.False(t, liveUpdatableOnlyChange(base, ownerChange),
+		"a non-live connector change is not a live-updatable-only change")
 }
 
 func TestReloadCommandsSwapsInPlace(t *testing.T) {
@@ -236,12 +254,13 @@ func TestUpdateCommandsOnlyReloadsWithoutRestart(t *testing.T) {
 
 	require.Equal(t, int32(1), runs.Load(), "a command-only change must not restart the work loop")
 
-	// A connection-affecting change (new channel) still restarts.
-	chSpec := cmdSpec
-	chSpec.Connectors = []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "self", "channels": []any{"#two"}}, Secrets: map[string]any{}}}
-	events <- TenantEvent{Kind: TenantUpserted, Spec: chSpec}
+	// A non-live connector change (owner_mode) still restarts. (Nick/channel
+	// changes apply live — covered by TestUpdateIgnoreOnlyReloadsWithoutRestart.)
+	ownerSpec := cmdSpec
+	ownerSpec.Connectors = []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "account"}, Secrets: map[string]any{}}}
+	events <- TenantEvent{Kind: TenantUpserted, Spec: ownerSpec}
 	require.Eventually(t, func() bool { return runs.Load() == 2 }, 2*time.Second, 10*time.Millisecond,
-		"a connector change must restart the work loop")
+		"a non-live connector change must restart the work loop")
 
 	cancel()
 	require.ErrorIs(t, <-done, context.Canceled)
@@ -312,11 +331,18 @@ func TestLiveUpdatableOnlyChangeAllowsIgnoreEdit(t *testing.T) {
 	require.True(t, liveUpdatableOnlyChange(base, ignoreEdit),
 		"an ignore-list edit must be applied without a reconnect")
 
-	// An ignore edit alongside a connector change must still force a restart.
+	// A channels change is now live (JOIN/PART), so a channels + ignore edit
+	// is still live-updatable-only — no reconnect.
 	ignoreAndChannel := specWithChannel("x", "#two")
 	ignoreAndChannel.IgnoredNicks = ignoreEdit.IgnoredNicks
-	require.False(t, liveUpdatableOnlyChange(base, ignoreAndChannel),
-		"a connector change alongside an ignore edit is not live-updatable-only")
+	require.True(t, liveUpdatableOnlyChange(base, ignoreAndChannel),
+		"a channels change applies live, so with an ignore edit it stays live-updatable-only")
+
+	// A non-live connector field (here owner_mode) still forces a restart.
+	ownerChange := specWithChannel("x", "#one")
+	ownerChange.Connectors[0].Config["owner_mode"] = "account"
+	require.False(t, liveUpdatableOnlyChange(base, ownerChange),
+		"a non-live connector change is not live-updatable-only")
 }
 
 func TestReloadGuardFallsBackWhenNotRunning(t *testing.T) {
@@ -421,12 +447,21 @@ func TestUpdateIgnoreOnlyReloadsWithoutRestart(t *testing.T) {
 	require.Never(t, func() bool { return runs.Load() != 1 }, 200*time.Millisecond, 20*time.Millisecond,
 		"an ignore-only change must never restart the work loop")
 
-	// A connector change still restarts.
-	chSpec := ignoreSpec
-	chSpec.Connectors = []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "self", "channels": []any{"#two"}}, Secrets: map[string]any{}}}
-	events <- TenantEvent{Kind: TenantUpserted, Spec: chSpec}
+	// A channels-only connector change applies live (JOIN/PART), so it must
+	// NOT restart — that's what keeps the user's /join in sync without
+	// dropping the session.
+	chLiveSpec := ignoreSpec
+	chLiveSpec.Connectors = []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "self", "channels": []any{"#two"}}, Secrets: map[string]any{}}}
+	events <- TenantEvent{Kind: TenantUpserted, Spec: chLiveSpec}
+	require.Never(t, func() bool { return runs.Load() != 1 }, 200*time.Millisecond, 20*time.Millisecond,
+		"a channels-only change must apply live, not restart the work loop")
+
+	// A non-live connector change (owner_mode) still restarts.
+	ownerSpec := chLiveSpec
+	ownerSpec.Connectors = []ConnectorSpec{{Type: "irc", Config: map[string]any{"owner_mode": "account", "channels": []any{"#two"}}, Secrets: map[string]any{}}}
+	events <- TenantEvent{Kind: TenantUpserted, Spec: ownerSpec}
 	require.Eventually(t, func() bool { return runs.Load() == 2 }, 2*time.Second, 10*time.Millisecond,
-		"a connector change must restart the work loop")
+		"a non-live connector change must restart the work loop")
 
 	cancel()
 	require.ErrorIs(t, <-done, context.Canceled)

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -589,18 +589,22 @@ func (t *Tenant) update(spec TenantSpec) {
 	if liveUpdatableOnlyChange(prev, spec) {
 		commandsChanged := !commandSetsEqual(prev.Commands, spec.Commands)
 		ignoresChanged := !reflect.DeepEqual(prev.IgnoredNicks, spec.IgnoredNicks)
-		if !commandsChanged && !ignoresChanged {
+		nickChanged, channelsChanged := ircNickChannelsChanged(prev, spec)
+		if !commandsChanged && !ignoresChanged && !nickChanged && !channelsChanged {
 			return // only the usage baseline moved — nothing to reconnect for
 		}
 		// Apply each changed facet in place. The command set swaps via
-		// ReplaceDynamic; the ignore list swaps the registry-wide guard. Either
-		// returning false means the tenant isn't running, so fall through to a
-		// restart that re-seeds everything from the new spec at build time.
+		// ReplaceDynamic; the ignore list swaps the registry-wide guard; nick
+		// and channels apply live via NICK / JOIN+PART. Any "false" means the
+		// tenant isn't running, so fall through to a restart that re-seeds
+		// everything from the new spec at build time.
 		okCommands := !commandsChanged || t.reloadCommands(spec.Commands)
 		okIgnores := !ignoresChanged || t.reloadGuard()
-		if okCommands && okIgnores {
+		okNickChan := (!nickChanged && !channelsChanged) || t.applyNickChannels(spec)
+		if okCommands && okIgnores && okNickChan {
 			t.log.Info("tenant settings reloaded in place",
-				"commands", len(spec.Commands), "ignored", len(spec.IgnoredNicks))
+				"commands", len(spec.Commands), "ignored", len(spec.IgnoredNicks),
+				"nick_changed", nickChanged, "channels_changed", channelsChanged)
 			return
 		}
 	}
@@ -638,7 +642,62 @@ func liveUpdatableOnlyChange(a, b TenantSpec) bool {
 	a.IgnoredNicks, b.IgnoredNicks = nil, nil
 	a.PlanCapabilities = capsWithoutTokenUsage(a.PlanCapabilities)
 	b.PlanCapabilities = capsWithoutTokenUsage(b.PlanCapabilities)
+	// nick + channels apply live (NICK / JOIN+PART) without a reconnect, so a
+	// change confined to them must not restart — that's also what makes
+	// syncing the user's live /nick and /join back into the desired config
+	// safe (the echoed change reconciles to a no-op instead of looping).
+	a.Connectors = stripLiveConnectorFields(a.Connectors)
+	b.Connectors = stripLiveConnectorFields(b.Connectors)
 	return reflect.DeepEqual(a, b)
+}
+
+// stripLiveConnectorFields returns the connectors with the IRC connector's
+// live-applicable config keys (nick, channels) removed, so spec comparison
+// ignores them. Deep-copies the affected config map so the caller's spec is
+// untouched.
+func stripLiveConnectorFields(conns []ConnectorSpec) []ConnectorSpec {
+	out := make([]ConnectorSpec, len(conns))
+	for i, c := range conns {
+		out[i] = c
+		if c.Type != "irc" || c.Config == nil {
+			continue
+		}
+		cfg := make(map[string]any, len(c.Config))
+		for k, v := range c.Config {
+			if k == "nick" || k == "channels" {
+				continue
+			}
+			cfg[k] = v
+		}
+		out[i].Config = cfg
+	}
+	return out
+}
+
+// ircNickChannelsChanged reports whether the IRC connector's desired nick or
+// channel set moved between two specs.
+func ircNickChannelsChanged(prev, next TenantSpec) (nick, channels bool) {
+	p := firstIRCConnectorSpec(prev.Connectors)
+	n := firstIRCConnectorSpec(next.Connectors)
+	nick = stringField(p.Config, "nick") != stringField(n.Config, "nick")
+	channels = !reflect.DeepEqual(stringSlice(p.Config, "channels"), stringSlice(n.Config, "channels"))
+	return nick, channels
+}
+
+// applyNickChannels applies the spec's desired nick and channels to the live
+// connector without a reconnect. Returns false when the tenant isn't running
+// (no live connector), so the caller falls back to a restart.
+func (t *Tenant) applyNickChannels(spec TenantSpec) bool {
+	t.mu.Lock()
+	conn := t.ircConn
+	t.mu.Unlock()
+	if conn == nil {
+		return false
+	}
+	cs := firstIRCConnectorSpec(spec.Connectors)
+	conn.ApplyNick(stringField(cs.Config, "nick"))
+	conn.ReconcileChannels(stringSlice(cs.Config, "channels"))
+	return true
 }
 
 // capsWithoutTokenUsage returns a copy of caps with the live LLM-usage baseline


### PR DESCRIPTION
## Why

Nick and channel changes forced a full reconnect: the pooled feed compares specs and any nick/channel diff fell through to a restart; the single-instance runtime only learns them from boot env. A reconnect drops the session (and, with a shared egress IP, risks the connection-flood path the prior PR hardened). They should apply live.

## What

- **Shared primitives** (`connector.go`): `ApplyNick` (live `NICK`, with the existing reclaim loop covering a 433) and `ReconcileChannels` (a `JOIN`/`PART` delta against the wanted set). Both idempotent — an unchanged set is a no-op.
- **Pooled** (`tenant.go`): nick + channels join the live-updatable set in `Tenant.update`, so a feed change reconciles in place instead of restarting. This also makes echoing a live change back through the feed safe — it reconciles to a no-op rather than looping.
- **Single-instance** (`configrefresh`): a new poller (`CONFIG_URL`), mirroring `commandrefresh`, pulls the desired nick/channels and applies them in place. Inert when unset, so self-host is unaffected.

Both runtimes go through the same connector primitives.

## Test

`go test -race ./...`, coverage gate (`.testcoverage.yml`), and `golangci-lint` all pass locally. Adds connector-primitive tests, the `configrefresh` package tests, runtime-wiring tests, and updates the hot-reload tests to the new contract (channels-only change applies live / no restart; a non-live connector field still restarts).