### PR TITLE
test(commands): cover splitOptions helper

### DIFF
--- a/internal/commands/builder_internal_test.go
+++ b/internal/commands/builder_internal_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "trims whitespace around options",
+			in:   " red, green ,blue ",
+			want: []string{"red", "green", "blue"},
+		},
+		{
+			name: "drops empty options",
+			in:   "alpha,, , beta,",
+			want: []string{"alpha", "beta"},
+		},
+		{
+			name: "preserves internal whitespace",
+			in:   "two words, spaced  inside",
+			want: []string{"two words", "spaced  inside"},
+		},
+		{
+			name: "empty input yields no options",
+			in:   "",
+			want: []string{},
+		},
+		{
+			name: "whitespace only input yields no options",
+			in:   " \t\n ",
+			want: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, splitOptions(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
﻿## Summary

Adds direct table-driven unit coverage for `splitOptions`, covering comma-separated input, surrounding whitespace, empty entries, blank input, and values containing internal whitespace.

## Type of change

- [ ] `feat` - new feature
- [ ] `fix` - bug fix
- [ ] `refactor` - internal change, no user-visible behavior change
- [ ] `docs` - documentation only
- [x] `test` - tests only
- [ ] `chore` - tooling, CI, deps
- [ ] `perf` - performance improvement
- [ ] `breaking change` - incompatible API change (mark in commit footer)

## Test plan

- [x] `go test ./internal/commands`
- [x] `go test ./internal/commands -run TestSplitOptions -count=1`

## Checklist

- [x] Tests added or updated
- [ ] Coverage is still >=90% (`make cover-gate`)
- [ ] `make lint test` is green locally (or `golangci-lint run && go test -race ./...`)
- [ ] Documentation updated if user-facing behavior changed

Closes #92
