### PR TITLE
feat(web): send Cache-Control no-store on /health and /metrics

### DIFF
--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -465,6 +465,7 @@ func (g *Gateway) sendInitialConnectorState(ctx context.Context, c *client) {
 
 func (g *Gateway) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
 	body := map[string]any{
 		"status":         "ok",
 		"uptime_seconds": int(time.Since(g.started).Seconds()),
@@ -475,6 +476,7 @@ func (g *Gateway) handleHealth(w http.ResponseWriter, _ *http.Request) {
 
 func (g *Gateway) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
 	g.metMu.Lock()
 	conns := g.metrics.connections
 	fails := g.metrics.authFailures

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"errors"
+
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -217,6 +218,7 @@ func TestHealthEndpoint(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
 	var out map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
 	assert.Equal(t, "ok", out["status"])
@@ -228,6 +230,7 @@ func TestMetricsEndpoint(t *testing.T) {
 
 	resp, err := http.Get("http://" + g.Addr() + "/metrics")
 	require.NoError(t, err)
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
 	body, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	out := string(body)


### PR DESCRIPTION
## Summary

Add `Cache-Control: no-store` headers to the `/health` and `/metrics` endpoints to prevent caching by intermediaries.

This ensures health and metrics responses always reflect the current state of the service and are not served from cache.

## Type of change

* [x] `feat` — new feature
* [ ] `fix` — bug fix
* [ ] `refactor` — internal change, no user-visible behavior change
* [ ] `docs` — documentation only
* [ ] `test` — tests only
* [ ] `chore` — tooling, CI, deps
* [ ] `perf` — performance improvement
* [ ] `breaking change` — incompatible API change (mark in commit footer)

## Test plan

* [x] Added assertions verifying `Cache-Control: no-store` is present on `/health`
* [x] Added assertions verifying `Cache-Control: no-store` is present on `/metrics`
* [x] Ran `go test ./internal/web/...`

## Checklist

* [x] Tests added or updated
* [ ] Coverage is still ≥ 90% (`make cover-gate`)
* [ ] `make lint test` is green locally (or `golangci-lint run && go test -race ./...`)
* [x] Documentation updated if user-facing behavior changed (not applicable)

## Notes

Verified the updated endpoint tests locally with:

```bash
go test ./internal/web/...
```

I was unable to run `make test` locally because the race detector requires CGO in my Windows environment, and `golangci-lint` is not installed locally. CI will validate the full test and lint suite.

```
```