### PR TITLE
ci: add advisory govulncheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,19 @@ jobs:
           go install github.com/vladopajic/go-test-coverage/v2@latest
           go-test-coverage --config .testcoverage.yml
 
+  govulncheck:
+    name: Govulncheck (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
   build:
     name: Build (linux/amd64)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a separate `Govulncheck (advisory)` CI job using the repo's `go.mod` toolchain version
- run `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- keep the first scan advisory/non-blocking so vulnerabilities surface on PRs without immediately changing branch-protection behavior

Closes #105

## Verification
- `python3` YAML parse of `.github/workflows/ci.yml` -> passed
- `git diff --check` -> passed
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` -> ran under downloaded `go1.26.3`; exited nonzero and surfaced reachable standard-library findings GO-2026-5039 and GO-2026-5037, both fixed in Go 1.26.4

I made the job advisory because the first local run already finds reachable vulnerabilities in the currently pinned Go 1.26.3 standard library. That should make the signal visible on PRs while leaving the follow-up decision to either bump the Go toolchain or make the check required once the baseline is clean.