### PR TITLE
ci: add stale-PR bot; fix flaky SA5011 lint in nudge test

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: Stale PRs
+
+# Closes pull requests that have gone silent so the open-PR queue reflects
+# work that is actually live. A PR is marked `stale` after 14 days with no
+# activity, then closed 7 days later if still untouched. Any comment, review,
+# or push resets the clock — closing is never permanent, and a closed PR can
+# be reopened. Issues are intentionally left alone.
+
+on:
+  schedule:
+    - cron: "30 2 * * *" # daily, 02:30 UTC
+  workflow_dispatch: {}
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  stale:
+    name: Mark and close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          days-before-issue-stale: -1 # never touch issues
+          days-before-issue-close: -1
+          stale-pr-label: stale
+          exempt-pr-labels: keep,pinned,blocked
+          exempt-draft-pr: true
+          stale-pr-message: >
+            This pull request has had no activity for 14 days, so it's been
+            marked `stale`. If it's still relevant, leave a comment or push an
+            update and the label clears automatically. Otherwise it will be
+            closed in 7 days — you can always reopen it later.
+          close-pr-message: >
+            Closing this pull request after 21 days of inactivity. Thanks for
+            the contribution — feel free to reopen it if you'd like to pick it
+            back up.

--- a/internal/connector/irc/nudge_internal_test.go
+++ b/internal/connector/irc/nudge_internal_test.go
@@ -12,10 +12,9 @@ import (
 // irc_test) so it can poke the unexported `now` field without exporting
 // a test-only setter.
 func TestOwnerNudgeResetsAtUTCMidnight(t *testing.T) {
+	// Literal valid args, so construction never returns nil — no guard
+	// needed (and a nil-check-then-deref trips staticcheck SA5011).
 	n := NewOwnerNudge("alice", 2)
-	if n == nil {
-		t.Fatal("nudge construction failed")
-	}
 
 	// Frozen clock pointing at 2026-05-15 23:50 UTC.
 	clock := time.Date(2026, 5, 15, 23, 50, 0, 0, time.UTC)


### PR DESCRIPTION
## Stale-PR bot

Adds `.github/workflows/stale.yml` (uses `actions/stale`) to keep the open-PR queue reflecting work that's actually live:

- Marks a PR `stale` after **14 days** of no activity, closes it **7 days** later (21d total).
- Any comment, review, or push clears the label automatically; closed PRs can be reopened.
- Runs daily on a cron (plus `workflow_dispatch` for manual runs), using the built-in `GITHUB_TOKEN` — no secret to provision.
- Scope: **PRs only** (issues disabled via `days-before-issue-stale: -1`). Drafts and `keep`/`pinned`/`blocked`-labelled PRs are exempt.

## Lint fix

The 0.17.0 release PR's `Lint` job failed on `staticcheck SA5011` (nil-pointer) in `nudge_internal_test.go`, while the identical irc code passed on `main` at the same minute — a non-deterministic result tied to golangci-lint's cache state. The `if n == nil` guard there is dead: `NewOwnerNudge("alice", 2)` is called with literal valid args and can never return nil. Removing the pointless guard eliminates the SA5011 trigger in every cache state.