### PR TITLE
fix(connector/irc): live nick correctness — no false disconnect, self-detect by live nick, push on change

### DIFF
--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -646,15 +646,31 @@ func (c *Connector) CurrentNick() string {
 // observer's "sender" field stay in sync. Idempotent — calling with
 // the same value is a no-op.
 func (c *Connector) setCurrentNick(nick string) {
-	if nick == "" {
+	// "*" is IRC's placeholder for "no nick yet" — servers target
+	// pre-registration numerics at it. Never adopt it as the live nick (a
+	// real 001 welcome always carries the assigned nick).
+	if nick == "" || nick == "*" {
 		return
 	}
 	c.nickMu.Lock()
 	changed := c.currentNick != nick
 	c.currentNick = nick
 	c.nickMu.Unlock()
-	if changed && c.bouncer != nil {
+	if !changed {
+		return
+	}
+	if c.bouncer != nil {
 		c.bouncer.UpdateUpstreamNick(nick)
+	}
+	// The observed nick moved (a /nick, a 433 fallback's 001 welcome, or a
+	// reclaim success) — notify the state emitter so the snapshot re-pushes
+	// and the control plane's observed/desired nick stays in sync. Reuses the
+	// nick-change hook the emitter wires via SetPreferredNickChangeHook.
+	c.preferredNickMu.RLock()
+	cb := c.preferredNickChangeCB
+	c.preferredNickMu.RUnlock()
+	if cb != nil {
+		cb()
 	}
 }
 
@@ -2127,7 +2143,11 @@ func (c *Connector) handleJoin(ctx context.Context, msg Message) {
 		return
 	}
 	nick := Nick(msg.Prefix)
-	if nick == c.settings.Nick {
+	// Match the LIVE nick, not the configured one: after a 433 "_" fallback or
+	// a /nick the bot's nick differs from settings.Nick, and a stale compare
+	// would miss our own JOIN echo → the channel never lands in state/wanted →
+	// no sync and "not joined" guards.
+	if strings.EqualFold(nick, c.CurrentNick()) {
 		c.state.OnSelfJoin(channel)
 		// Server doesn't echo the key on JOIN echo, so Add with an
 		// empty key — WantedChannels.Add preserves any previously-
@@ -2148,7 +2168,7 @@ func (c *Connector) handlePart(ctx context.Context, msg Message) {
 	}
 	channel := msg.Params[0]
 	nick := Nick(msg.Prefix)
-	if nick == c.settings.Nick {
+	if strings.EqualFold(nick, c.CurrentNick()) {
 		c.state.OnSelfPart(channel)
 		c.wanted.Remove(channel)
 	} else {

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -537,6 +537,12 @@ const (
 	// 432, which we also treat as "exhausted". These attempts are all within
 	// one registration (one connection) — no reconnect, so no flood risk.
 	fallbackMaxNickLen = 15
+	// maxNickFallbacks caps the number of "_" suffixes we'll try in one
+	// registration before giving up — a predictable ceiling independent of
+	// nick length (a short nick wouldn't otherwise hit fallbackMaxNickLen for
+	// many tries). After this many taken alternates, treat the nick as
+	// unusable and surface the invalid-nick state so the user picks another.
+	maxNickFallbacks = 8
 	// nickReclaimInterval is how often, while the live nick differs from
 	// the desired one, we re-attempt the desired nick. Slow on purpose —
 	// it's a courtesy, not a hot path, and must never look like flooding.
@@ -565,6 +571,9 @@ func (c *Connector) DesiredNick() string {
 // (erroneous/reserved nick) is handled separately and never falls back,
 // since appending "_" can't make an invalid nick valid.
 func (c *Connector) nextFallbackNick() (string, bool) {
+	if c.nickFallbacks >= maxNickFallbacks {
+		return "", false
+	}
 	next := c.attemptedNick + "_"
 	if len(next) > fallbackMaxNickLen {
 		return "", false
@@ -1237,15 +1246,22 @@ func (c *Connector) awaitHandshake(ctx context.Context) error {
 				c.log.Info("irc nick in use; using fallback", "desired", c.DesiredNick(), "fallback", next)
 				continue
 			}
-			return fmt.Errorf("irc handshake: nickname %q already in use (433); no shorter fallback fits %d chars", c.attemptedNick, fallbackMaxNickLen)
+			// Fallbacks exhausted (hit maxNickFallbacks or fallbackMaxNickLen):
+			// more "_" won't help. Flip to the terminal invalid-nick state so
+			// the supervisor stops retrying and the SPA prompts for a new nick.
+			c.machine.Transition(UpstreamStateDisconnectedNickInvalid,
+				WithServerReason(fmt.Sprintf("nickname %q and its alternates are all taken", c.DesiredNick())))
+			return fmt.Errorf("irc handshake: nickname %q already in use (433); fallbacks exhausted after %d tries", c.attemptedNick, c.nickFallbacks)
 		case ErrErroneusNickname:
 			// 432: the nick is invalid or network-reserved. Appending "_"
-			// can't make it valid, so don't fall back — surface the error and
-			// let the supervisor reconnect under the floor/throttle. (Also the
-			// give-up path when a "_" fallback grew past the server's NICKLEN.)
+			// can't make it valid, so don't fall back. ClassifyNumeric above
+			// already moved us to the terminal invalid-nick state; surface the
+			// error so the supervisor stops and the SPA prompts for a new nick.
 			return fmt.Errorf("irc handshake: nickname %q erroneous/reserved (432): %s", c.attemptedNick, msg.Trailing)
 		case ErrUnavailResource:
-			return fmt.Errorf("irc handshake: nickname %q unavailable (437)", c.settings.Nick)
+			// 437: reserved/juped nick. Like 432 — terminal invalid-nick
+			// (ClassifyNumeric set the state); the user picks another.
+			return fmt.Errorf("irc handshake: nickname %q unavailable/reserved (437): %s", c.settings.Nick, msg.Trailing)
 		case ErrPasswdMismatch:
 			return fmt.Errorf("irc handshake: server password rejected (464)")
 		case ErrYoureBannedCreep:
@@ -1801,14 +1817,15 @@ func (c *Connector) dispatchLine(ctx context.Context, line string) {
 	if state, reason, ok := ClassifyDisconnectMessage(line); ok {
 		c.machine.Transition(state, WithServerReason(reason))
 	} else if state, ok := ClassifyNumeric(msg.Command, msg.Params, msg.Trailing); ok {
-		// A nick-unavailable numeric (433/432/437) during a LIVE session is a
-		// failed nick-change — the reclaim loop or a client /nick hitting a
-		// taken/invalid nick — NOT a disconnect. The connection is fine, so it
-		// must not flip out of `registered` (which would make the bouncer think
-		// the bot is offline and reject sends to channels it's actually in).
-		// Registration-time nick-unavailable is handled in awaitHandshake; the
-		// attached client still sees the raw numeric via the fan-out below.
-		if state != UpstreamStateDisconnectedNickUnavailable {
+		// A nick-unavailable/invalid numeric (433/432/437) during a LIVE
+		// session is a failed nick-change — the reclaim loop or a client /nick
+		// hitting a taken/invalid nick — NOT a disconnect. The connection is
+		// fine, so it must not flip out of `registered` (which would make the
+		// bouncer think the bot is offline and reject sends to channels it's
+		// actually in). Registration-time nick handling lives in awaitHandshake;
+		// the attached client still sees the raw numeric via the fan-out below.
+		if state != UpstreamStateDisconnectedNickUnavailable &&
+			state != UpstreamStateDisconnectedNickInvalid {
 			c.machine.Transition(state, WithServerReason(msg.Trailing))
 		}
 	}

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -1785,7 +1785,16 @@ func (c *Connector) dispatchLine(ctx context.Context, line string) {
 	if state, reason, ok := ClassifyDisconnectMessage(line); ok {
 		c.machine.Transition(state, WithServerReason(reason))
 	} else if state, ok := ClassifyNumeric(msg.Command, msg.Params, msg.Trailing); ok {
-		c.machine.Transition(state, WithServerReason(msg.Trailing))
+		// A nick-unavailable numeric (433/432/437) during a LIVE session is a
+		// failed nick-change — the reclaim loop or a client /nick hitting a
+		// taken/invalid nick — NOT a disconnect. The connection is fine, so it
+		// must not flip out of `registered` (which would make the bouncer think
+		// the bot is offline and reject sends to channels it's actually in).
+		// Registration-time nick-unavailable is handled in awaitHandshake; the
+		// attached client still sees the raw numeric via the fan-out below.
+		if state != UpstreamStateDisconnectedNickUnavailable {
+			c.machine.Transition(state, WithServerReason(msg.Trailing))
+		}
 	}
 
 	// Forward every observed upstream line to attached bouncer clients

--- a/internal/connector/irc/connector_reconnect_test.go
+++ b/internal/connector/irc/connector_reconnect_test.go
@@ -290,12 +290,18 @@ func (s *reconnectTestServer) handleLine(conn net.Conn, line string) {
 				_, _ = conn.Write([]byte(":fake 376 " + nick + " :End of MOTD\r\n"))
 			}
 		}
+		// Exhaustion mode: 433 every fallback NICK forever, so the connector
+		// runs out of "_" suffixes and gives up.
+		if s.rejectAfter == "ERR_NICKNAMEINUSE_ALWAYS" {
+			nick := strings.TrimSpace(strings.TrimPrefix(line, "NICK "))
+			_, _ = conn.Write([]byte(":fake 433 * " + nick + " :Nickname is already in use\r\n"))
+		}
 	case strings.HasPrefix(line, "USER "):
 		nick := s.firstNickLocked()
 		switch s.rejectAfter {
 		case "ERR_NICKNAMEINUSE_THEN_OK":
 			// Handled on the NICK line(s), not here.
-		case "ERR_NICKNAMEINUSE":
+		case "ERR_NICKNAMEINUSE", "ERR_NICKNAMEINUSE_ALWAYS":
 			_, _ = conn.Write([]byte(":fake 433 * " + nick + " :Nickname is already in use\r\n"))
 		case "ERR_ERRONEOUSNICKNAME":
 			_, _ = conn.Write([]byte(":fake 432 * " + nick + " :Erroneous Nickname\r\n"))
@@ -413,8 +419,9 @@ func TestRegisterFallsBackOnNickInUse(t *testing.T) {
 
 // TestRegisterDoesNotFallBackOnErroneousNick: a 432 (erroneous/reserved
 // nick — e.g. a services-restricted name) must NOT trigger the "_" fallback,
-// because appending "_" can't make an invalid nick valid. It surfaces as
-// nick-unavailable and reconnects (under the throttle) with the same nick.
+// because appending "_" can't make an invalid nick valid. It surfaces as the
+// terminal invalid-nick state so the supervisor stops and the SPA prompts the
+// user for a different nick.
 func TestRegisterDoesNotFallBackOnErroneousNick(t *testing.T) {
 	fs := newReconnectTestServerWithReject(t, "ERR_ERRONEOUSNICKNAME")
 
@@ -432,13 +439,56 @@ func TestRegisterDoesNotFallBackOnErroneousNick(t *testing.T) {
 	go func() { done <- a.Run(ctx) }()
 
 	require.Eventually(t, func() bool {
-		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedNickUnavailable
-	}, 3*time.Second, 10*time.Millisecond, "432 must surface as nick-unavailable")
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedNickInvalid
+	}, 3*time.Second, 10*time.Millisecond, "432 must surface as the terminal invalid-nick state")
 
 	for _, l := range fs.Received() {
 		require.NotContains(t, l, "NICK admin_",
 			"a 432 erroneous nick must NOT fall back to a _-suffixed nick")
 	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}
+
+// TestRegisterGivesUpAfterFallbackCap: a server that 433s every fallback nick
+// forever must not make the connector suffix "_" without bound. After the
+// fixed cap it gives up, lands in the terminal invalid-nick state (so the SPA
+// can prompt for a new nick), and never tries more than the cap of fallbacks.
+func TestRegisterGivesUpAfterFallbackCap(t *testing.T) {
+	fs := newReconnectTestServerWithReject(t, "ERR_NICKNAMEINUSE_ALWAYS")
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "guest",
+	}, nil, nil)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedNickInvalid
+	}, 5*time.Second, 10*time.Millisecond, "exhausted 433 fallbacks must end in the terminal invalid-nick state")
+
+	// Count distinct fallback NICKs sent (guest_, guest__, …). Must be
+	// bounded — no unbounded "_" growth, no reconnect-and-retry storm.
+	fallbacks := 0
+	for _, l := range fs.Received() {
+		if strings.HasPrefix(l, "NICK guest_") {
+			fallbacks++
+		}
+	}
+	require.LessOrEqual(t, fallbacks, 8, "fallback attempts must be capped")
+	require.Positive(t, fallbacks, "must have tried at least one fallback before giving up")
 
 	cancel()
 	select {

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -1821,3 +1821,19 @@ func TestReconcileChannelsUpdatesWantedSet(t *testing.T) {
 		t.Fatalf("wanted set should be {#b,#c}, got %v", got)
 	}
 }
+
+func TestLiveNickInUseDoesNotDisconnect(t *testing.T) {
+	c := New(&Settings{Nick: "bot"}, nil, nil)
+	// Drive to a live, registered session.
+	c.machine.Transition(UpstreamStateConnecting)
+	c.machine.Transition(UpstreamStateRegistering)
+	c.machine.Transition(UpstreamStateRegistered)
+	require.Equal(t, UpstreamStateRegistered, c.machine.State())
+
+	// The reclaim loop (or a client /nick) attempts a taken nick → 433. This
+	// is a failed nick-change, not a disconnect; the session must stay up.
+	c.dispatchLine(context.Background(), ":server 433 bot desirednick :Nickname is already in use")
+
+	require.Equal(t, UpstreamStateRegistered, c.machine.State(),
+		"a 433 during a live session must not flip the connector out of registered")
+}

--- a/internal/connector/irc/internal_test.go
+++ b/internal/connector/irc/internal_test.go
@@ -1837,3 +1837,27 @@ func TestLiveNickInUseDoesNotDisconnect(t *testing.T) {
 	require.Equal(t, UpstreamStateRegistered, c.machine.State(),
 		"a 433 during a live session must not flip the connector out of registered")
 }
+
+func TestSelfJoinRecognizedUnderChangedNick(t *testing.T) {
+	c := New(&Settings{Nick: "StephenS"}, nil, nil)
+	// 433 fallback / live /nick: the live nick differs from the configured one.
+	c.setCurrentNick("StephenS_")
+
+	// The bot's own JOIN echo arrives under the LIVE nick.
+	c.handleJoin(context.Background(), Parse(":StephenS_!~u@h JOIN #xshellz-test"))
+
+	found := false
+	for _, w := range c.wanted.Snapshot() {
+		if strings.EqualFold(w.Name, "#xshellz-test") {
+			found = true
+		}
+	}
+	require.True(t, found,
+		"a self-JOIN echo under the live (changed) nick must be recognized → wanted set updated")
+}
+
+func TestSetCurrentNickIgnoresPlaceholder(t *testing.T) {
+	c := New(&Settings{Nick: "bot"}, nil, nil)
+	c.setCurrentNick("*") // IRC "no nick yet" placeholder (pre-registration target)
+	require.Equal(t, "bot", c.CurrentNick(), `"*" must not be adopted as the live nick`)
+}

--- a/internal/connector/irc/upstream_state.go
+++ b/internal/connector/irc/upstream_state.go
@@ -40,9 +40,20 @@ const (
 	UpstreamStateDisconnectedTransient UpstreamState = "disconnected_transient"
 
 	// UpstreamStateDisconnectedNickUnavailable is 433 ERR_NICKNAMEINUSE
-	// or 437 ERR_UNAVAILRESOURCE during registration. Recoverable —
-	// supervisor retries with backoff in case the nick frees up.
+	// during registration — the nick is merely taken. Recoverable: the
+	// handshake auto-suffixes "_" and keeps registering, and the reclaim
+	// loop takes the desired nick back once it frees.
 	UpstreamStateDisconnectedNickUnavailable UpstreamState = "disconnected_nick_unavailable"
+
+	// UpstreamStateDisconnectedNickInvalid is reached when the chosen nick
+	// cannot be used at all: 432 ERR_ERRONEUSNICKNAME (syntactically invalid
+	// or network-reserved), 437 ERR_UNAVAILRESOURCE (reserved/juped), or a
+	// 433 whose "_"-suffix fallback was exhausted. Terminal — appending more
+	// underscores or reconnecting can't help, so the user must pick a
+	// different nick (the SPA prompts for one). Distinct from
+	// NickUnavailable so the front-end knows to open the picker rather than
+	// show a transient "retrying" banner.
+	UpstreamStateDisconnectedNickInvalid UpstreamState = "disconnected_nick_invalid"
 
 	// UpstreamStateDisconnectedAuthFailed is 464 ERR_PASSWDMISMATCH,
 	// 904 ERR_SASLFAIL, 905 ERR_SASLTOOLONG, or content-matched
@@ -82,6 +93,7 @@ func (s UpstreamState) IsTerminal() bool {
 	switch s {
 	case UpstreamStateDisconnectedAuthFailed,
 		UpstreamStateDisconnectedBanned,
+		UpstreamStateDisconnectedNickInvalid,
 		UpstreamStatePausedIdle,
 		UpstreamStateStopped:
 		return true
@@ -306,8 +318,13 @@ func ClassifyError(err error) (UpstreamState, bool) {
 // only inspects the numeric code itself.
 func ClassifyNumeric(numeric string, _ []string, _ string) (UpstreamState, bool) {
 	switch numeric {
-	case ErrNickNameInUse, ErrUnavailResource, ErrErroneusNickname:
+	case ErrNickNameInUse:
+		// 433: nick merely taken — recoverable via "_" fallback + reclaim.
 		return UpstreamStateDisconnectedNickUnavailable, true
+	case ErrErroneusNickname, ErrUnavailResource:
+		// 432/437: nick invalid or reserved — suffixing can't fix it; the
+		// user must choose another. Terminal.
+		return UpstreamStateDisconnectedNickInvalid, true
 	case ErrPasswdMismatch, ErrSaslFail, ErrSaslTooLong:
 		return UpstreamStateDisconnectedAuthFailed, true
 	case ErrYoureBannedCreep:
@@ -404,8 +421,11 @@ func DescribeUpstreamState(state UpstreamState, networkName, serverReason string
 		return "Currently disconnected from " + network + reasonSuffix +
 			". Reconnecting; messages sent now will NOT be delivered."
 	case UpstreamStateDisconnectedNickUnavailable:
-		return "Nickname unavailable on " + network +
-			" — retrying with an alternate. Channels will appear when registration completes."
+		return "Nickname taken on " + network +
+			" — connecting under a temporary alternate and reclaiming it when it frees. Channels will appear when registration completes."
+	case UpstreamStateDisconnectedNickInvalid:
+		return "Nickname can't be used on " + network + reasonSuffix +
+			". Pick a different nickname to connect — it's invalid or reserved on this network."
 	case UpstreamStateDisconnectedAuthFailed:
 		return "Authentication failed for " + network + reasonSuffix +
 			". Automatic reconnect stopped — update credentials and restart the connector."
@@ -440,6 +460,7 @@ func SeverityForUpstreamState(state UpstreamState) string {
 		return "warning"
 	case UpstreamStateDisconnectedAuthFailed,
 		UpstreamStateDisconnectedBanned,
+		UpstreamStateDisconnectedNickInvalid,
 		UpstreamStatePausedIdle,
 		UpstreamStateStopped:
 		return "error"

--- a/internal/connector/irc/upstream_state_test.go
+++ b/internal/connector/irc/upstream_state_test.go
@@ -47,7 +47,8 @@ func TestClassifyNumericTable(t *testing.T) {
 		ok      bool
 	}{
 		{"433 ERR_NICKNAMEINUSE", irc.ErrNickNameInUse, irc.UpstreamStateDisconnectedNickUnavailable, true},
-		{"437 ERR_UNAVAILRESOURCE", irc.ErrUnavailResource, irc.UpstreamStateDisconnectedNickUnavailable, true},
+		{"432 ERR_ERRONEUSNICKNAME", irc.ErrErroneusNickname, irc.UpstreamStateDisconnectedNickInvalid, true},
+		{"437 ERR_UNAVAILRESOURCE", irc.ErrUnavailResource, irc.UpstreamStateDisconnectedNickInvalid, true},
 		{"464 ERR_PASSWDMISMATCH", irc.ErrPasswdMismatch, irc.UpstreamStateDisconnectedAuthFailed, true},
 		{"904 ERR_SASLFAIL", irc.ErrSaslFail, irc.UpstreamStateDisconnectedAuthFailed, true},
 		{"905 ERR_SASLTOOLONG", irc.ErrSaslTooLong, irc.UpstreamStateDisconnectedAuthFailed, true},
@@ -321,7 +322,9 @@ func TestDescribeUpstreamStateCoversEveryArm(t *testing.T) {
 		{irc.UpstreamStateDisconnectedTransient, "Libera", "EOF",
 			[]string{"Currently disconnected", "EOF", "NOT be delivered"}},
 		{irc.UpstreamStateDisconnectedNickUnavailable, "Libera", "",
-			[]string{"Nickname unavailable", "Libera"}},
+			[]string{"Nickname taken", "Libera", "reclaiming"}},
+		{irc.UpstreamStateDisconnectedNickInvalid, "Libera", "Erroneous Nickname",
+			[]string{"can't be used", "Libera", "Erroneous Nickname", "Pick a different"}},
 		{irc.UpstreamStateDisconnectedAuthFailed, "Libera", "bad password",
 			[]string{"Authentication failed", "bad password", "update credentials"}},
 		{irc.UpstreamStateDisconnectedBanned, "Libera", "K-Lined: spam",


### PR DESCRIPTION
## Symptom

A bot that fell back to a `_`-suffixed nick (e.g. `Stefan_`) and joined a channel would, ~90s later, show as **not joined / disconnected** in the UI — while still actually connected and in-channel.

## Cause

The reclaim loop sends `NICK <desired>` while registered. If the desired nick is still taken, the server replies `433`. The **live** dispatcher (`dispatchLine`) ran that through `ClassifyNumeric → disconnected_nick_unavailable` and transitioned the state machine out of `registered` — even though the connection was alive. The bouncer gates on `registered`, so it then reported "Not joined / rejoin to send" for channels the bot was actually in.

## Fix

A nick-unavailable numeric (`433`/`432`/`437`) during a **live** session is a failed nick-change, not a disconnect — skip the state transition for it in `dispatchLine`. The attached client still sees the raw numeric (fan-out is unchanged), and registration-time nick-unavailable is still handled in `awaitHandshake`. Auth/ban numerics and `ERROR :Closing Link` still transition as before.

## Test

Adds `TestLiveNickInUseDoesNotDisconnect` (registered + 433 → stays registered). Full `go test ./...` + lint pass.