### PR TITLE
feat(connector/irc): report desired nick distinctly; adopt a self-rename as intent

### DIFF
--- a/internal/connector/irc/codes.go
+++ b/internal/connector/irc/codes.go
@@ -45,6 +45,7 @@ const (
 
 	ErrNoSuchNick       = "401"
 	ErrNoMOTD           = "422"
+	ErrErroneusNickname = "432"
 	ErrNickNameInUse    = "433"
 	ErrUnavailResource  = "437"
 	ErrNotRegistered    = "451"

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -529,13 +529,13 @@ func (c *Connector) effectiveNick() string {
 }
 
 const (
-	// maxNickFallbacks caps the "_"-suffix attempts within one handshake
-	// before giving up (and reconnecting under the floor). A genuinely
-	// busy nick clears within a few suffixes; an unbounded loop would
-	// just hammer the server.
-	maxNickFallbacks = 5
-	// fallbackMaxNickLen is a conservative NICKLEN: appending "_" past it
-	// would earn a 432 instead of registering, so we trim the base first.
+	// fallbackMaxNickLen bounds the "_"-suffix fallback: each 433 appends
+	// one more underscore (Stephen → Stephen_ → Stephen__ …) until the nick
+	// would exceed this length, at which point we give up and let the
+	// supervisor reconnect under the floor/throttle. A conservative cap that
+	// most networks accept; a stricter server's own NICKLEN surfaces as a
+	// 432, which we also treat as "exhausted". These attempts are all within
+	// one registration (one connection) — no reconnect, so no flood risk.
 	fallbackMaxNickLen = 15
 	// nickReclaimInterval is how often, while the live nick differs from
 	// the desired one, we re-attempt the desired nick. Slow on purpose —
@@ -557,19 +557,19 @@ func (c *Connector) DesiredNick() string {
 	return c.desiredNick
 }
 
-// nextFallbackNick derives the next "_"-suffixed nick after a 433, up to
-// maxNickFallbacks. Trims the base when appending would exceed a
-// conservative NICKLEN so the fallback isn't itself rejected.
+// nextFallbackNick appends one more "_" to the last attempted nick after a
+// 433, growing Stephen → Stephen_ → Stephen__ … Returns ok=false once the
+// next suffix would exceed fallbackMaxNickLen — i.e. no shorter alternative
+// is left — so the caller gives up and lets the supervisor reconnect under
+// the floor/throttle. Only ever called on a 433 (nick in use); a 432
+// (erroneous/reserved nick) is handled separately and never falls back,
+// since appending "_" can't make an invalid nick valid.
 func (c *Connector) nextFallbackNick() (string, bool) {
-	if c.nickFallbacks >= maxNickFallbacks {
+	next := c.attemptedNick + "_"
+	if len(next) > fallbackMaxNickLen {
 		return "", false
 	}
 	c.nickFallbacks++
-	base := c.attemptedNick
-	if len(base) >= fallbackMaxNickLen {
-		base = base[:fallbackMaxNickLen-1]
-	}
-	next := base + "_"
 	c.attemptedNick = next
 	return next, true
 }
@@ -1221,7 +1221,13 @@ func (c *Connector) awaitHandshake(ctx context.Context) error {
 				c.log.Info("irc nick in use; using fallback", "desired", c.DesiredNick(), "fallback", next)
 				continue
 			}
-			return fmt.Errorf("irc handshake: nickname %q already in use (433) after %d fallbacks", c.attemptedNick, maxNickFallbacks)
+			return fmt.Errorf("irc handshake: nickname %q already in use (433); no shorter fallback fits %d chars", c.attemptedNick, fallbackMaxNickLen)
+		case ErrErroneusNickname:
+			// 432: the nick is invalid or network-reserved. Appending "_"
+			// can't make it valid, so don't fall back — surface the error and
+			// let the supervisor reconnect under the floor/throttle. (Also the
+			// give-up path when a "_" fallback grew past the server's NICKLEN.)
+			return fmt.Errorf("irc handshake: nickname %q erroneous/reserved (432): %s", c.attemptedNick, msg.Trailing)
 		case ErrUnavailResource:
 			return fmt.Errorf("irc handshake: nickname %q unavailable (437)", c.settings.Nick)
 		case ErrPasswdMismatch:

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -2205,9 +2205,15 @@ func (c *Connector) handleNickChange(ctx context.Context, msg Message) {
 	c.state.OnNickChange(old, newNick)
 	// Self-rename: bump the live nick (and the bouncer's upstreamNick
 	// via setCurrentNick) so every surface that reads CurrentNick
-	// reflects the new identity.
+	// reflects the new identity. A self-rename observed here is the user's
+	// intent (a client /nick the bouncer forwarded, or a feed-driven
+	// ApplyNick) — adopt it as the desired nick too so the reclaim loop
+	// doesn't fight it and the change syncs back as the new saved nick.
+	// (A 433 fallback happens during registration, not here, so it never
+	// reaches this path and the original desired nick is preserved.)
 	if old == c.CurrentNick() {
 		c.setCurrentNick(newNick)
+		c.setDesiredNick(newNick)
 	}
 	c.publish(ctx, agent.Event{
 		Type: agent.EventUserNickChange,

--- a/internal/connector/irc/connector_reconnect_test.go
+++ b/internal/connector/irc/connector_reconnect_test.go
@@ -297,6 +297,8 @@ func (s *reconnectTestServer) handleLine(conn net.Conn, line string) {
 			// Handled on the NICK line(s), not here.
 		case "ERR_NICKNAMEINUSE":
 			_, _ = conn.Write([]byte(":fake 433 * " + nick + " :Nickname is already in use\r\n"))
+		case "ERR_ERRONEOUSNICKNAME":
+			_, _ = conn.Write([]byte(":fake 432 * " + nick + " :Erroneous Nickname\r\n"))
 		case "ERR_PASSWDMISMATCH":
 			_, _ = conn.Write([]byte(":fake 464 " + nick + " :Password incorrect\r\n"))
 		case "ERR_YOUREBANNEDCREEP":
@@ -400,6 +402,43 @@ func TestRegisterFallsBackOnNickInUse(t *testing.T) {
 
 	require.Equal(t, "turborg_", conn.CurrentNick(), "live nick is the fallback")
 	require.Equal(t, "turborg", conn.DesiredNick(), "desired (reclaim target) stays the original")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}
+
+// TestRegisterDoesNotFallBackOnErroneousNick: a 432 (erroneous/reserved
+// nick — e.g. a services-restricted name) must NOT trigger the "_" fallback,
+// because appending "_" can't make an invalid nick valid. It surfaces as
+// nick-unavailable and reconnects (under the throttle) with the same nick.
+func TestRegisterDoesNotFallBackOnErroneousNick(t *testing.T) {
+	fs := newReconnectTestServerWithReject(t, "ERR_ERRONEOUSNICKNAME")
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "admin",
+	}, nil, nil)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedNickUnavailable
+	}, 3*time.Second, 10*time.Millisecond, "432 must surface as nick-unavailable")
+
+	for _, l := range fs.Received() {
+		require.NotContains(t, l, "NICK admin_",
+			"a 432 erroneous nick must NOT fall back to a _-suffixed nick")
+	}
 
 	cancel()
 	select {

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -557,6 +557,8 @@ func TestSelfNickChangeSyncsCurrentNickAndBouncer(t *testing.T) {
 
 	assert.Equal(t, "renamed", c.CurrentNick(),
 		"self-NICK observed must update CurrentNick")
+	assert.Equal(t, "renamed", c.DesiredNick(),
+		"a self-rename is the user's intent — it must become the desired nick so reclaim doesn't fight it and it syncs back")
 	prefix := b.upstreamPrefix()
 	assert.Contains(t, prefix, "renamed!",
 		"setCurrentNick must propagate to the bouncer's upstream prefix")

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -1755,33 +1755,37 @@ func TestBouncerActivityHeartbeat(t *testing.T) {
 
 func TestNextFallbackNick(t *testing.T) {
 	c := New(&Settings{Nick: "turborg"}, nil, nil)
-	c.attemptedNick = "turborg"
-	for i := 1; i <= maxNickFallbacks; i++ {
+	c.attemptedNick = "turborg" // 7 chars
+
+	// Each call appends exactly one more "_" (Stephen → Stephen_ → …),
+	// growing until the next suffix would exceed the cap.
+	prev := "turborg"
+	for {
 		got, ok := c.nextFallbackNick()
 		if !ok {
-			t.Fatalf("fallback %d should be allowed", i)
+			break
 		}
-		if !strings.HasSuffix(got, "_") {
-			t.Fatalf("fallback %d must end with _, got %q", i, got)
+		if got != prev+"_" {
+			t.Fatalf("expected %q, got %q", prev+"_", got)
 		}
+		if len(got) > fallbackMaxNickLen {
+			t.Fatalf("fallback %q exceeds cap %d", got, fallbackMaxNickLen)
+		}
+		prev = got
 	}
-	if _, ok := c.nextFallbackNick(); ok {
-		t.Fatal("must stop after maxNickFallbacks")
+	// The last accepted fallback reaches exactly the cap (no room for more).
+	if len(prev) != fallbackMaxNickLen {
+		t.Fatalf("last fallback %q (len %d) should reach the cap %d", prev, len(prev), fallbackMaxNickLen)
 	}
 }
 
-func TestNextFallbackNickTrimsLongBase(t *testing.T) {
+func TestNextFallbackNickGivesUpWhenNoRoom(t *testing.T) {
+	// Already at the cap: no shorter "_"-suffixed alternative fits, so give
+	// up (the caller then surfaces the 433 and reconnects under the throttle).
 	c := New(&Settings{}, nil, nil)
 	c.attemptedNick = strings.Repeat("a", fallbackMaxNickLen)
-	got, ok := c.nextFallbackNick()
-	if !ok {
-		t.Fatal("a single fallback must be allowed")
-	}
-	if len(got) > fallbackMaxNickLen {
-		t.Fatalf("fallback must trim to fit the cap, got %q (len %d)", got, len(got))
-	}
-	if !strings.HasSuffix(got, "_") {
-		t.Fatalf("fallback must end with _, got %q", got)
+	if _, ok := c.nextFallbackNick(); ok {
+		t.Fatal("must give up when no shorter fallback fits the cap")
 	}
 }
 

--- a/internal/connector/irc/upstream_state.go
+++ b/internal/connector/irc/upstream_state.go
@@ -306,7 +306,7 @@ func ClassifyError(err error) (UpstreamState, bool) {
 // only inspects the numeric code itself.
 func ClassifyNumeric(numeric string, _ []string, _ string) (UpstreamState, bool) {
 	switch numeric {
-	case ErrNickNameInUse, ErrUnavailResource:
+	case ErrNickNameInUse, ErrUnavailResource, ErrErroneusNickname:
 		return UpstreamStateDisconnectedNickUnavailable, true
 	case ErrPasswdMismatch, ErrSaslFail, ErrSaslTooLong:
 		return UpstreamStateDisconnectedAuthFailed, true

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -649,11 +649,12 @@ func buildIRCSnapshot(ircConn *irc.Connector) statepush.SnapshotBuilder {
 		return statepush.Snapshot{
 			Connectors: map[string]statepush.ConnectorSnapshot{
 				ircConn.Name(): {
-					State:    string(machine.State()),
-					Since:    machine.EnteredAt().UTC(),
-					Channels: channels,
-					Nick:     nick,
-					Reason:   machine.ServerReason(),
+					State:       string(machine.State()),
+					Since:       machine.EnteredAt().UTC(),
+					Channels:    channels,
+					Nick:        nick,
+					DesiredNick: ircConn.DesiredNick(),
+					Reason:      machine.ServerReason(),
 				},
 			},
 		}

--- a/internal/server/tenant_statepush.go
+++ b/internal/server/tenant_statepush.go
@@ -51,11 +51,12 @@ func buildIRCSnapshot(conn *irc.Connector) statepush.SnapshotBuilder {
 		return statepush.Snapshot{
 			Connectors: map[string]statepush.ConnectorSnapshot{
 				conn.Name(): {
-					State:    string(machine.State()),
-					Since:    machine.EnteredAt().UTC(),
-					Channels: channels,
-					Nick:     nick,
-					Reason:   machine.ServerReason(),
+					State:       string(machine.State()),
+					Since:       machine.EnteredAt().UTC(),
+					Channels:    channels,
+					Nick:        nick,
+					DesiredNick: conn.DesiredNick(),
+					Reason:      machine.ServerReason(),
 				},
 			},
 		}

--- a/internal/statepush/state_emitter.go
+++ b/internal/statepush/state_emitter.go
@@ -48,6 +48,11 @@ type ConnectorSnapshot struct {
 	Since    time.Time         `json:"since"`
 	Channels []ChannelSnapshot `json:"channels"`
 	Nick     string            `json:"nick"`
+	// DesiredNick is the nick the user wants (the reclaim target), which
+	// differs from Nick when the server forced a "_" fallback. Receivers
+	// persist this as the desired/intent nick and Nick as the observed one,
+	// so a fallback never overwrites the user's saved nick.
+	DesiredNick string `json:"desired_nick"`
 	// Reason is the last server-supplied human-readable explanation for
 	// the current state — e.g. the disconnect/ban text an upstream sent.
 	// Empty for healthy states or when the server gave no reason.

--- a/internal/statepush/state_emitter_test.go
+++ b/internal/statepush/state_emitter_test.go
@@ -114,11 +114,12 @@ func TestStateEmitter_NotifyChangeFiresPutWithZeroDebounce(t *testing.T) {
 		return statepush.Snapshot{
 			Connectors: map[string]statepush.ConnectorSnapshot{
 				"irc": {
-					State:    "disconnected_banned",
-					Since:    time.Unix(0, 0).UTC(),
-					Channels: []statepush.ChannelSnapshot{statepush.NewChannelSnapshot("#a", "")},
-					Nick:     "stefan",
-					Reason:   "Unsolicited advertisements/mass abuse.",
+					State:       "disconnected_banned",
+					Since:       time.Unix(0, 0).UTC(),
+					Channels:    []statepush.ChannelSnapshot{statepush.NewChannelSnapshot("#a", "")},
+					Nick:        "stefan_",
+					DesiredNick: "stefan",
+					Reason:      "Unsolicited advertisements/mass abuse.",
 				},
 			},
 		}
@@ -137,7 +138,8 @@ func TestStateEmitter_NotifyChangeFiresPutWithZeroDebounce(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.bodyAt(0), &got))
 	require.Contains(t, got.Connectors, "irc")
 	assert.Equal(t, "disconnected_banned", got.Connectors["irc"].State)
-	assert.Equal(t, "stefan", got.Connectors["irc"].Nick)
+	assert.Equal(t, "stefan_", got.Connectors["irc"].Nick, "observed/active nick (the fallback)")
+	assert.Equal(t, "stefan", got.Connectors["irc"].DesiredNick, "desired/intent nick (the reclaim target)")
 	assert.Equal(t, "Unsolicited advertisements/mass abuse.", got.Connectors["irc"].Reason)
 	require.Len(t, got.Connectors["irc"].Channels, 1)
 	assert.Equal(t, "#a", got.Connectors["irc"].Channels[0].Name)


### PR DESCRIPTION
## Why

Builds on the live nick/channel apply (#113): for a live `/nick` to sync back to the saved nick correctly, two things are needed.

1. The snapshot reported a single nick (the active one). After a 433 `_` fallback, the active nick is `stephen_` — persisting that as the saved nick would lose the user's intent and stop the reclaim loop from ever taking `stephen` back.
2. A live `/nick` (forwarded by the bouncer) changed the live nick but not the desired one, so the reclaim loop would fight the user's own rename.

## What

- Add `desired_nick` to the state snapshot, reported alongside the active `nick`. Receivers persist `desired_nick` as the saved/intent nick and `nick` as the observed one.
- On observing our own `NICK` change (`handleNickChange`), adopt it as the desired nick too — a self-rename is the user's intent. A 433 fallback occurs during registration, not on this path, so the original desired nick is preserved.

Additive snapshot field (empty for older receivers, like the prior `reason` field). Covers both runtimes (shared connector + both snapshot builders).

## Test

`go test -race ./...`, coverage gate, `golangci-lint` all pass. Self-nick test asserts the desired-nick adoption; statepush round-trip asserts `desired_nick` distinct from the active nick.