### PR TITLE
feat(commands): add indexed argument placeholders

### DIFF
--- a/internal/commands/builder.go
+++ b/internal/commands/builder.go
@@ -164,9 +164,10 @@ func llmHandler(d Definition, provider llm.Provider, ctx renderCtx, log *slog.Lo
 // (or the bound, for random) between the colon and the closing brace. `[^}]*`
 // keeps them from spanning across a `}`.
 var (
-	choiceRe  = regexp.MustCompile(`\{choice:([^}]*)\}`)
-	randomRe  = regexp.MustCompile(`\{random:([^}]*)\}`)
-	shuffleRe = regexp.MustCompile(`\{shuffle:([^}]*)\}`)
+	choiceRe     = regexp.MustCompile(`\{choice:([^}]*)\}`)
+	randomRe     = regexp.MustCompile(`\{random:([^}]*)\}`)
+	shuffleRe    = regexp.MustCompile(`\{shuffle:([^}]*)\}`)
+	indexedArgRe = regexp.MustCompile(`\{arg(\d+)\}`)
 )
 
 // render substitutes the supported placeholders in a template.
@@ -186,7 +187,7 @@ func render(tmpl string, env *agent.InboundEnvelope, args []string, ctx renderCt
 	tmpl = expandHelpers(tmpl)
 
 	now := time.Now().UTC()
-	return strings.NewReplacer(
+	tmpl = strings.NewReplacer(
 		"{user}", env.Sender,
 		"{nick}", env.Sender,
 		"{args}", strings.TrimSpace(strings.Join(args, " ")),
@@ -199,6 +200,22 @@ func render(tmpl string, env *agent.InboundEnvelope, args []string, ctx renderCt
 		"{time}", now.Format("15:04:05"),
 		"{datetime}", now.Format("2006-01-02 15:04:05 UTC"),
 	).Replace(tmpl)
+
+	tmpl = indexedArgRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		match := indexedArgRe.FindStringSubmatch(m)
+		if len(match) != 2 {
+			return ""
+		}
+
+		n, err := strconv.Atoi(match[1])
+		if err != nil || n < 1 || n > len(args) {
+			return ""
+		}
+
+		return args[n-1]
+	})
+
+	return tmpl
 }
 
 // expandHelpers evaluates the random dynamic-placeholder helpers in a template.

--- a/internal/commands/builder_test.go
+++ b/internal/commands/builder_test.go
@@ -158,6 +158,65 @@ func TestBuildStaticArgsCannotInjectHelper(t *testing.T) {
 	assert.Equal(t, "you said: {random:9}", out.Text, "a helper inside args stays literal")
 }
 
+func TestBuildStaticIndexedArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		args     []string
+		want     string
+	}{
+		{
+			name:     "first argument",
+			template: "{arg1}",
+			args:     []string{"alice"},
+			want:     "alice",
+		},
+		{
+			name:     "second argument",
+			template: "{arg2}",
+			args:     []string{"alice", "bob"},
+			want:     "bob",
+		},
+		{
+			name:     "out of range becomes empty",
+			template: "x{arg3}y",
+			args:     []string{"alice"},
+			want:     "xy",
+		},
+		{
+			name:     "helper inside indexed arg stays literal",
+			template: "{arg1}",
+			args:     []string{"{random:9}"},
+			want:     "{random:9}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			built := commands.Build([]commands.Definition{
+				{
+					Name:     "echo",
+					Type:     commands.TypeStatic,
+					Template: tt.template,
+					Access:   commands.AccessEveryone,
+				},
+			}, nil, nil, "", "", nil)
+
+			require.Len(t, built, 1)
+
+			out := dispatch(
+				t,
+				built[0],
+				agent.NewInbound("irc", "#c", "u", "!echo"),
+				tt.args,
+			)
+
+			require.NotNil(t, out)
+			assert.Equal(t, tt.want, out.Text)
+		})
+	}
+}
+
 func TestBuildLLMPassesModelAndSystem(t *testing.T) {
 	prov := &recordingProvider{resp: "the answer\n\nis   42"}
 	built := commands.Build([]commands.Definition{


### PR DESCRIPTION
## Summary

Add support for indexed argument placeholders such as `{arg1}`, `{arg2}`, and so on.

Indexed placeholders resolve to the corresponding positional argument and return an empty string when the requested argument is not present. Added table-driven tests covering indexed substitution, out-of-range behavior, and helper-injection safety.

## Type of change

* [x] `feat` — new feature
* [ ] `fix` — bug fix
* [ ] `refactor` — internal change, no user-visible behavior change
* [ ] `docs` — documentation only
* [ ] `test` — tests only
* [ ] `chore` — tooling, CI, deps
* [ ] `perf` — performance improvement
* [ ] `breaking change` — incompatible API change (mark in commit footer)

## Test plan

* [x] Added table-driven tests covering indexed argument substitution
* [x] Verified out-of-range indexed placeholders resolve to an empty string
* [x] Verified helper tokens supplied through indexed arguments remain literal and are not evaluated
* [x] Ran `go test ./...`

## Checklist

* [x] Tests added or updated
* [ ] Coverage is still ≥ 90% (`make cover-gate`)
* [ ] `make lint test` is green locally (or `golangci-lint run && go test -race ./...`)
* [ ] Documentation updated if user-facing behavior changed