### PR TITLE
feat(connector/irc): park & resume the upstream link (Suspend/Resume + nick recovery)

### DIFF
--- a/internal/configrefresh/refresh.go
+++ b/internal/configrefresh/refresh.go
@@ -14,7 +14,7 @@
 //	GET <url>
 //	  Authorization: Bearer <token>
 //	  Status: 200 on success.
-//	  Body: {"nick": "<nick>", "channels": ["#a", "#b", ...]}
+//	  Body: {"nick": "<nick>", "channels": ["#a", "#b", ...], "suspended": false}
 //
 // Failures are non-fatal: the last applied config stays in force and the loop
 // retries on the next tick.
@@ -40,6 +40,11 @@ const (
 type Config struct {
 	Nick     string   `json:"nick"`
 	Channels []string `json:"channels"`
+	// Suspended is the user's desired connect/disconnect intent. true parks
+	// the upstream link (Suspend); false reconnects (Resume). Absent decodes
+	// to false (connected), so an old control plane that omits the field keeps
+	// the connector connected.
+	Suspended bool `json:"suspended"`
 }
 
 // Apply installs a freshly-fetched config on the live connector. The runtime

--- a/internal/connector/irc/connector.go
+++ b/internal/connector/irc/connector.go
@@ -213,6 +213,21 @@ type Connector struct {
 	whoInFlight map[string]*whoBuilder
 
 	stopOnce sync.Once
+
+	// lifecycleMu guards suspended, the user-disconnect intent driven by
+	// Suspend()/Resume() (the chat UI's Connect/Disconnect button, delivered
+	// via the config-refresh poll / tenant feed). Distinct from the observed
+	// upstream state: suspended is what the user WANTS, the state machine is
+	// what IS.
+	lifecycleMu sync.Mutex
+	suspended   bool
+
+	// lifecycleCh is a buffered(1) wakeup the supervisor selects on so a
+	// Suspend/Resume/nick-change unblocks a parked supervisor (or interrupts
+	// a backoff sleep) promptly instead of waiting out the park re-check
+	// ticker. A best-effort fast path: the authoritative park predicate is
+	// re-evaluated on every wake, so a coalesced/dropped signal is harmless.
+	lifecycleCh chan struct{}
 }
 
 // whoisBuilder accumulates a WHOIS response across the 311/312/313/317/
@@ -277,6 +292,7 @@ func New(s *Settings, log *slog.Logger, events *agent.EventBus) *Connector {
 		wanted:      NewWantedChannels(s.NormalizedChannels()),
 		currentNick: s.Nick,
 		tb:          newTBHandler(log),
+		lifecycleCh: make(chan struct{}, 1),
 		storm: newReconnectStorm(
 			defaultReconnectStormWindow,
 			defaultReconnectStormMax,
@@ -596,9 +612,141 @@ func (c *Connector) ApplyNick(nick string) {
 	}
 	c.setDesiredNick(nick)
 	c.SetPreferredNick(nick)
-	if c.machine.State() == UpstreamStateRegistered {
+	switch c.machine.State() {
+	case UpstreamStateRegistered:
 		if cli := c.getClient(); cli != nil {
 			_ = cli.WriteLine(CmdNick + " " + nick)
+		}
+	case UpstreamStateDisconnectedNickInvalid:
+		// Parked awaiting a usable nick: the fresh choice is the resume
+		// trigger. Wake the supervisor, which re-registers with the queued
+		// preferred nick. The park predicate also re-checks DesiredNick on
+		// its own ticker, so a missed wakeup self-heals.
+		c.signalLifecycle()
+	}
+}
+
+// Suspend drops the upstream link on user request (the chat UI's Disconnect
+// button) WITHOUT tearing the connector down: it records the intent, sends a
+// QUIT, closes the upstream client, and parks the supervisor in
+// disconnected_by_user awaiting Resume. The bouncer and web gateway stay up —
+// critical pooled, where one container is shared by N tenants. Idempotent and
+// safe to call from any goroutine; a no-op when already suspended.
+func (c *Connector) Suspend() {
+	c.lifecycleMu.Lock()
+	if c.suspended {
+		c.lifecycleMu.Unlock()
+		return
+	}
+	c.suspended = true
+	c.lifecycleMu.Unlock()
+
+	// Publish the parkable state BEFORE closing the client so the supervisor's
+	// post-session classification sees disconnected_by_user (parkable) and
+	// parks, instead of treating the close as a transient failure to back off
+	// from. classifyFallback / transitionFromError both bail on parkable
+	// states, so a concurrent bringUp can't clobber it.
+	c.machine.Transition(UpstreamStateDisconnectedByUser)
+	if cli := c.getClient(); cli != nil {
+		_ = cli.WriteLine(CmdQuit + " :" + c.settings.EffectiveQuitMessage())
+		_ = cli.Close()
+		c.setClient(nil)
+	}
+	c.signalLifecycle()
+}
+
+// Resume clears a user-requested disconnect and wakes the parked supervisor,
+// which reconnects immediately (no backoff — a deliberate action, rate-limited
+// upstream by the control plane's lifecycle cooldown). Idempotent and safe
+// from any goroutine; a no-op when not suspended.
+func (c *Connector) Resume() {
+	c.lifecycleMu.Lock()
+	if !c.suspended {
+		c.lifecycleMu.Unlock()
+		return
+	}
+	c.suspended = false
+	c.lifecycleMu.Unlock()
+	c.signalLifecycle()
+}
+
+// SetInitialSuspended records a boot-time user-disconnect intent before Start.
+// When true, Start skips the initial connect and Run parks immediately, so a
+// connector that boots while the user has it disconnected (a pooled tenant
+// built from a suspended spec, a restarted container) comes up parked rather
+// than flapping connect→quit. Must be called before Start; not for live use
+// (use Suspend/Resume for that).
+func (c *Connector) SetInitialSuspended(v bool) {
+	c.lifecycleMu.Lock()
+	c.suspended = v
+	c.lifecycleMu.Unlock()
+}
+
+// isSuspended reports the current user-disconnect intent.
+func (c *Connector) isSuspended() bool {
+	c.lifecycleMu.Lock()
+	defer c.lifecycleMu.Unlock()
+	return c.suspended
+}
+
+// shouldPark reports whether the supervisor should park rather than maintain
+// an upstream session: the user has suspended the link, or the chosen nick is
+// unusable (awaiting a new one). The authoritative source of truth the park
+// loop re-evaluates on every wakeup.
+func (c *Connector) shouldPark() bool {
+	return c.isSuspended() || c.machine.State() == UpstreamStateDisconnectedNickInvalid
+}
+
+// signalLifecycle pokes the supervisor's lifecycle wakeup channel without
+// blocking. Coalesces — a pending signal absorbs the new one — because the
+// receiver always re-reads the authoritative state, so one wakeup is enough.
+func (c *Connector) signalLifecycle() {
+	select {
+	case c.lifecycleCh <- struct{}{}:
+	default:
+	}
+}
+
+// parkRecheckInterval is the safety-net cadence at which a parked supervisor
+// re-evaluates its park predicate even if the fast-path lifecycle signal was
+// missed (coalesced/dropped). Slow on purpose: the signal handles the common
+// case immediately; this only bounds the worst-case resume latency.
+const parkRecheckInterval = 2 * time.Second
+
+// park blocks the supervisor while the connector is intentionally off-upstream
+// (user-suspended or awaiting a usable nick), doing no dialing, backoff, or
+// escalation. It returns true when the park condition clears (Resume / a new
+// nick) and the supervisor should reconnect, or false when ctx is cancelled
+// (operator shutdown) and the supervisor should stop.
+//
+// stillParked is the caller-captured predicate evaluated on every wakeup; it
+// is the source of truth (the lifecycleCh signal and the ticker are only
+// prompts to re-check), so a missed signal self-heals within parkRecheckInterval.
+func (c *Connector) park(ctx context.Context, stillParked func() bool) bool {
+	// Drop any signal buffered before this park began — it predates us and the
+	// predicate, not the channel, decides.
+	select {
+	case <-c.lifecycleCh:
+	default:
+	}
+	if !stillParked() {
+		return true
+	}
+	c.log.Info("irc upstream parked", "state", c.machine.State())
+	t := time.NewTicker(parkRecheckInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-c.lifecycleCh:
+			if !stillParked() {
+				return true
+			}
+		case <-t.C:
+			if !stillParked() {
+				return true
+			}
 		}
 	}
 }
@@ -758,17 +906,27 @@ func (c *Connector) Start(ctx context.Context) error {
 		}
 	}
 
-	// A RECOVERABLE initial-connect failure (unreachable network, wrong port,
-	// TLS/cert mismatch, plaintext-on-TLS-port) must NOT abort Start: the
-	// bouncer + web shell are already up, and Run's supervisor retries with
-	// backoff. bringUp has set the state machine to the disconnected_* reason,
-	// which surfaces on the connector pill as "disconnected: <reason>,
-	// reconnecting". Only a terminal failure (operator cancel, auth/ban) aborts.
-	if err := c.bringUp(ctx); err != nil {
-		if !c.machine.State().IsRecoverable() {
+	// Boot already suspended (a pooled tenant built from a suspended spec, or a
+	// restarted container the user had disconnected): skip the initial connect
+	// and let Run park immediately, rather than flapping connect→quit. The
+	// bouncer + web shell are already up.
+	if c.isSuspended() {
+		c.machine.Transition(UpstreamStateDisconnectedByUser)
+		c.log.Info("irc connector starting suspended; awaiting resume")
+	} else if err := c.bringUp(ctx); err != nil {
+		// A RECOVERABLE initial-connect failure (unreachable network, wrong
+		// port, TLS/cert mismatch, plaintext-on-TLS-port) must NOT abort Start:
+		// the bouncer + web shell are already up, and Run's supervisor retries
+		// with backoff. A PARKABLE failure (unusable nick) likewise enters
+		// supervision so the SPA can prompt for a new nick and resume in place.
+		// bringUp has set the state machine to the disconnected_* reason, which
+		// surfaces on the connector pill. Only a terminal failure (operator
+		// cancel, auth/ban) aborts.
+		st := c.machine.State()
+		if !st.IsRecoverable() && !st.IsParkable() {
 			return err
 		}
-		c.log.Warn("irc initial connect failed; entering reconnect supervision", "err", err)
+		c.log.Warn("irc initial connect failed; entering reconnect supervision", "err", err, "state", st)
 	}
 
 	if c.settings.CTCPMaxPerWindow > 0 && c.settings.CTCPWindowSeconds > 0 {
@@ -946,7 +1104,7 @@ func (c *Connector) transitionFromError(err error) {
 // path (that misclassified an unreachable network as a permanent stop, killing
 // the tenant instead of reconnecting).
 func (c *Connector) classifyFallback(ctx context.Context, err error) {
-	if cur := c.machine.State(); cur.IsRecoverable() || cur.IsTerminal() {
+	if cur := c.machine.State(); cur.IsRecoverable() || cur.IsTerminal() || cur.IsParkable() {
 		return
 	}
 	if ctx.Err() != nil {
@@ -1338,6 +1496,14 @@ func (c *Connector) readLineRespectingCtx(ctx context.Context) (string, error) {
 //   - non-nil error when the connector reaches a terminal state
 //     (auth_failed / banned / paused_idle) — agent.Run treats that as
 //     fatal and unwinds the rest of the connectors via Stop.
+//
+// This is the connector's central supervisor state machine — park / session /
+// classify / terminal / backoff-reconnect, each guarded for operator cancel +
+// terminal escalation. The cohesive sub-steps (runPark, runSession) are already
+// extracted; the remaining branchiness is the irreducible loop itself, like the
+// sibling runSession / dispatchLine loops in this file.
+//
+//nolint:gocyclo // central supervisor state machine; see the doc comment above.
 func (c *Connector) Run(ctx context.Context) error {
 	// A nil client with the machine still in its initial Idle state means Run
 	// was called before Start ever attempted a connect — a programming error.
@@ -1391,6 +1557,19 @@ func (c *Connector) Run(ctx context.Context) error {
 	}
 
 	for {
+		// Park whenever the user has suspended the link or the chosen nick is
+		// unusable: block with no dialing, backoff, or escalation until Resume
+		// / a new nick / operator shutdown, then reconnect immediately. Parking
+		// keeps the bouncer + web gateway up — only the upstream link is down.
+		if c.shouldPark() {
+			newStart, stop := c.runPark(runCtx, backoff, watchdogDone)
+			if stop {
+				return nil
+			}
+			sessionStart = newStart
+			continue
+		}
+
 		err := c.runSession(runCtx)
 
 		// Operator-initiated cancellation takes precedence over any
@@ -1403,13 +1582,21 @@ func (c *Connector) Run(ctx context.Context) error {
 
 		// If the read/dispatch path observed a classified ERROR or
 		// numeric, the state machine is already in the right place.
-		// Otherwise, fall back to classifying the Go error.
-		if cur := c.machine.State(); !cur.IsRecoverable() && !cur.IsTerminal() {
+		// Otherwise, fall back to classifying the Go error. Parkable states
+		// (a mid-session Suspend, an unusable nick) are intentional and must
+		// not be reclassified as a transport failure.
+		if cur := c.machine.State(); !cur.IsRecoverable() && !cur.IsTerminal() && !cur.IsParkable() {
 			c.transitionFromError(err)
 		}
 
 		if c.machine.State().IsTerminal() {
 			return exitTerminal(err)
+		}
+
+		// A mid-session Suspend or a now-unusable nick: loop so the park
+		// branch at the top handles it (no backoff reset / sleep churn).
+		if c.shouldPark() {
+			continue
 		}
 
 		// Only credit a backoff reset if the session that just ended ran
@@ -1437,7 +1624,16 @@ func (c *Connector) Run(ctx context.Context) error {
 				return nil
 			}
 			return exitTerminal(nil)
+		case <-c.lifecycleCh:
+			// A Suspend/Resume landed during the backoff sleep — re-evaluate
+			// at the top (park if now suspended, otherwise dial immediately).
+			continue
 		case <-time.After(delay):
+		}
+
+		// A Suspend during the sleep flips us parkable; don't dial.
+		if c.shouldPark() {
+			continue
 		}
 
 		if err := c.bringUp(runCtx); err != nil {
@@ -1454,6 +1650,44 @@ func (c *Connector) Run(ctx context.Context) error {
 		}
 		sessionStart = time.Now()
 	}
+}
+
+// runPark blocks the supervisor on a parkable state (user-suspended or awaiting
+// a usable nick) and, once it clears, performs one immediate reconnect. Returns
+// the session-start stamp for a successful reconnect (zero when the reconnect
+// failed — the caller's loop re-evaluates) and stop=true when the connector
+// should shut down (operator cancel during the park). Factored out of Run's
+// loop to keep that supervisor readable.
+func (c *Connector) runPark(runCtx context.Context, backoff *BackoffSchedule, watchdogDone <-chan struct{}) (sessionStart time.Time, stop bool) {
+	if c.isSuspended() {
+		// Re-assert the parkable state in case a racing bringUp moved it.
+		c.machine.Transition(UpstreamStateDisconnectedByUser)
+	}
+	// Capture the desired nick so a nick-invalid park ends precisely when the
+	// user picks a different one (a suspend parks until the intent flips). park
+	// re-evaluates this on every wakeup, so a missed lifecycle signal self-heals.
+	parkNick := c.DesiredNick()
+	stillParked := func() bool {
+		if c.isSuspended() {
+			return true
+		}
+		return c.machine.State() == UpstreamStateDisconnectedNickInvalid &&
+			c.DesiredNick() == parkNick
+	}
+	if !c.park(runCtx, stillParked) {
+		c.machine.Transition(UpstreamStateStopped)
+		<-watchdogDone
+		return time.Time{}, true
+	}
+	// Resumed by a deliberate action: connect now with a fresh backoff (the
+	// control plane's lifecycle cooldown rate-limits user toggles, and the
+	// process-level connect gate guards the egress IP).
+	backoff.Reset()
+	if err := c.bringUp(runCtx); err != nil {
+		c.log.Warn("irc connect after resume failed", "err", err)
+		return time.Time{}, false
+	}
+	return time.Now(), false
 }
 
 // reconnectDelay returns how long to wait before the next reconnect: the
@@ -1662,6 +1896,16 @@ func (c *Connector) runSession(ctx context.Context) error {
 	return g.Wait()
 }
 
+// isOutageState reports whether a state should count as an outage for the
+// escalation watchdog: anything that isn't registered AND isn't an intentional
+// park. A parked link (user-suspended or awaiting a usable nick) is deliberate,
+// not a failure — escalating it to paused_idle would tear down a connector the
+// user simply disconnected; Resume restarts the outage clock from the next
+// reconnect.
+func isOutageState(s UpstreamState) bool {
+	return s != UpstreamStateRegistered && !s.IsParkable()
+}
+
 // runEscalationWatchdog runs the long-outage escalation timers in
 // parallel with the reconnect loop. It measures outage duration as
 // "time since the connector was last in registered" — NOT dwell in a
@@ -1713,11 +1957,11 @@ func (c *Connector) runEscalationWatchdog(ctx context.Context) <-chan struct{} {
 		}
 
 		sub := c.machine.Subscribe(func(change UpstreamStateChange) {
-			if change.To == UpstreamStateRegistered {
+			if isOutageState(change.To) {
+				startOutage()
+			} else {
 				endOutage()
-				return
 			}
-			startOutage()
 		})
 		defer sub.Unsubscribe()
 
@@ -1727,7 +1971,7 @@ func (c *Connector) runEscalationWatchdog(ctx context.Context) <-chan struct{} {
 		// and recovered, state is registered — no outage. If bringUp
 		// is still mid-flight on first reconnect, state is connecting
 		// — count that as outage start).
-		if c.machine.State() != UpstreamStateRegistered {
+		if isOutageState(c.machine.State()) {
 			startOutage()
 		}
 

--- a/internal/connector/irc/connector_park_resume_test.go
+++ b/internal/connector/irc/connector_park_resume_test.go
@@ -1,0 +1,266 @@
+package irc_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// TestSuspendParksWithoutReconnect covers the Disconnect button's core
+// contract: Suspend() drops the upstream link (QUIT) and parks the supervisor
+// in disconnected_by_user WITHOUT tearing the connector down or entering the
+// reconnect loop — a parked connector must never dial. Resume() then brings it
+// straight back, proving the bouncer/web gateway survived the whole time.
+func TestSuspendParksWithoutReconnect(t *testing.T) {
+	fs := newReconnectTestServer(t)
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "turborg",
+		Channels: []string{"#test"},
+	}, nil, nil)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered &&
+			fs.Sessions() == 1
+	}, 2*time.Second, 10*time.Millisecond, "first registration must complete")
+
+	conn.Suspend()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedByUser
+	}, time.Second, 10*time.Millisecond, "Suspend must park in disconnected_by_user")
+
+	require.Eventually(t, func() bool {
+		return containsPrefix("QUIT")(fs.Received())
+	}, time.Second, 25*time.Millisecond,
+		"Suspend must send a QUIT; received: %v", fs.Received())
+
+	// While parked the supervisor must NOT dial — no second session opens even
+	// though the backoff floor would otherwise have fired by now.
+	require.Never(t, func() bool {
+		return fs.Sessions() > 1
+	}, 1500*time.Millisecond, 50*time.Millisecond,
+		"a parked connector must not reconnect")
+
+	conn.Resume()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered &&
+			fs.Sessions() == 2
+	}, 3*time.Second, 25*time.Millisecond,
+		"Resume must reconnect; sessions=%d state=%s", fs.Sessions(), conn.UpstreamState().State())
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}
+
+// TestSuspendDoesNotEscalateToPausedIdle guards the watchdog fix: a parked
+// (user-suspended) link is intentional, not an outage, so the escalation
+// watchdog must NOT promote it to the terminal paused_idle state — that would
+// tear down a connector the user merely disconnected. We pick warn/pause
+// windows short enough that an un-fixed watchdog would have escalated.
+func TestSuspendDoesNotEscalateToPausedIdle(t *testing.T) {
+	fs := newReconnectTestServer(t)
+
+	conn := irc.New(&irc.Settings{
+		Hostname:           "127.0.0.1",
+		Port:               fs.Port(),
+		Nick:               "turborg",
+		UpstreamWarnAfter:  100 * time.Millisecond,
+		UpstreamPauseAfter: 300 * time.Millisecond,
+	}, nil, nil)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered
+	}, 2*time.Second, 10*time.Millisecond, "first registration must complete")
+
+	conn.Suspend()
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedByUser
+	}, time.Second, 10*time.Millisecond, "Suspend must park")
+
+	// Well past UpstreamPauseAfter: the state must stay parked, never escalate.
+	require.Never(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStatePausedIdle
+	}, time.Second, 50*time.Millisecond,
+		"a parked connector must not escalate to paused_idle")
+	assert.Equal(t, irc.UpstreamStateDisconnectedByUser, conn.UpstreamState().State())
+
+	// And it's still a live, resumable connector — the run loop didn't unwind.
+	conn.Resume()
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered
+	}, 3*time.Second, 25*time.Millisecond, "Resume must reconnect after the pause window")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}
+
+// TestInvalidNickParksAndResumesOnNewNick covers the invalid-nick recovery
+// path: a 432 on the chosen nick parks the supervisor in
+// disconnected_nick_invalid (no reconnect storm), and applying a usable nick
+// resumes it in place — re-registering under the new nick with no operator
+// restart. The server 432s "admin" and welcomes only "guest".
+func TestInvalidNickParksAndResumesOnNewNick(t *testing.T) {
+	fs := newReconnectTestServerWithReject(t, "ERR_ERRONEOUSNICKNAME_UNTIL_GOOD")
+	fs.goodNick = "guest"
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "admin",
+	}, nil, nil)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedNickInvalid
+	}, 3*time.Second, 10*time.Millisecond, "the invalid nick must park in disconnected_nick_invalid")
+
+	// Parked, not looping: no unbounded reconnect attempts on an unusable nick.
+	require.Never(t, func() bool {
+		return fs.Sessions() > 2
+	}, time.Second, 50*time.Millisecond, "an invalid-nick park must not storm reconnects")
+
+	// Pick a usable nick — this is the resume trigger.
+	conn.ApplyNick("guest")
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered &&
+			conn.CurrentNick() == "guest"
+	}, 3*time.Second, 25*time.Millisecond,
+		"applying a usable nick must resume and re-register; state=%s nick=%s",
+		conn.UpstreamState().State(), conn.CurrentNick())
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}
+
+// TestStartSuspendedDoesNotConnect covers the boot-while-suspended path: a
+// connector marked suspended before Start must come up parked rather than
+// flapping connect→quit (a pooled tenant built from a suspended spec, or a
+// restarted container the user had disconnected). Resume connects it.
+func TestStartSuspendedDoesNotConnect(t *testing.T) {
+	fs := newReconnectTestServer(t)
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "turborg",
+	}, nil, nil)
+	conn.SetInitialSuspended(true)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedByUser
+	}, time.Second, 10*time.Millisecond, "a suspended boot must park in disconnected_by_user")
+
+	// No upstream connection must have been opened at all.
+	require.Never(t, func() bool {
+		return fs.Sessions() > 0
+	}, time.Second, 50*time.Millisecond, "a suspended boot must not dial upstream")
+
+	conn.Resume()
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered &&
+			fs.Sessions() == 1
+	}, 3*time.Second, 25*time.Millisecond, "Resume must perform the first connect")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}
+
+// TestSuspendResumeIdempotent verifies the guards: a second Suspend while
+// already suspended is a no-op, and a Resume while connected (never suspended)
+// doesn't disturb the live session.
+func TestSuspendResumeIdempotent(t *testing.T) {
+	fs := newReconnectTestServer(t)
+
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1",
+		Port:     fs.Port(),
+		Nick:     "turborg",
+	}, nil, nil)
+
+	a := agent.New(nil)
+	a.AddConnector(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- a.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateRegistered
+	}, 2*time.Second, 10*time.Millisecond, "first registration must complete")
+
+	// Resume while connected (not suspended) is a no-op — the session survives.
+	conn.Resume()
+	require.Never(t, func() bool {
+		return conn.UpstreamState().State() != irc.UpstreamStateRegistered
+	}, 500*time.Millisecond, 50*time.Millisecond,
+		"Resume on a live, non-suspended connector must not disturb it")
+
+	conn.Suspend()
+	require.Eventually(t, func() bool {
+		return conn.UpstreamState().State() == irc.UpstreamStateDisconnectedByUser
+	}, time.Second, 10*time.Millisecond, "Suspend must park")
+
+	// A second Suspend is a no-op (still parked, no extra QUIT churn).
+	conn.Suspend()
+	assert.Equal(t, irc.UpstreamStateDisconnectedByUser, conn.UpstreamState().State())
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("agent did not shut down")
+	}
+}

--- a/internal/connector/irc/connector_reconnect_test.go
+++ b/internal/connector/irc/connector_reconnect_test.go
@@ -146,6 +146,12 @@ type reconnectTestServer struct {
 	// ERR_NICKNAMEINUSE_THEN_OK fallback mode).
 	reg433Sent bool
 
+	// goodNick, with the "ERR_ERRONEOUSNICKNAME_UNTIL_GOOD" reject mode, is
+	// the one nick the server accepts: it 432s every other NICK (driving the
+	// invalid-nick park) and welcomes only this one — so a test can confirm
+	// the supervisor resumes and re-registers once a usable nick is applied.
+	goodNick string
+
 	// joinHook lets edge tests intercept the JOIN reply. Returning
 	// true means "I handled this JOIN" and suppresses the default
 	// self-JOIN echo; returning false falls through to the standard
@@ -296,10 +302,22 @@ func (s *reconnectTestServer) handleLine(conn net.Conn, line string) {
 			nick := strings.TrimSpace(strings.TrimPrefix(line, "NICK "))
 			_, _ = conn.Write([]byte(":fake 433 * " + nick + " :Nickname is already in use\r\n"))
 		}
+		// Nick-recovery mode: 432 every NICK that isn't goodNick (parking the
+		// connector in invalid-nick), and welcome the moment the good one
+		// arrives — so a resume-on-new-nick can complete registration.
+		if s.rejectAfter == "ERR_ERRONEOUSNICKNAME_UNTIL_GOOD" {
+			nick := strings.TrimSpace(strings.TrimPrefix(line, "NICK "))
+			if nick == s.goodNick {
+				_, _ = conn.Write([]byte(":fake 001 " + nick + " :Welcome\r\n"))
+				_, _ = conn.Write([]byte(":fake 376 " + nick + " :End of MOTD\r\n"))
+			} else {
+				_, _ = conn.Write([]byte(":fake 432 * " + nick + " :Erroneous Nickname\r\n"))
+			}
+		}
 	case strings.HasPrefix(line, "USER "):
 		nick := s.firstNickLocked()
 		switch s.rejectAfter {
-		case "ERR_NICKNAMEINUSE_THEN_OK":
+		case "ERR_NICKNAMEINUSE_THEN_OK", "ERR_ERRONEOUSNICKNAME_UNTIL_GOOD":
 			// Handled on the NICK line(s), not here.
 		case "ERR_NICKNAMEINUSE", "ERR_NICKNAMEINUSE_ALWAYS":
 			_, _ = conn.Write([]byte(":fake 433 * " + nick + " :Nickname is already in use\r\n"))

--- a/internal/connector/irc/upstream_state.go
+++ b/internal/connector/irc/upstream_state.go
@@ -48,12 +48,21 @@ const (
 	// UpstreamStateDisconnectedNickInvalid is reached when the chosen nick
 	// cannot be used at all: 432 ERR_ERRONEUSNICKNAME (syntactically invalid
 	// or network-reserved), 437 ERR_UNAVAILRESOURCE (reserved/juped), or a
-	// 433 whose "_"-suffix fallback was exhausted. Terminal — appending more
-	// underscores or reconnecting can't help, so the user must pick a
-	// different nick (the SPA prompts for one). Distinct from
+	// 433 whose "_"-suffix fallback was exhausted. Parkable — appending more
+	// underscores or reconnecting can't help, so the supervisor parks (no
+	// dialing, no escalation) until the user picks a different nick, at which
+	// point ApplyNick resumes the supervisor with the new value. Distinct from
 	// NickUnavailable so the front-end knows to open the picker rather than
 	// show a transient "retrying" banner.
 	UpstreamStateDisconnectedNickInvalid UpstreamState = "disconnected_nick_invalid"
+
+	// UpstreamStateDisconnectedByUser is a deliberate, user-requested
+	// disconnect via Suspend() (the chat UI's Disconnect button). Parkable:
+	// the supervisor sends QUIT, parks the upstream link, and keeps the
+	// bouncer + web gateway up — especially important pooled, where the
+	// container is shared by N tenants and can never be stopped for one user.
+	// Resume() reconnects. Not a failure; it carries no server reason.
+	UpstreamStateDisconnectedByUser UpstreamState = "disconnected_by_user"
 
 	// UpstreamStateDisconnectedAuthFailed is 464 ERR_PASSWDMISMATCH,
 	// 904 ERR_SASLFAIL, 905 ERR_SASLTOOLONG, or content-matched
@@ -88,14 +97,32 @@ func (s UpstreamState) IsRecoverable() bool {
 
 // IsTerminal reports whether the supervisor should stop retrying after
 // observing this state. Mirrors the operator-policy fork between
-// "automatic reconnect continues" and "needs operator action".
+// "automatic reconnect continues" and "needs operator action". Parkable
+// states (see IsParkable) are deliberately NOT terminal — the supervisor
+// blocks on them rather than unwinding the connector.
 func (s UpstreamState) IsTerminal() bool {
 	switch s {
 	case UpstreamStateDisconnectedAuthFailed,
 		UpstreamStateDisconnectedBanned,
-		UpstreamStateDisconnectedNickInvalid,
 		UpstreamStatePausedIdle,
 		UpstreamStateStopped:
+		return true
+	}
+	return false
+}
+
+// IsParkable reports whether the supervisor should PARK on this state —
+// block without dialing, backing off, or escalating — until an external
+// trigger (Resume, or a new nick via ApplyNick) unblocks it. Distinct from
+// terminal (which unwinds the connector goroutine) and recoverable (which
+// keeps reconnecting): a parked connector keeps the bouncer + web gateway
+// up and simply has no upstream link.
+//
+//   - DisconnectedByUser: parked until Resume().
+//   - DisconnectedNickInvalid: parked until a usable nick is applied.
+func (s UpstreamState) IsParkable() bool {
+	switch s {
+	case UpstreamStateDisconnectedByUser, UpstreamStateDisconnectedNickInvalid:
 		return true
 	}
 	return false
@@ -426,6 +453,9 @@ func DescribeUpstreamState(state UpstreamState, networkName, serverReason string
 	case UpstreamStateDisconnectedNickInvalid:
 		return "Nickname can't be used on " + network + reasonSuffix +
 			". Pick a different nickname to connect — it's invalid or reserved on this network."
+	case UpstreamStateDisconnectedByUser:
+		return "Disconnected from " + network +
+			" at your request. Reconnect to rejoin — messages sent now will NOT be delivered."
 	case UpstreamStateDisconnectedAuthFailed:
 		return "Authentication failed for " + network + reasonSuffix +
 			". Automatic reconnect stopped — update credentials and restart the connector."
@@ -453,6 +483,9 @@ func DescribeUpstreamState(state UpstreamState, networkName, serverReason string
 func SeverityForUpstreamState(state UpstreamState) string {
 	switch state {
 	case UpstreamStateRegistered:
+		return "info"
+	case UpstreamStateDisconnectedByUser:
+		// A deliberate user disconnect is not a fault — no alarming banner.
 		return "info"
 	case UpstreamStateConnecting, UpstreamStateRegistering,
 		UpstreamStateDisconnectedTransient,

--- a/internal/connector/irc/upstream_state_test.go
+++ b/internal/connector/irc/upstream_state_test.go
@@ -32,6 +32,20 @@ func TestUpstreamStateClassifications(t *testing.T) {
 		assert.True(t, irc.UpstreamStateStopped.IsTerminal())
 		assert.False(t, irc.UpstreamStateDisconnectedTransient.IsTerminal())
 		assert.False(t, irc.UpstreamStateRegistered.IsTerminal())
+		// Parkable states are NOT terminal — the supervisor blocks on them
+		// rather than unwinding the connector.
+		assert.False(t, irc.UpstreamStateDisconnectedByUser.IsTerminal())
+		assert.False(t, irc.UpstreamStateDisconnectedNickInvalid.IsTerminal())
+	})
+	t.Run("parkable bucket", func(t *testing.T) {
+		assert.True(t, irc.UpstreamStateDisconnectedByUser.IsParkable())
+		assert.True(t, irc.UpstreamStateDisconnectedNickInvalid.IsParkable())
+		// Parkable is disjoint from recoverable and terminal.
+		assert.False(t, irc.UpstreamStateDisconnectedByUser.IsRecoverable())
+		assert.False(t, irc.UpstreamStateDisconnectedTransient.IsParkable())
+		assert.False(t, irc.UpstreamStateDisconnectedNickUnavailable.IsParkable())
+		assert.False(t, irc.UpstreamStateRegistered.IsParkable())
+		assert.False(t, irc.UpstreamStateStopped.IsParkable())
 	})
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -235,6 +235,14 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 			}
 			ircConn.ApplyNick(cfg.Nick)
 			ircConn.ReconcileChannels(cfg.Channels)
+			// Reconcile the user's connect/disconnect intent live (idempotent):
+			// Suspend parks the upstream link, Resume reconnects, neither
+			// touches the bouncer / web gateway.
+			if cfg.Suspended {
+				ircConn.Suspend()
+			} else {
+				ircConn.Resume()
+			}
 		},
 		log,
 	)

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -372,6 +372,10 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// RFC-1413 responder can name it (kills the ~ prefix + satisfies
 			// "identd required" networks). Shared registry across all tenants.
 			conn.SetIdentReporter(t.idents)
+			// Boot already parked when the user has the link disconnected, so a
+			// pool restart of a suspended tenant comes up parked rather than
+			// flapping connect→quit. Live toggles arrive via applySuspend.
+			conn.SetInitialSuspended(boolField(cs.Config, "suspended", false))
 
 			// Durable message store (write-through to the control plane), so the
 			// bouncer welcome replay, web-shell scrollback, and the user's
@@ -586,27 +590,8 @@ func (t *Tenant) update(spec TenantSpec) {
 	// only matters as the restart-recovery seed applied at build time; a live
 	// change to it alone is a no-op here. A command-set change still reloads in
 	// place. Anything else falls through to a restart.
-	if liveUpdatableOnlyChange(prev, spec) {
-		commandsChanged := !commandSetsEqual(prev.Commands, spec.Commands)
-		ignoresChanged := !reflect.DeepEqual(prev.IgnoredNicks, spec.IgnoredNicks)
-		nickChanged, channelsChanged := ircNickChannelsChanged(prev, spec)
-		if !commandsChanged && !ignoresChanged && !nickChanged && !channelsChanged {
-			return // only the usage baseline moved — nothing to reconnect for
-		}
-		// Apply each changed facet in place. The command set swaps via
-		// ReplaceDynamic; the ignore list swaps the registry-wide guard; nick
-		// and channels apply live via NICK / JOIN+PART. Any "false" means the
-		// tenant isn't running, so fall through to a restart that re-seeds
-		// everything from the new spec at build time.
-		okCommands := !commandsChanged || t.reloadCommands(spec.Commands)
-		okIgnores := !ignoresChanged || t.reloadGuard()
-		okNickChan := (!nickChanged && !channelsChanged) || t.applyNickChannels(spec)
-		if okCommands && okIgnores && okNickChan {
-			t.log.Info("tenant settings reloaded in place",
-				"commands", len(spec.Commands), "ignored", len(spec.IgnoredNicks),
-				"nick_changed", nickChanged, "channels_changed", channelsChanged)
-			return
-		}
+	if liveUpdatableOnlyChange(prev, spec) && t.applyLiveUpdate(prev, spec) {
+		return
 	}
 
 	t.log.Info("tenant spec changed; restarting", "connectors", t.connectorTypes())
@@ -620,6 +605,40 @@ func (t *Tenant) update(spec TenantSpec) {
 	case t.restartCh <- struct{}{}:
 	default:
 	}
+}
+
+// applyLiveUpdate reconciles the live-updatable facets (command set, ignore
+// list, nick/channels, connect/disconnect intent) of a spec change in place,
+// with no reconnect. The caller has already established that ONLY such facets
+// changed (liveUpdatableOnlyChange). Returns true when every changed facet
+// applied; false means the tenant isn't running (a facet apply reported no live
+// connector), so the caller falls back to a restart that re-seeds everything
+// from the new spec at build time. A change confined to the usage baseline
+// applies nothing and returns true (nothing to reconnect for).
+func (t *Tenant) applyLiveUpdate(prev, spec TenantSpec) bool {
+	commandsChanged := !commandSetsEqual(prev.Commands, spec.Commands)
+	ignoresChanged := !reflect.DeepEqual(prev.IgnoredNicks, spec.IgnoredNicks)
+	nickChanged, channelsChanged := ircNickChannelsChanged(prev, spec)
+	suspendChanged := ircSuspendChanged(prev, spec)
+	if !commandsChanged && !ignoresChanged && !nickChanged && !channelsChanged && !suspendChanged {
+		return true // only the usage baseline moved — nothing to reconnect for
+	}
+	// Apply each changed facet in place. The command set swaps via
+	// ReplaceDynamic; the ignore list swaps the registry-wide guard; nick and
+	// channels apply live via NICK / JOIN+PART; the connect/disconnect intent
+	// parks/resumes the upstream link.
+	okCommands := !commandsChanged || t.reloadCommands(spec.Commands)
+	okIgnores := !ignoresChanged || t.reloadGuard()
+	okNickChan := (!nickChanged && !channelsChanged) || t.applyNickChannels(spec)
+	okSuspend := !suspendChanged || t.applySuspend(spec)
+	if okCommands && okIgnores && okNickChan && okSuspend {
+		t.log.Info("tenant settings reloaded in place",
+			"commands", len(spec.Commands), "ignored", len(spec.IgnoredNicks),
+			"nick_changed", nickChanged, "channels_changed", channelsChanged,
+			"suspend_changed", suspendChanged)
+		return true
+	}
+	return false
 }
 
 // commandsOnlyChange reports whether two differing specs differ in nothing
@@ -652,9 +671,9 @@ func liveUpdatableOnlyChange(a, b TenantSpec) bool {
 }
 
 // stripLiveConnectorFields returns the connectors with the IRC connector's
-// live-applicable config keys (nick, channels) removed, so spec comparison
-// ignores them. Deep-copies the affected config map so the caller's spec is
-// untouched.
+// live-applicable config keys (nick, channels, suspended) removed, so spec
+// comparison ignores them. Deep-copies the affected config map so the caller's
+// spec is untouched.
 func stripLiveConnectorFields(conns []ConnectorSpec) []ConnectorSpec {
 	out := make([]ConnectorSpec, len(conns))
 	for i, c := range conns {
@@ -664,7 +683,7 @@ func stripLiveConnectorFields(conns []ConnectorSpec) []ConnectorSpec {
 		}
 		cfg := make(map[string]any, len(c.Config))
 		for k, v := range c.Config {
-			if k == "nick" || k == "channels" {
+			if k == "nick" || k == "channels" || k == "suspended" {
 				continue
 			}
 			cfg[k] = v
@@ -682,6 +701,35 @@ func ircNickChannelsChanged(prev, next TenantSpec) (nick, channels bool) {
 	nick = stringField(p.Config, "nick") != stringField(n.Config, "nick")
 	channels = !reflect.DeepEqual(stringSlice(p.Config, "channels"), stringSlice(n.Config, "channels"))
 	return nick, channels
+}
+
+// ircSuspendChanged reports whether the IRC connector's user connect/disconnect
+// intent moved between two specs.
+func ircSuspendChanged(prev, next TenantSpec) bool {
+	p := firstIRCConnectorSpec(prev.Connectors)
+	n := firstIRCConnectorSpec(next.Connectors)
+	return boolField(p.Config, "suspended", false) != boolField(n.Config, "suspended", false)
+}
+
+// applySuspend applies the spec's desired connect/disconnect intent to the live
+// connector without a respawn: Suspend parks the upstream link, Resume
+// reconnects, neither touches the bouncer / web gateway. Returns false when the
+// tenant isn't running (no live connector), so the caller falls back to a
+// restart that re-seeds the intent at build time via SetInitialSuspended.
+func (t *Tenant) applySuspend(spec TenantSpec) bool {
+	t.mu.Lock()
+	conn := t.ircConn
+	t.mu.Unlock()
+	if conn == nil {
+		return false
+	}
+	cs := firstIRCConnectorSpec(spec.Connectors)
+	if boolField(cs.Config, "suspended", false) {
+		conn.Suspend()
+	} else {
+		conn.Resume()
+	}
+	return true
 }
 
 // applyNickChannels applies the spec's desired nick and channels to the live


### PR DESCRIPTION
Add a **park-and-resume** primitive to the IRC supervisor so the upstream link can be dropped and brought back without tearing the connector down — the bouncer and web gateway stay up the whole time. This backs two operator-facing features: a connect/disconnect control, and recovery from an unusable nick.

## What changed

- **New parkable state class** (`disconnected_by_user` + `disconnected_nick_invalid`): neither terminal nor recoverable. The supervisor now *parks* on a parkable state — no dialing, no backoff, no escalation — and blocks until an external trigger, instead of unwinding the connector goroutine. See `UpstreamState.IsParkable()`.
- **`Suspend()` / `Resume()`** drive a user-disconnect intent: `Suspend` sends `QUIT` and parks in `disconnected_by_user`; `Resume` reconnects immediately (no backoff).
- **`disconnected_nick_invalid` now parks** instead of unwinding; `ApplyNick` with a usable nick resumes the supervisor in place and re-registers under the new nick — no restart.
- **`SetInitialSuspended`** lets a connector boot parked (a restarted runtime, or a pooled instance built from a suspended spec) rather than flapping connect→quit.
- **Escalation watchdog** treats parkable states as not-an-outage, so a parked link is never promoted to `paused_idle`.
- **Dedicated path**: the config-refresh poll carries `suspended` → `Suspend`/`Resume`.
- **Pooled path**: the instance feed's `suspended` applies live (`Suspend`/`Resume`), stripped from the respawn comparison so a toggle never restarts the instance; build-time seed via `SetInitialSuspended`.

## Why

Park/resume is the single primitive both features need: the supervisor previously exited its goroutine on any terminal state, so there was no way to come back without a full respawn. This rewrites the reconnect/backoff/storm/watchdog loop carefully — it's the same path hardened for the anti-flood fix, so it lands as its own PR with tests.

## Tests

New coverage for: park-without-reconnect, no `paused_idle` escalation while parked, invalid-nick park + resume on a new nick, boot-suspended, and Suspend/Resume idempotency, plus enum-classification parity. Full `internal/connector/irc`, `internal/server`, `internal/configrefresh`, and `internal/runtime` suites green; `go vet` + golangci-lint clean.