### PR TITLE
feat(llm): surface cached_tokens and model on usage records

### DIFF
--- a/internal/llm/openaicompat/provider.go
+++ b/internal/llm/openaicompat/provider.go
@@ -109,8 +109,11 @@ type chatResponse struct {
 		Message string `json:"message"`
 	} `json:"error"`
 	Usage *struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
+		PromptTokens        int `json:"prompt_tokens"`
+		CompletionTokens    int `json:"completion_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
 	} `json:"usage"`
 }
 
@@ -175,6 +178,9 @@ func (p *Provider) Ask(ctx context.Context, prompt string, opts ...llm.CallOptio
 	if decoded.Usage != nil {
 		usage.InputTokens = decoded.Usage.PromptTokens
 		usage.OutputTokens = decoded.Usage.CompletionTokens
+		if decoded.Usage.PromptTokensDetails != nil {
+			usage.CachedTokens = decoded.Usage.PromptTokensDetails.CachedTokens
+		}
 	}
 	return decoded.Choices[0].Message.Content, usage, nil
 }

--- a/internal/llm/openaicompat/provider_test.go
+++ b/internal/llm/openaicompat/provider_test.go
@@ -64,6 +64,28 @@ func TestAskSendsModelAndSystemAndReturnsContent(t *testing.T) {
 	assert.Equal(t, "be terse", first["content"])
 }
 
+func TestAskParsesUsageIncludingCachedTokens(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}],"usage":{"prompt_tokens":100,"completion_tokens":20,"prompt_tokens_details":{"cached_tokens":40}}}`))
+	}))
+	defer srv.Close()
+
+	p, err := openaicompat.New(openaicompat.Settings{
+		APIKey:     "sk-test",
+		BaseURL:    srv.URL + "/v1",
+		Model:      "m",
+		HTTPClient: srv.Client(),
+	})
+	require.NoError(t, err)
+
+	_, usage, err := p.Ask(context.Background(), "ping")
+	require.NoError(t, err)
+	assert.Equal(t, 100, usage.InputTokens)
+	assert.Equal(t, 20, usage.OutputTokens)
+	assert.Equal(t, 40, usage.CachedTokens)
+}
+
 func TestAskSurfacesAPIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -11,10 +11,14 @@ import (
 	"iter"
 )
 
-// Usage reports the token consumption of a single LLM call.
+// Usage reports the token consumption of a single LLM call. CachedTokens is the
+// subset of InputTokens served from the backend's prefix cache (0 when the
+// backend reports none); it lets a downstream meter credit cache hits at a lower
+// rate than fresh input.
 type Usage struct {
 	InputTokens  int
 	OutputTokens int
+	CachedTokens int
 }
 
 // ErrBudgetExhausted is returned by BudgetedProvider when the rolling

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -240,11 +240,16 @@ func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outp
 	}
 	budget := llm.NewTokenBudget()
 	budget.SetBaseline(usedInput, usedOutput)
+	model := provider.Model()
 	return llm.NewBudgetedProvider(provider, budget, inputCap, outputCap, func(u llm.Usage) {
 		inTotal, outTotal := budget.Totals()
+		// cached_tokens (prefix-cache subset of input) and model let a downstream
+		// meter price the call per model with cache crediting.
 		log.Info("llm_usage",
 			"input_tokens", u.InputTokens,
 			"output_tokens", u.OutputTokens,
+			"cached_tokens", u.CachedTokens,
+			"model", model,
 			"input_total", inTotal,
 			"output_total", outTotal,
 		)
@@ -254,6 +259,8 @@ func BuildBudgetedProvider(a *agent.Agent, provider llm.Provider, inputCap, outp
 			Fields: map[string]any{
 				"input_tokens":  u.InputTokens,
 				"output_tokens": u.OutputTokens,
+				"cached_tokens": u.CachedTokens,
+				"model":         model,
 				"input_total":   inTotal,
 				"output_total":  outTotal,
 				"input_cap":     inputCap,

--- a/internal/runtime/wire_test.go
+++ b/internal/runtime/wire_test.go
@@ -180,13 +180,15 @@ func TestBuildBudgetedProviderPublishesUsageEvent(t *testing.T) {
 	a.Events.Subscribe(agent.EventLLMUsage, func(_ context.Context, ev *agent.Event) {
 		got <- ev
 	})
-	wrapped := runtime.BuildBudgetedProvider(a, &usageProvider{in: 30, out: 12}, 1000, 500, 0, 0, nil)
+	wrapped := runtime.BuildBudgetedProvider(a, &usageProvider{in: 30, out: 12, cached: 8}, 1000, 500, 0, 0, nil)
 	_, _, err := wrapped.Ask(context.Background(), "hi")
 	require.NoError(t, err)
 	select {
 	case ev := <-got:
 		require.Equal(t, 30, ev.Fields["input_tokens"])
 		require.Equal(t, 12, ev.Fields["output_tokens"])
+		require.Equal(t, 8, ev.Fields["cached_tokens"])
+		require.Equal(t, "usage", ev.Fields["model"])
 	default:
 		t.Fatal("expected an EventLLMUsage to be published")
 	}
@@ -195,13 +197,14 @@ func TestBuildBudgetedProviderPublishesUsageEvent(t *testing.T) {
 // usageProvider reports fixed token usage so the budgeted wrapper records
 // and publishes a usage event.
 type usageProvider struct {
-	in  int
-	out int
+	in     int
+	out    int
+	cached int
 }
 
 func (usageProvider) Model() string { return "usage" }
 func (p *usageProvider) Ask(context.Context, string, ...llm.CallOption) (string, llm.Usage, error) {
-	return "ok", llm.Usage{InputTokens: p.in, OutputTokens: p.out}, nil
+	return "ok", llm.Usage{InputTokens: p.in, OutputTokens: p.out, CachedTokens: p.cached}, nil
 }
 func (usageProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
 	return func(func(string, error) bool) {}


### PR DESCRIPTION
Parse `prompt_tokens_details.cached_tokens` from OpenAI-compatible backends into `Usage`, and include `cached_tokens` + the model on the structured `llm_usage` log line and the `EventLLMUsage` payload.

This lets a downstream meter price each call per model and credit prefix-cache hits at a lower rate than fresh input. Purely additive — both fields default harmlessly (0 / "") for consumers that ignore them.

Tests: cached-token parsing in the openaicompat provider; cached_tokens + model on the published usage event.