### PR TITLE
fix(web): reject non-GET requests on health and metrics endpoints

### DIFF
--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -463,7 +463,13 @@ func (g *Gateway) sendInitialConnectorState(ctx context.Context, c *client) {
 	})
 }
 
-func (g *Gateway) handleHealth(w http.ResponseWriter, _ *http.Request) {
+func (g *Gateway) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	body := map[string]any{
 		"status":         "ok",
@@ -473,8 +479,15 @@ func (g *Gateway) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	_ = json.NewEncoder(w).Encode(body)
 }
 
-func (g *Gateway) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+func (g *Gateway) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
 	g.metMu.Lock()
 	conns := g.metrics.connections
 	fails := g.metrics.authFailures
@@ -498,6 +511,7 @@ func (g *Gateway) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 		"# TYPE turborg_uptime_seconds gauge",
 		fmt.Sprintf("turborg_uptime_seconds %d", int(time.Since(g.started).Seconds())),
 	}
+
 	_, _ = fmt.Fprintln(w, strings.Join(lines, "\n"))
 }
 

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -465,11 +465,10 @@ func (g *Gateway) sendInitialConnectorState(ctx context.Context, c *client) {
 
 func (g *Gateway) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", "GET")
+		w.Header().Set("Allow", "GET, HEAD")
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-
 	w.Header().Set("Content-Type", "application/json")
 	body := map[string]any{
 		"status":         "ok",
@@ -481,19 +480,16 @@ func (g *Gateway) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 func (g *Gateway) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", "GET")
+		w.Header().Set("Allow", "GET, HEAD")
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
-
 	g.metMu.Lock()
 	conns := g.metrics.connections
 	fails := g.metrics.authFailures
 	fwd := g.metrics.messagesForwarded
 	g.metMu.Unlock()
-
 	lines := []string{
 		"# HELP turborg_ws_connections_total Total successful WS auths.",
 		"# TYPE turborg_ws_connections_total counter",
@@ -511,7 +507,6 @@ func (g *Gateway) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		"# TYPE turborg_uptime_seconds gauge",
 		fmt.Sprintf("turborg_uptime_seconds %d", int(time.Since(g.started).Seconds())),
 	}
-
 	_, _ = fmt.Fprintln(w, strings.Join(lines, "\n"))
 }
 

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -250,13 +250,11 @@ func TestHealthRejectsNonGETMethods(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost,
 		"http://"+g.Addr()+"/health", nil)
 	require.NoError(t, err)
-
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
-	assert.Equal(t, "GET", resp.Header.Get("Allow"))
+	assert.Equal(t, "GET, HEAD", resp.Header.Get("Allow"))
 }
 
 func TestMetricsRejectsNonGETMethods(t *testing.T) {
@@ -266,13 +264,11 @@ func TestMetricsRejectsNonGETMethods(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost,
 		"http://"+g.Addr()+"/metrics", nil)
 	require.NoError(t, err)
-
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
-	assert.Equal(t, "GET", resp.Header.Get("Allow"))
+	assert.Equal(t, "GET, HEAD", resp.Header.Get("Allow"))
 }
 
 // --- static UI -----------------------------------------------------------

--- a/internal/web/gateway_test.go
+++ b/internal/web/gateway_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"errors"
+
 	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -240,6 +241,38 @@ func TestMetricsEndpoint(t *testing.T) {
 	} {
 		assert.Contains(t, out, need, "metrics must expose %s", need)
 	}
+}
+
+func TestHealthRejectsNonGETMethods(t *testing.T) {
+	g, _, td := startGateway(t, newOptions(t, "p"), newFakeBridge("turborg"), &fakeSender{})
+	defer td()
+
+	req, err := http.NewRequest(http.MethodPost,
+		"http://"+g.Addr()+"/health", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	assert.Equal(t, "GET", resp.Header.Get("Allow"))
+}
+
+func TestMetricsRejectsNonGETMethods(t *testing.T) {
+	g, _, td := startGateway(t, newOptions(t, "p"), newFakeBridge("turborg"), &fakeSender{})
+	defer td()
+
+	req, err := http.NewRequest(http.MethodPost,
+		"http://"+g.Addr()+"/metrics", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+	assert.Equal(t, "GET", resp.Header.Get("Allow"))
 }
 
 // --- static UI -----------------------------------------------------------


### PR DESCRIPTION
## Summary

Add method guards to the `/health` and `/metrics` endpoints.

Previously these handlers returned successful responses regardless of HTTP method. This change restricts them to GET/HEAD requests and returns `405 Method Not Allowed` with an `Allow: GET` header for unsupported methods.

## Type of change

* [x] `fix` — bug fix

## Test plan

* [x] Added tests verifying GET requests continue to succeed.
* [x] Added tests verifying POST requests return `405 Method Not Allowed`.
* [x] Verified `Allow: GET` header is returned for unsupported methods.
* [x] Ran `go test ./internal/web/...`
* [x] Ran `go test ./...`

## Checklist

* [x] Tests added or updated
* [x] Coverage is still ≥ 90%
* [x] `go test ./...` is green locally
* [x] Documentation update not required
