### PR TITLE
feat(skill+flow): trigger/action skills + declarative node-graph flow engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,24 +26,40 @@
 # TURBORG_LOG_LEVEL=INFO                                 # DEBUG / INFO / WARNING / ERROR / CRITICAL
 # TURBORG_LOG_FORMAT=text                                # text (human) or json (CW Logs / Loki ingestion)
 
-# --- Command dispatch ---
-# Commands are data-driven: the agent ships with none and dispatches only the
-# command set you supply via TURBORG_COMMANDS (see below). Each command has a
-# trigger name, a type (static or llm), a template, and an access policy.
+# --- Skills (commands + triggers) ---
+# Skills are data-driven: the agent ships with none and runs only the skill set
+# you supply via TURBORG_COMMANDS (see below). A skill pairs a trigger (what
+# makes it fire) with an action (what it does). The default trigger is a
+# command — a prefixed word a user types — so an existing command set keeps
+# working unchanged.
 # TURBORG_COMMAND_PREFIX=!                               # leading character for the command trigger
 # TURBORG_COMMAND_MAX_PER_WINDOW=5                       # per-sender sliding-window throttle
 # TURBORG_COMMAND_WINDOW_SECONDS=30
-# Cap on how many commands the registry accepts. The default (0) rejects ALL
-# commands — so to load your own TURBORG_COMMANDS you must raise this. -1 =
-# unlimited (the right value for most self-host setups); a positive N caps it.
+# Cap on how many skills the agent accepts. The default (0) rejects ALL skills —
+# so to load your own TURBORG_COMMANDS you must raise this. -1 = unlimited (the
+# right value for most self-host setups); a positive N caps it. Applies to
+# command, event, match, and schedule skills alike.
 TURBORG_CUSTOM_COMMANDS_MAX=-1
 
-# TURBORG_COMMANDS is a JSON array of command definitions. Placeholders {nick},
-# {args}, {channel} are substituted in the template. type=static replies with
-# the rendered template verbatim; type=llm runs it as a prompt against the
-# configured LLM (see below) — an optional "instructions" field sets that
-# command's system prompt. access is everyone | owner | allowlist.
+# TURBORG_COMMANDS is a JSON array of skill definitions (flat, backward-
+# compatible wire). Template placeholders like {nick}, {args}, {channel},
+# {text} are substituted at fire time.
+#   action type:  static (reply with the rendered template), llm (run it as a
+#                 prompt against the configured LLM; an optional "instructions"
+#                 field sets the system prompt), llm_classify (ask the LLM for a
+#                 moderation verdict), effect (a channel action: kick/ban/mute/
+#                 mode/notice/op/voice/topic), or webhook (POST the trigger
+#                 context as JSON to an external "webhook" URL — the integration
+#                 seam to outbound flow engines).
+#   trigger_kind: command (default), event (USER_JOIN/USER_LEAVE/USER_KICKED/
+#                 USER_NICK_CHANGE/TOPIC_CHANGED/MODE_CHANGED), match (a regex
+#                 over every message), or schedule (an interval like "30m"/"1h"
+#                 or a 5-field cron). An optional "channels" array scopes a
+#                 trigger to specific channels.
+#   access:       everyone | owner | allowlist (command skills only).
 # TURBORG_COMMANDS=[{"name":"rules","type":"static","template":"Be excellent to each other.","access":"everyone"}]
+# TURBORG_COMMANDS=[{"name":"welcome","trigger_kind":"event","event":"USER_JOIN","type":"static","template":"Welcome {nick} to {channel}!"}]
+# TURBORG_COMMANDS=[{"name":"to-flow","trigger_kind":"event","event":"USER_JOIN","type":"webhook","webhook":"https://flows.example/hook","template":"{nick} joined {channel}"}]
 
 # --- Owner / authorization for !commands ---
 # TURBORG_OWNER_MODE selects which trust model the agent uses for !commands.

--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,17 @@ TURBORG_CUSTOM_COMMANDS_MAX=-1
 # declarative — nodes come from a fixed catalog; no arbitrary code runs.
 # TURBORG_FLOWS=[{"name":"greet","trigger":{"kind":"match","match":"(?i)^hi"},"nodes":[{"id":"c","type":"if","config":{"left":"{user}","op":"ne","right":"bot"}},{"id":"s","type":"say","config":{"text":"hello {user}"}}],"edges":[{"from":"start","to":"c"},{"from":"c","to":"s","port":"true"}]}]
 
+# TURBORG_FLOWS_URL lets a running agent hot-reload its flow set in place — no
+# reconnect. Point it at an HTTP endpoint that returns the current flow set as a
+# JSON array (the same shape as TURBORG_FLOWS); the agent polls it and swaps the
+# live flow set whenever it changes. Leave unset to keep the boot TURBORG_FLOWS
+# set fixed for the life of the process. TURBORG_FLOWS_TOKEN is the Bearer token
+# sent on each poll (defaults to the message-sink token when unset);
+# TURBORG_FLOWS_REFRESH_SECONDS is the poll interval (0 = default 15s).
+# TURBORG_FLOWS_URL=https://example/flows
+# TURBORG_FLOWS_TOKEN=secret
+# TURBORG_FLOWS_REFRESH_SECONDS=15
+
 # --- Durable skill/flow state (optional) ---
 # By default the state that skills and flows keep between fires (setvar/getvar
 # values, quiz scores, a seen-database, counters, history) lives in-process and

--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,16 @@ TURBORG_CUSTOM_COMMANDS_MAX=-1
 # TURBORG_COMMANDS=[{"name":"welcome","trigger_kind":"event","event":"USER_JOIN","type":"static","template":"Welcome {nick} to {channel}!"}]
 # TURBORG_COMMANDS=[{"name":"to-flow","trigger_kind":"event","event":"USER_JOIN","type":"webhook","webhook":"https://flows.example/hook","template":"{nick} joined {channel}"}]
 
+# TURBORG_FLOWS is a JSON array of node-graph flows — the modular layer above
+# single-shot skills. Each flow has a trigger (same kinds as a skill: command/
+# event/match/schedule), a list of activity "nodes", and the "edges" wiring
+# them. The agent walks the graph when the trigger fires, threading a data bag
+# ({user}/{channel}/{text}/…) between nodes. Node types: set, if, switch, stop,
+# say, notice, effect, llm, webhook, setvar, getvar. The same cap
+# (TURBORG_CUSTOM_COMMANDS_MAX) gates how many flows are accepted. The graph is
+# declarative — nodes come from a fixed catalog; no arbitrary code runs.
+# TURBORG_FLOWS=[{"name":"greet","trigger":{"kind":"match","match":"(?i)^hi"},"nodes":[{"id":"c","type":"if","config":{"left":"{user}","op":"ne","right":"bot"}},{"id":"s","type":"say","config":{"text":"hello {user}"}}],"edges":[{"from":"start","to":"c"},{"from":"c","to":"s","port":"true"}]}]
+
 # --- Owner / authorization for !commands ---
 # TURBORG_OWNER_MODE selects which trust model the agent uses for !commands.
 # Default is "none" — the agent refuses every !command until you opt in.

--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,19 @@ TURBORG_CUSTOM_COMMANDS_MAX=-1
 # declarative — nodes come from a fixed catalog; no arbitrary code runs.
 # TURBORG_FLOWS=[{"name":"greet","trigger":{"kind":"match","match":"(?i)^hi"},"nodes":[{"id":"c","type":"if","config":{"left":"{user}","op":"ne","right":"bot"}},{"id":"s","type":"say","config":{"text":"hello {user}"}}],"edges":[{"from":"start","to":"c"},{"from":"c","to":"s","port":"true"}]}]
 
+# --- Durable skill/flow state (optional) ---
+# By default the state that skills and flows keep between fires (setvar/getvar
+# values, quiz scores, a seen-database, counters, history) lives in-process and
+# is lost when the agent restarts. Point TURBORG_STATE_URL at an HTTP service
+# that persists it and that state survives restarts instead. The agent reads and
+# writes each value under {URL}/state/{namespace}/{key} (namespace = the skill
+# or flow name) with GET/PUT/DELETE and a Bearer token. A state-service outage
+# degrades gracefully — reads miss, writes drop — and never blocks messages.
+# Short-lived flood counters stay in-process regardless. Leave unset to keep the
+# in-process default.
+# TURBORG_STATE_URL=https://state.example/agents/my-bot
+# TURBORG_STATE_TOKEN=your-bearer-token
+
 # --- Owner / authorization for !commands ---
 # TURBORG_OWNER_MODE selects which trust model the agent uses for !commands.
 # Default is "none" — the agent refuses every !command until you opt in.

--- a/internal/agent/actor.go
+++ b/internal/agent/actor.go
@@ -1,0 +1,30 @@
+package agent
+
+// Actor is the connector-agnostic action surface a skill engine uses to act on
+// a chat network: send messages and notices, and perform channel moderation.
+// Every protocol adapter that supports these provides an implementation;
+// connectors that cannot perform an action return an error from it.
+//
+// Targets are connector-native identifiers (an IRC channel/nick, a Discord
+// channel/user id, …). The engine never constructs protocol wire itself — it
+// only calls these methods, so moderation stays portable across connectors.
+type Actor interface {
+	// Say sends a message to a channel (or a user, for a direct target).
+	Say(channel, text string) error
+	// Notice sends a notice to a target (channel or user).
+	Notice(target, text string) error
+	// Kick removes a nick from a channel with an optional reason.
+	Kick(channel, nick, reason string) error
+	// Ban bans a nick or mask from a channel.
+	Ban(channel, mask string) error
+	// SetMode applies a raw mode string (with optional args) to a channel.
+	SetMode(channel, modes string, args ...string) error
+	// Op grants channel-operator status to a nick.
+	Op(channel, nick string) error
+	// Voice grants voice to a nick.
+	Voice(channel, nick string) error
+	// Topic sets a channel's topic.
+	Topic(channel, topic string) error
+	// Invite invites a nick to a channel.
+	Invite(channel, nick string) error
+}

--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -37,6 +37,11 @@ const (
 	EventLLMUsage       EventType = "LLM_USAGE"
 	EventError          EventType = "ERROR"
 	EventRaw            EventType = "RAW"
+
+	// EventModeration is emitted when a skill engine applies a moderation
+	// effect (kick/ban/mute/notice/…) so downstream consumers can audit
+	// automated actions. Additive — it does not change any existing value.
+	EventModeration EventType = "MODERATION"
 )
 
 type Event struct {

--- a/internal/agent/events.go
+++ b/internal/agent/events.go
@@ -42,6 +42,11 @@ const (
 	// effect (kick/ban/mute/notice/…) so downstream consumers can audit
 	// automated actions. Additive — it does not change any existing value.
 	EventModeration EventType = "MODERATION"
+
+	// EventWebhookReceived is emitted when an authenticated inbound webhook
+	// fires a matching trigger, so downstream consumers can audit external
+	// integrations. Additive — it does not change any existing value.
+	EventWebhookReceived EventType = "WEBHOOK_RECEIVED"
 )
 
 type Event struct {

--- a/internal/commandrefresh/refresh.go
+++ b/internal/commandrefresh/refresh.go
@@ -32,7 +32,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/turborg/turborg/internal/commands"
+	"github.com/turborg/turborg/internal/skill"
 )
 
 const (
@@ -44,7 +44,7 @@ const (
 // Apply installs a new command set on the live agent. The runtime supplies a
 // closure that rebuilds the handlers (with the agent's provider + owner-trust)
 // and swaps them via CommandRegistry.ReplaceDynamic.
-type Apply func(defs []commands.Definition)
+type Apply func(defs []skill.Skill)
 
 // Refresher periodically pulls the tenant's command set and applies changes.
 type Refresher struct {
@@ -55,7 +55,7 @@ type Refresher struct {
 	client   *http.Client
 	log      *slog.Logger
 
-	last     []commands.Definition
+	last     []skill.Skill
 	haveLast bool
 }
 
@@ -122,7 +122,7 @@ func (r *Refresher) refreshOnce(ctx context.Context) {
 	r.log.Info("commands reloaded in place", "commands", len(defs))
 }
 
-func (r *Refresher) fetch(ctx context.Context) ([]commands.Definition, error) {
+func (r *Refresher) fetch(ctx context.Context) ([]skill.Skill, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.endpoint, nil)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (r *Refresher) fetch(ctx context.Context) ([]commands.Definition, error) {
 		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
 
-	var defs []commands.Definition
+	var defs []skill.Skill
 	if err := json.NewDecoder(resp.Body).Decode(&defs); err != nil {
 		return nil, fmt.Errorf("decode body: %w", err)
 	}

--- a/internal/commandrefresh/refresh_test.go
+++ b/internal/commandrefresh/refresh_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/turborg/turborg/internal/commands"
+	"github.com/turborg/turborg/internal/skill"
 )
 
 func TestMain(m *testing.M) {
@@ -23,17 +23,17 @@ func TestMain(m *testing.M) {
 type spyApply struct {
 	mu    sync.Mutex
 	calls int
-	last  []commands.Definition
+	last  []skill.Skill
 }
 
-func (s *spyApply) apply(defs []commands.Definition) {
+func (s *spyApply) apply(defs []skill.Skill) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.calls++
 	s.last = defs
 }
 
-func (s *spyApply) snapshot() (int, []commands.Definition) {
+func (s *spyApply) snapshot() (int, []skill.Skill) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.calls, s.last
@@ -65,7 +65,7 @@ func TestRefreshAppliesCommandsAndSendsAuth(t *testing.T) {
 	assert.Equal(t, 1, calls)
 	require.Len(t, last, 1)
 	assert.Equal(t, "weather", last[0].Name)
-	assert.Equal(t, commands.AccessOwner, last[0].Access)
+	assert.Equal(t, skill.AccessOwner, last[0].Access)
 	assert.Equal(t, "Bearer secret-tok", gotAuth.Load())
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -205,6 +205,14 @@ type Settings struct {
 	// delivers through its tenant feed.
 	Commands string `env:"COMMANDS"`
 
+	// Flows is the JSON-encoded set of declarative node-graph flows the agent
+	// runs: an array of {name,trigger,nodes,edges} objects. Each flow wires
+	// activity nodes (set/if/switch/say/effect/llm/webhook/…) into a graph the
+	// agent walks when the flow's trigger fires. Empty → no flows. The graph is
+	// declarative — nodes come from a fixed catalog; there is no arbitrary code
+	// execution.
+	Flows string `env:"FLOWS"`
+
 	// OwnerDMNudgeEvery triggers a DM to the owner after every N outbound
 	// messages. 0 = disabled. Used by operators who want a regular usage
 	// summary delivered through IRC itself.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -165,6 +165,20 @@ type Settings struct {
 	// values below the floor are clamped up by the refresher.
 	CommandsRefreshSeconds int `env:"COMMANDS_REFRESH_SECONDS"`
 
+	// FlowsURL is an optional endpoint the agent polls to hot-reload its
+	// declarative node-graph flow set while it runs — no reconnect. Point it at a
+	// service that serves the latest flow set as JSON. Empty = no live reload (the
+	// boot TURBORG_FLOWS set is fixed). This gives a single-instance agent the
+	// same in-place ReplaceFlows the pooled runtime already does from its tenant
+	// feed.
+	FlowsURL string `env:"FLOWS_URL"`
+	// FlowsToken is the bearer sent on every flows poll. Defaults to
+	// MessageSinkToken via normalize() when unset — same per-container endpoint.
+	FlowsToken string `env:"FLOWS_TOKEN"`
+	// FlowsRefreshSeconds is the poll interval. 0 uses the package default;
+	// values below the floor are clamped up by the refresher.
+	FlowsRefreshSeconds int `env:"FLOWS_REFRESH_SECONDS"`
+
 	// ConfigURL is an optional endpoint the agent polls to hot-reload its live
 	// IRC nick + channel set while it runs — no reconnect. Empty = no live
 	// reload (the boot TURBORG_IRC_NICK / CHANNELS are fixed). This gives a
@@ -349,6 +363,11 @@ func (s *Settings) normalize() error {
 	// reuses that bearer unless overridden.
 	if s.CommandsToken == "" {
 		s.CommandsToken = s.MessageSinkToken
+	}
+	// The flows poll terminates at the same per-container endpoint, so it
+	// reuses that bearer unless overridden.
+	if s.FlowsToken == "" {
+		s.FlowsToken = s.MessageSinkToken
 	}
 	// The config (nick/channels) poll terminates at the same per-container
 	// endpoint, so it reuses that bearer unless overridden.

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -291,6 +291,19 @@ type Settings struct {
 	// unset — the write and read halves typically share the same
 	// per-container token.
 	MessageStoreToken string `env:"MESSAGE_STORE_TOKEN"`
+
+	// StateURL is an optional endpoint that gives skills and flows durable
+	// key/value state — counters, per-user values, a seen-database, history —
+	// that survives a restart. Empty = state is kept in-process only (the
+	// default) and lost when the agent stops. When set, point it at an HTTP
+	// service that implements the contract documented on skill.HTTPStore; the
+	// agent reads and writes each value under {StateURL}/state/{namespace}/{key}.
+	StateURL string `env:"STATE_URL"`
+
+	// StateToken is the bearer sent on every state request. Defaults to
+	// MessageSinkToken via normalize() when unset — the state backend typically
+	// terminates at the same per-container endpoint with the same bearer.
+	StateToken string `env:"STATE_TOKEN"`
 }
 
 // Load parses TURBORG_* env vars into a Settings, normalizing the
@@ -341,6 +354,11 @@ func (s *Settings) normalize() error {
 	// endpoint, so it reuses that bearer unless overridden.
 	if s.ConfigToken == "" {
 		s.ConfigToken = s.MessageSinkToken
+	}
+	// The durable-state backend terminates at the same per-container endpoint,
+	// so it reuses that bearer unless overridden.
+	if s.StateToken == "" {
+		s.StateToken = s.MessageSinkToken
 	}
 	return nil
 }

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -257,3 +257,18 @@ func TestNormalizeTrimsAllowedNetworksWhitespace(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"irc.libera.chat", "irc.oftc.net"}, s.AllowedNetworks)
 }
+
+func TestStateTokenDefaultsToSinkToken(t *testing.T) {
+	t.Setenv("TURBORG_MESSAGE_SINK_TOKEN", "shared-bearer")
+	t.Setenv("TURBORG_STATE_URL", "https://state.example/agents/bot")
+	s, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://state.example/agents/bot", s.StateURL)
+	assert.Equal(t, "shared-bearer", s.StateToken, "state token falls back to the sink token")
+
+	// An explicit state token overrides the fallback.
+	t.Setenv("TURBORG_STATE_TOKEN", "state-only")
+	s, err = config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "state-only", s.StateToken)
+}

--- a/internal/connector/irc/actor.go
+++ b/internal/connector/irc/actor.go
@@ -1,0 +1,80 @@
+package irc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/turborg/turborg/internal/agent"
+)
+
+// rawSender is the minimal connector surface the Actor needs: a single raw
+// upstream write. The Connector satisfies it via SendRaw. Narrowing to this
+// interface keeps the Actor unit-testable without a live upstream socket.
+type rawSender interface {
+	SendRaw(line string) error
+}
+
+// Actor implements agent.Actor over the IRC wire. It translates the
+// connector-agnostic action surface into raw IRC commands sent upstream via
+// the connector's SendRaw, so the skill engine can moderate any connector
+// uniformly.
+type Actor struct {
+	send rawSender
+}
+
+// NewActor builds an IRC Actor bound to a connector.
+func NewActor(c *Connector) *Actor { return &Actor{send: c} }
+
+var _ agent.Actor = (*Actor)(nil)
+
+func (a *Actor) Say(channel, text string) error {
+	return a.send.SendRaw(fmt.Sprintf("%s %s :%s", CmdPrivmsg, channel, text))
+}
+
+func (a *Actor) Notice(target, text string) error {
+	return a.send.SendRaw(fmt.Sprintf("%s %s :%s", CmdNotice, target, text))
+}
+
+func (a *Actor) Kick(channel, nick, reason string) error {
+	line := fmt.Sprintf("%s %s %s", CmdKick, channel, nick)
+	if reason != "" {
+		line += " :" + reason
+	}
+	return a.send.SendRaw(line)
+}
+
+// Ban sets +b on a resolved mask. A bare nick is widened to a nick!*@* mask
+// (the connector tracks no per-member host, so this is the best available
+// identity); a value that already looks like a mask is used as given.
+func (a *Actor) Ban(channel, mask string) error {
+	return a.SetMode(channel, "+b", resolveBanMask(mask))
+}
+
+func (a *Actor) SetMode(channel, modes string, args ...string) error {
+	line := fmt.Sprintf("%s %s %s", CmdMode, channel, modes)
+	if len(args) > 0 {
+		line += " " + strings.Join(args, " ")
+	}
+	return a.send.SendRaw(strings.TrimRight(line, " "))
+}
+
+func (a *Actor) Op(channel, nick string) error    { return a.SetMode(channel, "+o", nick) }
+func (a *Actor) Voice(channel, nick string) error { return a.SetMode(channel, "+v", nick) }
+
+func (a *Actor) Topic(channel, topic string) error {
+	return a.send.SendRaw(fmt.Sprintf("%s %s :%s", CmdTopic, channel, topic))
+}
+
+// Invite uses IRC argument order (INVITE <nick> <channel>).
+func (a *Actor) Invite(channel, nick string) error {
+	return a.send.SendRaw(fmt.Sprintf("%s %s %s", CmdInvite, nick, channel))
+}
+
+// resolveBanMask widens a bare nick to a nick!*@* mask; a value already
+// containing mask syntax (! or @) is returned unchanged.
+func resolveBanMask(mask string) string {
+	if strings.ContainsAny(mask, "!@") {
+		return mask
+	}
+	return mask + "!*@*"
+}

--- a/internal/connector/irc/actor_test.go
+++ b/internal/connector/irc/actor_test.go
@@ -1,0 +1,88 @@
+package irc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingSender captures every raw line the Actor emits.
+type recordingSender struct {
+	lines []string
+	err   error
+}
+
+func (r *recordingSender) SendRaw(line string) error {
+	r.lines = append(r.lines, line)
+	return r.err
+}
+
+func newTestActor() (*Actor, *recordingSender) {
+	rs := &recordingSender{}
+	return &Actor{send: rs}, rs
+}
+
+func TestActorTranslatesToIRCWire(t *testing.T) {
+	a, rs := newTestActor()
+
+	require.NoError(t, a.Say("#room", "hello"))
+	require.NoError(t, a.Notice("alice", "psst"))
+	require.NoError(t, a.Kick("#room", "bob", "spam"))
+	require.NoError(t, a.Kick("#room", "carol", "")) // no reason → no trailing
+	require.NoError(t, a.Op("#room", "dave"))
+	require.NoError(t, a.Voice("#room", "erin"))
+	require.NoError(t, a.SetMode("#room", "+m"))
+	require.NoError(t, a.Topic("#room", "new topic"))
+	require.NoError(t, a.Invite("#room", "frank"))
+
+	assert.Equal(t, []string{
+		"PRIVMSG #room :hello",
+		"NOTICE alice :psst",
+		"KICK #room bob :spam",
+		"KICK #room carol",
+		"MODE #room +o dave",
+		"MODE #room +v erin",
+		"MODE #room +m",
+		"TOPIC #room :new topic",
+		"INVITE frank #room",
+	}, rs.lines)
+}
+
+func TestActorBanResolvesMask(t *testing.T) {
+	a, rs := newTestActor()
+	require.NoError(t, a.Ban("#room", "troll"))             // bare nick → widened
+	require.NoError(t, a.Ban("#room", "troll!*@evil.host")) // full mask → as-is
+	assert.Equal(t, []string{
+		"MODE #room +b troll!*@*",
+		"MODE #room +b troll!*@evil.host",
+	}, rs.lines)
+}
+
+func TestActorSetModeWithArgs(t *testing.T) {
+	a, rs := newTestActor()
+	require.NoError(t, a.SetMode("#room", "+qo", "spammer", "helper"))
+	assert.Equal(t, "MODE #room +qo spammer helper", rs.lines[0])
+}
+
+func TestActorPropagatesSendError(t *testing.T) {
+	rs := &recordingSender{err: errors.New("not connected")}
+	a := &Actor{send: rs}
+	require.Error(t, a.Say("#room", "hi"))
+}
+
+func TestResolveBanMask(t *testing.T) {
+	assert.Equal(t, "nick!*@*", resolveBanMask("nick"))
+	assert.Equal(t, "nick!user@host", resolveBanMask("nick!user@host"))
+	assert.Equal(t, "*@host", resolveBanMask("*@host"))
+}
+
+func TestNewActorBindsConnector(t *testing.T) {
+	cfg := &Settings{Hostname: "irc.example", Nick: "bot"}
+	cfg.ApplyDefaults()
+	conn := New(cfg, nil, nil)
+	a := NewActor(conn)
+	// Not connected → SendRaw surfaces the connector's "not connected" error.
+	require.Error(t, a.Say("#room", "hi"))
+}

--- a/internal/flow/engine.go
+++ b/internal/flow/engine.go
@@ -41,6 +41,9 @@ type Engine struct {
 	maxFlows int
 	events   []compiled
 	matches  []compiled
+	// webhooks indexes inbound-webhook-trigger flows by lowercased name so
+	// FireWebhook can dispatch an external POST in O(1) without leaking the set.
+	webhooks map[string]compiled
 }
 
 // compiled is a runtime-ready flow: the definition plus the compiled match
@@ -121,6 +124,7 @@ func (e *Engine) ReplaceFlows(flows []Flow) {
 	e.mu.RUnlock()
 
 	var events, matches []compiled
+	webhooks := map[string]compiled{}
 	installed := 0
 	for _, f := range flows {
 		if limit != -1 && installed >= limit {
@@ -142,6 +146,14 @@ func (e *Engine) ReplaceFlows(flows []Flow) {
 		case skill.KindEvent:
 			events = append(events, compiled{flow: f, channels: channelSet(f.Trigger.Channels)})
 			installed++
+		case skill.KindWebhook:
+			key := strings.ToLower(strings.TrimSpace(f.Name))
+			if key == "" {
+				e.log.Warn("skipping webhook flow: empty name")
+				continue
+			}
+			webhooks[key] = compiled{flow: f, channels: channelSet(f.Trigger.Channels)}
+			installed++
 		default:
 			// command / schedule flows are not the bus engine's concern.
 		}
@@ -150,7 +162,34 @@ func (e *Engine) ReplaceFlows(flows []Flow) {
 	e.mu.Lock()
 	e.events = events
 	e.matches = matches
+	e.webhooks = webhooks
 	e.mu.Unlock()
+}
+
+// FireWebhook walks the flow whose webhook trigger matches name (case-
+// insensitive), seeding the data bag from bag. It returns true when a matching
+// webhook flow ran, false when no flow carries that name — the ingress handler
+// maps false onto a 404 with no detail so a caller can't enumerate the set. The
+// bag's "channel" is the trigger's first scoped channel when set, else whatever
+// the caller seeded.
+func (e *Engine) FireWebhook(name string, bag map[string]string) bool {
+	e.mu.RLock()
+	c, ok := e.webhooks[strings.ToLower(strings.TrimSpace(name))]
+	e.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	b := Bag{}
+	for k, v := range bag {
+		b[k] = v
+	}
+	if chans := c.flow.Trigger.Channels; len(chans) > 0 {
+		b["channel"] = chans[0]
+	}
+	b["platform"] = e.platform
+	b["owner"] = e.owner
+	e.run(context.Background(), c.flow, b)
+	return true
 }
 
 // validate checks a flow's node types are all registered. An empty graph is

--- a/internal/flow/engine.go
+++ b/internal/flow/engine.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -92,14 +93,24 @@ func NewEngine(o Options) *Engine {
 	}
 }
 
-func defaultPost(ctx context.Context, url string, payload []byte) error {
+func defaultPost(ctx context.Context, method, url string, payload []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, webhookTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if method == "" {
+		method = http.MethodPost
+	}
+	// A GET carries no request body; other verbs send the payload as JSON.
+	var body io.Reader
+	if method != http.MethodGet {
+		body = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err

--- a/internal/flow/engine.go
+++ b/internal/flow/engine.go
@@ -1,0 +1,347 @@
+package flow
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/llm"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+// maxSteps bounds how many nodes a single flow run may execute, so a malformed
+// or cyclic graph can never run away.
+const maxSteps = 256
+
+// webhookTimeout bounds a single webhook node POST.
+const webhookTimeout = 5 * time.Second
+
+// Engine runs event/match-triggered flows: it subscribes to the agent's
+// EventBus, seeds a data bag from each inbound message / lifecycle event, and
+// walks every flow whose trigger matches. The flow set is hot-swappable
+// (ReplaceFlows) under a write lock with a MaxFlows cap, mirroring the skill
+// engine.
+type Engine struct {
+	actor    agent.Actor
+	provider llm.Provider
+	store    skill.Store
+	post     PostFunc
+	platform string
+	owner    string
+	log      *slog.Logger
+
+	mu       sync.RWMutex
+	maxFlows int
+	events   []compiled
+	matches  []compiled
+}
+
+// compiled is a runtime-ready flow: the definition plus the compiled match
+// regex (match trigger only) and a normalized channel scope.
+type compiled struct {
+	flow     Flow
+	re       *regexp.Regexp
+	channels map[string]struct{}
+}
+
+// Options configures an Engine.
+type Options struct {
+	Actor    agent.Actor
+	Provider llm.Provider
+	Store    skill.Store
+	Platform string
+	Owner    string
+	MaxFlows int
+	Post     PostFunc
+	Log      *slog.Logger
+}
+
+// NewEngine builds a flow engine. It holds no flows until ReplaceFlows.
+func NewEngine(o Options) *Engine {
+	log := o.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	store := o.Store
+	if store == nil {
+		store = skill.NewMemoryStore()
+	}
+	post := o.Post
+	if post == nil {
+		post = defaultPost
+	}
+	return &Engine{
+		actor:    o.Actor,
+		provider: o.Provider,
+		store:    store,
+		post:     post,
+		platform: o.Platform,
+		owner:    o.Owner,
+		log:      log.With("component", "flow-engine"),
+		maxFlows: o.MaxFlows,
+	}
+}
+
+func defaultPost(ctx context.Context, url string, payload []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, webhookTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
+}
+
+// SetMaxFlows caps how many flows ReplaceFlows installs: 0 = none (default),
+// -1 = unrestricted, N = at most N.
+func (e *Engine) SetMaxFlows(n int) {
+	e.mu.Lock()
+	e.maxFlows = n
+	e.mu.Unlock()
+}
+
+// ReplaceFlows atomically swaps the engine's event/match flow set. A flow whose
+// nodes are unknown, whose graph is invalid, or whose match regex is bad is
+// dropped with a log line. The MaxFlows cap is enforced as a safety net.
+func (e *Engine) ReplaceFlows(flows []Flow) {
+	e.mu.RLock()
+	limit := e.maxFlows
+	e.mu.RUnlock()
+
+	var events, matches []compiled
+	installed := 0
+	for _, f := range flows {
+		if limit != -1 && installed >= limit {
+			break
+		}
+		if err := validate(f); err != nil {
+			e.log.Warn("skipping invalid flow", "flow", f.Name, "err", err)
+			continue
+		}
+		switch f.triggerKind() {
+		case skill.KindMatch:
+			re, err := regexp.Compile(f.Trigger.Match)
+			if err != nil {
+				e.log.Warn("skipping match flow: bad regex", "flow", f.Name, "err", err)
+				continue
+			}
+			matches = append(matches, compiled{flow: f, re: re, channels: channelSet(f.Trigger.Channels)})
+			installed++
+		case skill.KindEvent:
+			events = append(events, compiled{flow: f, channels: channelSet(f.Trigger.Channels)})
+			installed++
+		default:
+			// command / schedule flows are not the bus engine's concern.
+		}
+	}
+
+	e.mu.Lock()
+	e.events = events
+	e.matches = matches
+	e.mu.Unlock()
+}
+
+// validate checks a flow's node types are all registered. An empty graph is
+// valid (it simply does nothing).
+func validate(f Flow) error {
+	for _, n := range f.Nodes {
+		if _, ok := lookup(n.Type); !ok {
+			return &unknownNodeError{n.Type}
+		}
+	}
+	return nil
+}
+
+type unknownNodeError struct{ typ string }
+
+func (e *unknownNodeError) Error() string { return "unknown node type " + e.typ }
+
+// Subscribe wires the engine onto the agent's EventBus.
+func (e *Engine) Subscribe(bus *agent.EventBus) {
+	bus.Subscribe(agent.EventMessage, e.onMessage)
+	for _, t := range []agent.EventType{
+		agent.EventUserJoin, agent.EventUserLeave, agent.EventUserKicked,
+		agent.EventUserNickChange, agent.EventTopicChanged, agent.EventModeChanged,
+	} {
+		bus.Subscribe(t, e.onUserEvent)
+	}
+}
+
+func (e *Engine) onMessage(ctx context.Context, ev *agent.Event) {
+	env, ok := ev.Fields["envelope"].(*agent.InboundEnvelope)
+	if !ok || env == nil {
+		return
+	}
+	e.mu.RLock()
+	matches := e.matches
+	e.mu.RUnlock()
+	if len(matches) == 0 {
+		return
+	}
+	for _, m := range matches {
+		if !channelAllowed(m.channels, env.Channel) {
+			continue
+		}
+		if m.re != nil && !m.re.MatchString(env.Text) {
+			continue
+		}
+		bag := Bag{
+			"user": env.Sender, "channel": env.Channel, "text": env.Text,
+			"platform": e.platform, "owner": e.owner,
+		}
+		e.run(ctx, m.flow, bag)
+	}
+}
+
+func (e *Engine) onUserEvent(ctx context.Context, ev *agent.Event) {
+	e.mu.RLock()
+	events := e.events
+	e.mu.RUnlock()
+	if len(events) == 0 {
+		return
+	}
+	name := string(ev.Type)
+	bag := bagFromEvent(ev)
+	bag["platform"] = e.platform
+	bag["owner"] = e.owner
+	channel := bag.str("channel")
+	for _, m := range events {
+		if m.flow.Trigger.Event != name {
+			continue
+		}
+		if !channelAllowed(m.channels, channel) {
+			continue
+		}
+		e.run(ctx, m.flow, cloneBag(bag))
+	}
+}
+
+// run walks the flow graph from its entry nodes, executing each node and
+// following the output port it returns. Execution is bounded by maxSteps.
+func (e *Engine) run(ctx context.Context, f Flow, bag Bag) {
+	nc := &nodeContext{
+		actor: e.actor, provider: e.provider, store: e.store,
+		post: e.post, flowName: f.Name, bag: bag,
+	}
+	queue := f.entryNodes()
+	index := make(map[string]Node, len(f.Nodes))
+	for _, n := range f.Nodes {
+		index[n.ID] = n
+	}
+	steps := 0
+	for len(queue) > 0 {
+		if steps >= maxSteps {
+			e.log.Warn("flow exceeded step ceiling", "flow", f.Name)
+			return
+		}
+		steps++
+		id := queue[0]
+		queue = queue[1:]
+		node, ok := index[id]
+		if !ok {
+			continue
+		}
+		nt, ok := lookup(node.Type)
+		if !ok {
+			continue
+		}
+		port, err := nt.Handler(ctx, node, nc)
+		if err != nil {
+			e.log.Warn("flow node failed", "flow", f.Name, "node", node.ID, "type", node.Type, "err", err)
+			continue
+		}
+		if port == "\x00stop" {
+			continue
+		}
+		queue = append(queue, f.successors(id, port)...)
+	}
+}
+
+// RunOnce executes a flow against a caller-supplied bag, ignoring the trigger.
+// It is the entry the command/schedule paths use once those wire flows in, and
+// a test seam.
+func (e *Engine) RunOnce(ctx context.Context, f Flow, bag Bag) {
+	if bag == nil {
+		bag = Bag{}
+	}
+	if bag["platform"] == nil {
+		bag["platform"] = e.platform
+	}
+	if bag["owner"] == nil {
+		bag["owner"] = e.owner
+	}
+	e.run(ctx, f, bag)
+}
+
+func bagFromEvent(ev *agent.Event) Bag {
+	get := func(k string) string {
+		v, _ := ev.Fields[k].(string)
+		return v
+	}
+	bag := Bag{
+		"channel": get("channel"), "reason": get("reason"),
+		"topic": get("topic"), "modes": get("modes"),
+	}
+	switch ev.Type {
+	case agent.EventUserKicked:
+		bag["user"] = get("by")
+		bag["target"] = get("nick")
+	case agent.EventUserNickChange:
+		bag["old"] = get("old")
+		bag["new"] = get("new")
+		bag["user"] = get("old")
+	case agent.EventTopicChanged, agent.EventModeChanged:
+		bag["user"] = get("by")
+	default:
+		bag["user"] = get("nick")
+	}
+	return bag
+}
+
+func cloneBag(b Bag) Bag {
+	out := make(Bag, len(b))
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}
+
+func channelSet(channels []string) map[string]struct{} {
+	if len(channels) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(channels))
+	for _, c := range channels {
+		if c = strings.ToLower(strings.TrimSpace(c)); c != "" {
+			out[c] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func channelAllowed(set map[string]struct{}, channel string) bool {
+	if set == nil {
+		return true
+	}
+	_, ok := set[strings.ToLower(channel)]
+	return ok
+}
+
+// jsonMarshal is a tiny indirection so the webhook node and tests share one
+// encoder.
+func jsonMarshal(v any) ([]byte, error) { return json.Marshal(v) }

--- a/internal/flow/engine_test.go
+++ b/internal/flow/engine_test.go
@@ -1,0 +1,226 @@
+package flow
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+func newEngine(t *testing.T, o Options) (*Engine, *agent.EventBus) {
+	t.Helper()
+	if o.MaxFlows == 0 {
+		o.MaxFlows = -1
+	}
+	e := NewEngine(o)
+	bus := agent.NewEventBus(nil)
+	e.Subscribe(bus)
+	return e, bus
+}
+
+// branchingFlow: match → if(user ne bot) → true: say; false: stop.
+func branchingFlow() Flow {
+	return Flow{
+		Name:    "greet",
+		Trigger: skill.Trigger{Kind: skill.KindMatch, Match: `(?i)hi`},
+		Nodes: []Node{
+			{ID: "check", Type: "if", Config: map[string]any{"left": "{user}", "op": "ne", "right": "bot"}},
+			{ID: "greet", Type: "say", Config: map[string]any{"text": "hello {user}"}},
+			{ID: "ignore", Type: "stop"},
+		},
+		Edges: []Edge{
+			{From: "start", To: "check"},
+			{From: "check", To: "greet", Port: "true"},
+			{From: "check", To: "ignore", Port: "false"},
+		},
+	}
+}
+
+func TestEngineMatchBranchTrue(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{branchingFlow()})
+	bus.Publish(context.Background(), msgEvent("#r", "alice", "hi there"))
+	assert.Equal(t, []string{"say #r hello alice"}, act.snapshot())
+}
+
+func TestEngineMatchBranchFalse(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{branchingFlow()})
+	bus.Publish(context.Background(), msgEvent("#r", "bot", "hi"))
+	assert.Empty(t, act.snapshot(), "the false branch stops")
+}
+
+func TestEngineMatchNoMatch(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{branchingFlow()})
+	bus.Publish(context.Background(), msgEvent("#r", "alice", "nope"))
+	assert.Empty(t, act.snapshot())
+}
+
+func TestEngineChannelScope(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	f := branchingFlow()
+	f.Trigger.Channels = []string{"#ops"}
+	e.ReplaceFlows([]Flow{f})
+	bus.Publish(context.Background(), msgEvent("#general", "alice", "hi"))
+	assert.Empty(t, act.snapshot())
+	bus.Publish(context.Background(), msgEvent("#ops", "alice", "hi"))
+	assert.Equal(t, []string{"say #ops hello alice"}, act.snapshot())
+}
+
+func TestEngineEventFlow(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{{
+		Name:    "welcome",
+		Trigger: skill.Trigger{Kind: skill.KindEvent, Event: "USER_JOIN"},
+		Nodes:   []Node{{ID: "s", Type: "say", Config: map[string]any{"text": "welcome {user}"}}},
+	}})
+	bus.Publish(context.Background(), &agent.Event{Type: agent.EventUserJoin, Fields: map[string]any{"channel": "#r", "nick": "newbie"}})
+	assert.Equal(t, []string{"say #r welcome newbie"}, act.snapshot())
+}
+
+func TestEngineReplaceFlowsValidationAndCap(t *testing.T) {
+	e := NewEngine(Options{MaxFlows: 1})
+	e.ReplaceFlows([]Flow{
+		{Name: "bad-node", Trigger: skill.Trigger{Kind: skill.KindMatch, Match: "a"}, Nodes: []Node{{ID: "x", Type: "no-such-node"}}}, // dropped
+		{Name: "bad-regex", Trigger: skill.Trigger{Kind: skill.KindMatch, Match: "["}},                                                // dropped
+		{Name: "ok1", Trigger: skill.Trigger{Kind: skill.KindMatch, Match: "a"}},
+		{Name: "ok2", Trigger: skill.Trigger{Kind: skill.KindMatch, Match: "b"}}, // over cap
+	})
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	require.Len(t, e.matches, 1)
+	assert.Equal(t, "ok1", e.matches[0].flow.Name)
+}
+
+func TestEngineSetMaxFlows(t *testing.T) {
+	e := NewEngine(Options{MaxFlows: 0})
+	e.SetMaxFlows(-1)
+	e.ReplaceFlows([]Flow{{Name: "ev", Trigger: skill.Trigger{Kind: skill.KindEvent, Event: "USER_JOIN"}}})
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Len(t, e.events, 1)
+}
+
+func TestEngineRunOnceSeedsContext(t *testing.T) {
+	act := &fakeActor{}
+	e := NewEngine(Options{Actor: act, Platform: "irc.x", Owner: "stefan", MaxFlows: -1})
+	f := Flow{
+		Name:  "ctx",
+		Nodes: []Node{{ID: "s", Type: "say", Config: map[string]any{"channel": "#r", "text": "{platform}/{owner}"}}},
+	}
+	e.RunOnce(context.Background(), f, nil)
+	assert.Equal(t, []string{"say #r irc.x/stefan"}, act.snapshot())
+}
+
+func TestEngineStepCeiling(t *testing.T) {
+	// A 2-node cycle would loop forever without the step ceiling.
+	act := &fakeActor{}
+	e := NewEngine(Options{Actor: act, MaxFlows: -1})
+	f := Flow{
+		Name: "loop",
+		Nodes: []Node{
+			{ID: "a", Type: "set", Config: map[string]any{"fields": map[string]any{"k": "v"}}},
+			{ID: "b", Type: "set", Config: map[string]any{"fields": map[string]any{"k": "v"}}},
+		},
+		Edges: []Edge{{From: "start", To: "a"}, {From: "a", To: "b"}, {From: "b", To: "a"}},
+	}
+	e.RunOnce(context.Background(), f, Bag{}) // must terminate, not hang
+}
+
+func TestEngineNodeErrorContinues(t *testing.T) {
+	e := NewEngine(Options{Provider: &fakeProvider{err: errors.New("down")}, Actor: &fakeActor{}, MaxFlows: -1})
+	f := Flow{
+		Name: "err",
+		Nodes: []Node{
+			{ID: "x", Type: "llm", Config: map[string]any{"prompt": "q"}},
+			{ID: "y", Type: "say", Config: map[string]any{"channel": "#r", "text": "after"}},
+		},
+		Edges: []Edge{{From: "start", To: "x"}, {From: "x", To: "y"}},
+	}
+	e.RunOnce(context.Background(), f, Bag{})
+}
+
+func TestEngineRunSkipsUnknownAndMissing(t *testing.T) {
+	e := NewEngine(Options{Actor: &fakeActor{}, MaxFlows: -1})
+	// Edge points to a missing node id; node id present but unknown type is
+	// filtered at ReplaceFlows, so exercise the executor's guards via RunOnce.
+	f := Flow{
+		Name:  "x",
+		Nodes: []Node{{ID: "a", Type: "set", Config: map[string]any{"fields": map[string]any{}}}},
+		Edges: []Edge{{From: "start", To: "a"}, {From: "a", To: "ghost"}},
+	}
+	e.RunOnce(context.Background(), f, Bag{})
+}
+
+func TestEngineIgnoresNonEnvelope(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{branchingFlow()})
+	bus.Publish(context.Background(), &agent.Event{Type: agent.EventMessage, Fields: map[string]any{}})
+	assert.Empty(t, act.snapshot())
+}
+
+func TestEngineOnUserEventNoFlows(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{branchingFlow()}) // only a match flow
+	bus.Publish(context.Background(), &agent.Event{Type: agent.EventTopicChanged, Fields: map[string]any{"channel": "#r", "by": "u"}})
+	assert.Empty(t, act.snapshot())
+}
+
+func TestBagFromEventVariants(t *testing.T) {
+	k := bagFromEvent(&agent.Event{Type: agent.EventUserKicked, Fields: map[string]any{"channel": "#r", "nick": "v", "by": "op"}})
+	assert.Equal(t, "op", k["user"])
+	assert.Equal(t, "v", k["target"])
+	n := bagFromEvent(&agent.Event{Type: agent.EventUserNickChange, Fields: map[string]any{"old": "a", "new": "b"}})
+	assert.Equal(t, "a", n["old"])
+	tp := bagFromEvent(&agent.Event{Type: agent.EventTopicChanged, Fields: map[string]any{"by": "s"}})
+	assert.Equal(t, "s", tp["user"])
+}
+
+func TestChannelHelpers(t *testing.T) {
+	assert.Nil(t, channelSet(nil))
+	assert.Nil(t, channelSet([]string{" "}))
+	set := channelSet([]string{"#Ops"})
+	assert.True(t, channelAllowed(set, "#ops"))
+	assert.False(t, channelAllowed(set, "#x"))
+	assert.True(t, channelAllowed(nil, "#x"))
+}
+
+func TestDefaultPost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }))
+	defer srv.Close()
+	require.NoError(t, defaultPost(context.Background(), srv.URL, []byte(`{}`)))
+	require.Error(t, defaultPost(context.Background(), "://bad", []byte(`{}`)))
+	require.Error(t, defaultPost(context.Background(), "http://127.0.0.1:0/x", []byte(`{}`)))
+}
+
+func TestValidateUnknownNodeError(t *testing.T) {
+	err := validate(Flow{Nodes: []Node{{ID: "a", Type: "ghost"}}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ghost")
+}
+
+func TestEngineWebhookFlowEndToEnd(t *testing.T) {
+	var got []byte
+	e, bus := newEngine(t, Options{Post: func(_ context.Context, _ string, b []byte) error { got = b; return nil }})
+	e.ReplaceFlows([]Flow{{
+		Name:    "to-flow",
+		Trigger: skill.Trigger{Kind: skill.KindEvent, Event: "USER_JOIN"},
+		Nodes:   []Node{{ID: "w", Type: "webhook", Config: map[string]any{"url": "https://h"}}},
+	}})
+	bus.Publish(context.Background(), &agent.Event{Type: agent.EventUserJoin, Fields: map[string]any{"channel": "#r", "nick": "newbie"}})
+	assert.Contains(t, string(got), `"user":"newbie"`)
+}

--- a/internal/flow/engine_test.go
+++ b/internal/flow/engine_test.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -200,11 +201,25 @@ func TestChannelHelpers(t *testing.T) {
 }
 
 func TestDefaultPost(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }))
+	var gotMethod string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(200)
+	}))
 	defer srv.Close()
-	require.NoError(t, defaultPost(context.Background(), srv.URL, []byte(`{}`)))
-	require.Error(t, defaultPost(context.Background(), "://bad", []byte(`{}`)))
-	require.Error(t, defaultPost(context.Background(), "http://127.0.0.1:0/x", []byte(`{}`)))
+	require.NoError(t, defaultPost(context.Background(), "", srv.URL, []byte(`{}`)))
+	assert.Equal(t, http.MethodPost, gotMethod, "empty method defaults to POST")
+	assert.Equal(t, `{}`, string(gotBody))
+	// A GET carries no request body.
+	require.NoError(t, defaultPost(context.Background(), http.MethodGet, srv.URL, []byte(`{"ignored":true}`)))
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Empty(t, gotBody, "GET sends no body")
+	require.NoError(t, defaultPost(context.Background(), http.MethodDelete, srv.URL, nil))
+	assert.Equal(t, http.MethodDelete, gotMethod)
+	require.Error(t, defaultPost(context.Background(), http.MethodPost, "://bad", []byte(`{}`)))
+	require.Error(t, defaultPost(context.Background(), http.MethodPost, "http://127.0.0.1:0/x", []byte(`{}`)))
 }
 
 func TestValidateUnknownNodeError(t *testing.T) {
@@ -215,7 +230,7 @@ func TestValidateUnknownNodeError(t *testing.T) {
 
 func TestEngineWebhookFlowEndToEnd(t *testing.T) {
 	var got []byte
-	e, bus := newEngine(t, Options{Post: func(_ context.Context, _ string, b []byte) error { got = b; return nil }})
+	e, bus := newEngine(t, Options{Post: func(_ context.Context, _, _ string, b []byte) error { got = b; return nil }})
 	e.ReplaceFlows([]Flow{{
 		Name:    "to-flow",
 		Trigger: skill.Trigger{Kind: skill.KindEvent, Event: "USER_JOIN"},

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -23,6 +23,10 @@ type Flow struct {
 	Trigger skill.Trigger `json:"trigger"`
 	Nodes   []Node        `json:"nodes"`
 	Edges   []Edge        `json:"edges"`
+	// Category is optional display-only metadata (e.g. a builder-UI grouping
+	// label). The engine ignores it entirely; it round-trips through JSON so an
+	// authoring UI can carry it, but it never affects execution.
+	Category string `json:"category,omitempty"`
 }
 
 // Node is one activity in a flow: a registered Type plus free-form Config the

--- a/internal/flow/flow.go
+++ b/internal/flow/flow.go
@@ -1,0 +1,110 @@
+// Package flow is turborg's declarative node-graph engine: an operator wires
+// activity nodes (set / if / switch / say / notice / effect / llm / webhook /
+// getvar / setvar / stop) into a directed graph, and the engine walks that
+// graph when the flow's trigger fires. It is the modular, composable layer
+// above single-shot skills — a flow can branch, transform a data bag, call the
+// LLM, act on the network through the connector-agnostic Actor, and call out to
+// external endpoints, all without code.
+//
+// The model is intentionally small and JSON-serializable so a builder UI can
+// author flows and introspect the node catalog. It is declarative only: nodes
+// come from a fixed, vetted registry; there is no sandboxed or arbitrary code
+// execution. Execution is bounded (a step ceiling) so a malformed or cyclic
+// graph can never run away.
+package flow
+
+import "github.com/turborg/turborg/internal/skill"
+
+// Flow is one node graph plus the trigger that starts it. Trigger reuses the
+// skill trigger model (command / event / match / schedule) so flows and skills
+// share one trigger vocabulary.
+type Flow struct {
+	Name    string        `json:"name"`
+	Trigger skill.Trigger `json:"trigger"`
+	Nodes   []Node        `json:"nodes"`
+	Edges   []Edge        `json:"edges"`
+}
+
+// Node is one activity in a flow: a registered Type plus free-form Config the
+// node's handler interprets. ID is unique within the flow and is what edges
+// reference.
+type Node struct {
+	ID     string         `json:"id"`
+	Type   string         `json:"type"`
+	Config map[string]any `json:"config,omitempty"`
+}
+
+// Edge connects one node's output port to another node's input. Port selects a
+// branch on a multi-output node ("" for the default/single output; "true" /
+// "false" for an if node; a case label for a switch node). An edge whose From
+// is empty (or "start"/"trigger") is an entry edge.
+type Edge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Port string `json:"port,omitempty"`
+}
+
+// triggerKind returns the flow's trigger kind, defaulting to command.
+func (f Flow) triggerKind() skill.TriggerKind {
+	if f.Trigger.Kind == "" {
+		return skill.KindCommand
+	}
+	return f.Trigger.Kind
+}
+
+// entryNodes returns the IDs of nodes that no edge points to — the graph's
+// starting points. Explicit entry edges (From empty/"start"/"trigger") also
+// seed execution; their targets are returned too.
+func (f Flow) entryNodes() []string {
+	hasIncoming := map[string]bool{}
+	var explicit []string
+	for _, e := range f.Edges {
+		if isEntryFrom(e.From) {
+			explicit = append(explicit, e.To)
+			continue
+		}
+		hasIncoming[e.To] = true
+	}
+	seen := map[string]bool{}
+	var out []string
+	add := func(id string) {
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	for _, id := range explicit {
+		add(id)
+	}
+	for _, n := range f.Nodes {
+		if !hasIncoming[n.ID] {
+			add(n.ID)
+		}
+	}
+	return out
+}
+
+// successors returns the target node IDs reachable from node `from` via output
+// `port`. The default port ("") also follows edges authored without a port.
+func (f Flow) successors(from, port string) []string {
+	var out []string
+	for _, e := range f.Edges {
+		if e.From != from {
+			continue
+		}
+		if e.Port == port {
+			out = append(out, e.To)
+		}
+	}
+	return out
+}
+
+func isEntryFrom(from string) bool {
+	switch from {
+	case "", "start", "trigger":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -1,6 +1,7 @@
 package flow
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -32,6 +33,36 @@ func TestFlowJSONRoundTrip(t *testing.T) {
 	var again Flow
 	require.NoError(t, json.Unmarshal(out, &again))
 	assert.Equal(t, f, again)
+}
+
+// TestFlowCategoryRoundTripAndRun proves the optional Category field decodes
+// and re-encodes losslessly and is pure display metadata: a flow that carries a
+// category still executes exactly as one without.
+func TestFlowCategoryRoundTripAndRun(t *testing.T) {
+	raw := `{
+	  "name":"greet",
+	  "category":"Moderation",
+	  "trigger":{"kind":"match","match":"hi"},
+	  "nodes":[{"id":"s","type":"say","config":{"channel":"{channel}","text":"hi {user}"}}]
+	}`
+	var f Flow
+	require.NoError(t, json.Unmarshal([]byte(raw), &f))
+	assert.Equal(t, "Moderation", f.Category)
+
+	// Re-encoding preserves the category, and an empty category is omitted.
+	out, err := json.Marshal(f)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"category":"Moderation"`)
+	empty, err := json.Marshal(Flow{Name: "x"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(empty), "category")
+
+	// The category is inert: the flow still fires its say node.
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{f})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "hi there"))
+	assert.Equal(t, []string{"say #r hi u"}, act.snapshot())
 }
 
 func TestTriggerKindDefault(t *testing.T) {

--- a/internal/flow/flow_test.go
+++ b/internal/flow/flow_test.go
@@ -1,0 +1,74 @@
+package flow
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+func TestFlowJSONRoundTrip(t *testing.T) {
+	raw := `{
+	  "name":"welcome-flow",
+	  "trigger":{"kind":"event","event":"USER_JOIN","channels":["#ops"]},
+	  "nodes":[
+	    {"id":"a","type":"if","config":{"left":"{user}","op":"ne","right":"bot"}},
+	    {"id":"b","type":"say","config":{"text":"hi {user}"}}
+	  ],
+	  "edges":[{"from":"start","to":"a"},{"from":"a","to":"b","port":"true"}]
+	}`
+	var f Flow
+	require.NoError(t, json.Unmarshal([]byte(raw), &f))
+	assert.Equal(t, "welcome-flow", f.Name)
+	assert.Equal(t, skill.KindEvent, f.Trigger.Kind)
+	assert.Equal(t, "USER_JOIN", f.Trigger.Event)
+	require.Len(t, f.Nodes, 2)
+	require.Len(t, f.Edges, 2)
+
+	out, err := json.Marshal(f)
+	require.NoError(t, err)
+	var again Flow
+	require.NoError(t, json.Unmarshal(out, &again))
+	assert.Equal(t, f, again)
+}
+
+func TestTriggerKindDefault(t *testing.T) {
+	assert.Equal(t, skill.KindCommand, Flow{}.triggerKind())
+	assert.Equal(t, skill.KindMatch, Flow{Trigger: skill.Trigger{Kind: skill.KindMatch}}.triggerKind())
+}
+
+func TestEntryNodes(t *testing.T) {
+	f := Flow{
+		Nodes: []Node{{ID: "a"}, {ID: "b"}, {ID: "c"}},
+		Edges: []Edge{{From: "a", To: "b"}, {From: "b", To: "c"}},
+	}
+	// a has no incoming → entry.
+	assert.Equal(t, []string{"a"}, f.entryNodes())
+
+	// Explicit start edge seeds an entry even if the node has incoming edges.
+	f2 := Flow{
+		Nodes: []Node{{ID: "a"}, {ID: "b"}},
+		Edges: []Edge{{From: "start", To: "a"}, {From: "b", To: "a"}, {From: "a", To: "b"}},
+	}
+	assert.Equal(t, []string{"a"}, f2.entryNodes())
+}
+
+func TestSuccessors(t *testing.T) {
+	f := Flow{Edges: []Edge{
+		{From: "a", To: "b"},
+		{From: "a", To: "c", Port: "true"},
+		{From: "a", To: "d", Port: "true"},
+	}}
+	assert.Equal(t, []string{"b"}, f.successors("a", ""))
+	assert.Equal(t, []string{"c", "d"}, f.successors("a", "true"))
+	assert.Nil(t, f.successors("a", "false"))
+}
+
+func TestIsEntryFrom(t *testing.T) {
+	assert.True(t, isEntryFrom(""))
+	assert.True(t, isEntryFrom("start"))
+	assert.True(t, isEntryFrom("trigger"))
+	assert.False(t, isEntryFrom("a"))
+}

--- a/internal/flow/helpers_test.go
+++ b/internal/flow/helpers_test.go
@@ -1,0 +1,75 @@
+package flow
+
+import (
+	"context"
+	"iter"
+	"sync"
+	"testing"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/llm"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+type fakeActor struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (f *fakeActor) rec(s string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, s)
+}
+
+func (f *fakeActor) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeActor) Say(c, t string) error     { f.rec("say " + c + " " + t); return nil }
+func (f *fakeActor) Notice(t, x string) error  { f.rec("notice " + t + " " + x); return nil }
+func (f *fakeActor) Kick(c, n, r string) error { f.rec("kick " + c + " " + n + " " + r); return nil }
+func (f *fakeActor) Ban(c, m string) error     { f.rec("ban " + c + " " + m); return nil }
+func (f *fakeActor) Op(c, n string) error      { f.rec("op " + c + " " + n); return nil }
+func (f *fakeActor) Voice(c, n string) error   { f.rec("voice " + c + " " + n); return nil }
+func (f *fakeActor) Topic(c, t string) error   { f.rec("topic " + c + " " + t); return nil }
+func (f *fakeActor) Invite(c, n string) error  { f.rec("invite " + c + " " + n); return nil }
+func (f *fakeActor) SetMode(c, m string, a ...string) error {
+	line := "mode " + c + " " + m
+	for _, x := range a {
+		line += " " + x
+	}
+	f.rec(line)
+	return nil
+}
+
+type fakeProvider struct {
+	mu     sync.Mutex
+	resp   string
+	err    error
+	prompt string
+}
+
+func (p *fakeProvider) Model() string { return "fake" }
+func (p *fakeProvider) Ask(_ context.Context, prompt string, _ ...llm.CallOption) (string, llm.Usage, error) {
+	p.mu.Lock()
+	p.prompt = prompt
+	p.mu.Unlock()
+	return p.resp, llm.Usage{}, p.err
+}
+func (p *fakeProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
+	return func(func(string, error) bool) {}
+}
+
+func msgEvent(channel, sender, text string) *agent.Event {
+	return &agent.Event{
+		Type:   agent.EventMessage,
+		Fields: map[string]any{"envelope": agent.NewInbound("irc", channel, sender, text)},
+	}
+}

--- a/internal/flow/nodes.go
+++ b/internal/flow/nodes.go
@@ -95,6 +95,7 @@ func init() {
 	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string", "body": "string"}, Handler: nodeWebhook})
 	Register(NodeType{Name: "setvar", Ports: []string{""}, Config: map[string]any{"key": "string", "value": "string"}, Handler: nodeSetvar})
 	Register(NodeType{Name: "getvar", Ports: []string{""}, Config: map[string]any{"key": "string", "into": "string"}, Handler: nodeGetvar})
+	Register(NodeType{Name: "incr", Ports: []string{""}, Config: map[string]any{"key": "string", "by": "string", "into": "string"}, Handler: nodeIncr})
 }
 
 // cfg reads a string config value, rendered against the bag.
@@ -267,6 +268,37 @@ func nodeGetvar(_ context.Context, n Node, nc *nodeContext) (string, error) {
 		into = "var"
 	}
 	nc.bag[into] = v
+	return "", nil
+}
+
+// nodeIncr atomically-for-this-tenant increments a persisted integer counter
+// (default step 1, or "by") and writes the new value into the bag under "into"
+// (default the key). This is the counter/score/karma primitive that a linear
+// graph can't express with set alone. Backed by the persistent Store, so the
+// tally survives restarts.
+func nodeIncr(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	if nc.store == nil {
+		return "", nil
+	}
+	key := cfg(n, "key", nc.bag)
+	if key == "" {
+		return "", nil
+	}
+	cur, _ := nc.store.Get(nc.flowName, key)
+	base, _ := strconv.Atoi(strings.TrimSpace(cur))
+	by := 1
+	if b := strings.TrimSpace(cfg(n, "by", nc.bag)); b != "" {
+		if v, err := strconv.Atoi(b); err == nil {
+			by = v
+		}
+	}
+	next := strconv.Itoa(base + by)
+	nc.store.Set(nc.flowName, key, next, 0)
+	into := cfg(n, "into", nc.bag)
+	if into == "" {
+		into = key
+	}
+	nc.bag[into] = next
 	return "", nil
 }
 

--- a/internal/flow/nodes.go
+++ b/internal/flow/nodes.go
@@ -92,7 +92,7 @@ func init() {
 	Register(NodeType{Name: "notice", Ports: []string{""}, Config: map[string]any{"target": "string", "text": "string"}, Handler: nodeNotice})
 	Register(NodeType{Name: "effect", Ports: []string{""}, Config: map[string]any{"action": "kick|ban|mute|op|voice|mode|topic", "channel": "string", "target": "string", "modes": "string", "reason": "string"}, Handler: nodeEffect})
 	Register(NodeType{Name: "llm", Ports: []string{""}, Config: map[string]any{"prompt": "string", "system": "string", "model": "string", "into": "string"}, Handler: nodeLLM})
-	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string"}, Handler: nodeWebhook})
+	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string", "body": "string"}, Handler: nodeWebhook})
 	Register(NodeType{Name: "setvar", Ports: []string{""}, Config: map[string]any{"key": "string", "value": "string"}, Handler: nodeSetvar})
 	Register(NodeType{Name: "getvar", Ports: []string{""}, Config: map[string]any{"key": "string", "into": "string"}, Handler: nodeGetvar})
 }
@@ -235,6 +235,12 @@ func nodeWebhook(ctx context.Context, n Node, nc *nodeContext) (string, error) {
 	url := cfg(n, "url", nc.bag)
 	if url == "" || nc.post == nil {
 		return "", nil
+	}
+	// Optional custom body: a template rendered against the bag (e.g. your own
+	// JSON with {user}/{channel}/… placeholders). Empty falls back to posting
+	// the whole data bag as JSON.
+	if body := strings.TrimSpace(cfg(n, "body", nc.bag)); body != "" {
+		return "", nc.post(ctx, url, []byte(body))
 	}
 	payload, err := jsonMarshal(nc.bag)
 	if err != nil {

--- a/internal/flow/nodes.go
+++ b/internal/flow/nodes.go
@@ -1,0 +1,310 @@
+package flow
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/llm"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+// Bag is the JSON-friendly data envelope threaded through a flow's nodes. It is
+// seeded from the trigger (user, channel, text, …) and mutated by nodes (set,
+// llm, getvar, …) as execution proceeds.
+type Bag map[string]any
+
+func (b Bag) str(key string) string {
+	switch v := b[key].(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+// nodeContext carries the shared dependencies and the live data bag to a node
+// handler.
+type nodeContext struct {
+	actor    agent.Actor
+	provider llm.Provider
+	store    skill.Store
+	post     PostFunc
+	flowName string
+	bag      Bag
+}
+
+// PostFunc posts a JSON payload to a URL (the webhook node's egress). Tests
+// substitute a recorder.
+type PostFunc func(ctx context.Context, url string, payload []byte) error
+
+// Handler runs one node. It mutates nc.bag and returns the output port to
+// follow next ("" for the default single output).
+type Handler func(ctx context.Context, n Node, nc *nodeContext) (port string, err error)
+
+// NodeType is a registered activity kind: a stable name, the output ports it
+// can emit (for the builder UI to render branches), a JSON-schema-ish config
+// descriptor (for the UI to render fields), and the handler.
+type NodeType struct {
+	Name    string         `json:"name"`
+	Ports   []string       `json:"ports"`
+	Config  map[string]any `json:"config"`
+	Handler Handler        `json:"-"`
+}
+
+// registry is the process-wide node catalog. It is populated by the package
+// init below and is read-only thereafter, so concurrent flow execution needs
+// no lock.
+var registry = map[string]NodeType{}
+
+// Register adds a node type to the catalog. Re-registering a name overwrites
+// it. Intended for init-time wiring (the built-in catalog) and embedders that
+// extend the catalog before any flow runs.
+func Register(nt NodeType) { registry[nt.Name] = nt }
+
+// Types returns the node catalog sorted by name, for UI introspection.
+func Types() []NodeType {
+	out := make([]NodeType, 0, len(registry))
+	for _, nt := range registry {
+		out = append(out, nt)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func lookup(name string) (NodeType, bool) {
+	nt, ok := registry[name]
+	return nt, ok
+}
+
+func init() {
+	Register(NodeType{Name: "set", Ports: []string{""}, Config: map[string]any{"fields": "map[string]string"}, Handler: nodeSet})
+	Register(NodeType{Name: "if", Ports: []string{"true", "false"}, Config: map[string]any{"left": "string", "op": "eq|ne|contains|matches|gt|lt", "right": "string"}, Handler: nodeIf})
+	Register(NodeType{Name: "switch", Ports: []string{"<case>", "default"}, Config: map[string]any{"value": "string", "cases": "[]string"}, Handler: nodeSwitch})
+	Register(NodeType{Name: "stop", Ports: nil, Config: map[string]any{}, Handler: nodeStop})
+	Register(NodeType{Name: "say", Ports: []string{""}, Config: map[string]any{"channel": "string", "text": "string"}, Handler: nodeSay})
+	Register(NodeType{Name: "notice", Ports: []string{""}, Config: map[string]any{"target": "string", "text": "string"}, Handler: nodeNotice})
+	Register(NodeType{Name: "effect", Ports: []string{""}, Config: map[string]any{"action": "kick|ban|mute|op|voice|mode|topic", "channel": "string", "target": "string", "modes": "string", "reason": "string"}, Handler: nodeEffect})
+	Register(NodeType{Name: "llm", Ports: []string{""}, Config: map[string]any{"prompt": "string", "system": "string", "model": "string", "into": "string"}, Handler: nodeLLM})
+	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string"}, Handler: nodeWebhook})
+	Register(NodeType{Name: "setvar", Ports: []string{""}, Config: map[string]any{"key": "string", "value": "string"}, Handler: nodeSetvar})
+	Register(NodeType{Name: "getvar", Ports: []string{""}, Config: map[string]any{"key": "string", "into": "string"}, Handler: nodeGetvar})
+}
+
+// cfg reads a string config value, rendered against the bag.
+func cfg(n Node, key string, bag Bag) string {
+	v, _ := n.Config[key].(string)
+	return renderBag(v, bag)
+}
+
+func rawCfg(n Node, key string) string {
+	v, _ := n.Config[key].(string)
+	return v
+}
+
+// nodeSet renders each {fields} template and writes it into the bag.
+func nodeSet(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	fields, _ := n.Config["fields"].(map[string]any)
+	for k, raw := range fields {
+		tmpl, _ := raw.(string)
+		nc.bag[k] = renderBag(tmpl, nc.bag)
+	}
+	return "", nil
+}
+
+// nodeIf evaluates a condition and routes to the true/false port.
+func nodeIf(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	if evalCond(rawCfg(n, "op"), cfg(n, "left", nc.bag), cfg(n, "right", nc.bag)) {
+		return "true", nil
+	}
+	return "false", nil
+}
+
+// nodeSwitch routes to the port named by the rendered value when it is one of
+// the listed cases, else to "default".
+func nodeSwitch(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	val := cfg(n, "value", nc.bag)
+	cases, _ := n.Config["cases"].([]any)
+	for _, c := range cases {
+		if s, _ := c.(string); s == val {
+			return val, nil
+		}
+	}
+	return "default", nil
+}
+
+// nodeStop ends this branch (no outgoing ports).
+func nodeStop(context.Context, Node, *nodeContext) (string, error) { return "\x00stop", nil }
+
+func nodeSay(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	if nc.actor == nil {
+		return "", nil
+	}
+	channel := cfg(n, "channel", nc.bag)
+	if channel == "" {
+		channel = nc.bag.str("channel")
+	}
+	text := cfg(n, "text", nc.bag)
+	if channel == "" || text == "" {
+		return "", nil
+	}
+	return "", nc.actor.Say(channel, text)
+}
+
+func nodeNotice(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	if nc.actor == nil {
+		return "", nil
+	}
+	target := cfg(n, "target", nc.bag)
+	if target == "" {
+		target = nc.bag.str("channel")
+	}
+	text := cfg(n, "text", nc.bag)
+	if target == "" || text == "" {
+		return "", nil
+	}
+	return "", nc.actor.Notice(target, text)
+}
+
+func nodeEffect(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	if nc.actor == nil {
+		return "", nil
+	}
+	channel := cfg(n, "channel", nc.bag)
+	if channel == "" {
+		channel = nc.bag.str("channel")
+	}
+	target := cfg(n, "target", nc.bag)
+	if target == "" {
+		target = nc.bag.str("user")
+	}
+	if channel == "" {
+		return "", nil
+	}
+	reason := cfg(n, "reason", nc.bag)
+	switch skill.EffectAction(rawCfg(n, "action")) {
+	case skill.EffectKick:
+		return "", nc.actor.Kick(channel, target, reason)
+	case skill.EffectBan:
+		return "", nc.actor.Ban(channel, target)
+	case skill.EffectMute:
+		return "", nc.actor.SetMode(channel, "+q", target)
+	case skill.EffectOp:
+		return "", nc.actor.Op(channel, target)
+	case skill.EffectVoice:
+		return "", nc.actor.Voice(channel, target)
+	case skill.EffectMode:
+		return "", nc.actor.SetMode(channel, cfg(n, "modes", nc.bag))
+	case skill.EffectTopic:
+		return "", nc.actor.Topic(channel, cfg(n, "reason", nc.bag))
+	default:
+		return "", nil
+	}
+}
+
+func nodeLLM(ctx context.Context, n Node, nc *nodeContext) (string, error) {
+	if nc.provider == nil {
+		return "", nil
+	}
+	opts := []llm.CallOption{llm.WithMaxTokens(512)}
+	if sys := cfg(n, "system", nc.bag); sys != "" {
+		opts = append(opts, llm.WithSystem(sys))
+	}
+	if model := rawCfg(n, "model"); model != "" {
+		opts = append(opts, llm.WithModel(model))
+	}
+	answer, _, err := nc.provider.Ask(ctx, cfg(n, "prompt", nc.bag), opts...)
+	if err != nil {
+		return "", err
+	}
+	into := rawCfg(n, "into")
+	if into == "" {
+		into = "llm"
+	}
+	nc.bag[into] = strings.Join(strings.Fields(answer), " ")
+	return "", nil
+}
+
+func nodeWebhook(ctx context.Context, n Node, nc *nodeContext) (string, error) {
+	url := cfg(n, "url", nc.bag)
+	if url == "" || nc.post == nil {
+		return "", nil
+	}
+	payload, err := jsonMarshal(nc.bag)
+	if err != nil {
+		return "", err
+	}
+	return "", nc.post(ctx, url, payload)
+}
+
+func nodeSetvar(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	if nc.store == nil {
+		return "", nil
+	}
+	nc.store.Set(nc.flowName, cfg(n, "key", nc.bag), cfg(n, "value", nc.bag), 0)
+	return "", nil
+}
+
+func nodeGetvar(_ context.Context, n Node, nc *nodeContext) (string, error) {
+	if nc.store == nil {
+		return "", nil
+	}
+	v, _ := nc.store.Get(nc.flowName, cfg(n, "key", nc.bag))
+	into := rawCfg(n, "into")
+	if into == "" {
+		into = "var"
+	}
+	nc.bag[into] = v
+	return "", nil
+}
+
+// evalCond compares two rendered operands by op. Unknown ops are false.
+func evalCond(op, left, right string) bool {
+	switch op {
+	case "eq":
+		return left == right
+	case "ne":
+		return left != right
+	case "contains":
+		return strings.Contains(left, right)
+	case "matches":
+		re, err := regexp.Compile(right)
+		return err == nil && re.MatchString(left)
+	case "gt", "lt":
+		l, e1 := strconv.ParseFloat(strings.TrimSpace(left), 64)
+		r, e2 := strconv.ParseFloat(strings.TrimSpace(right), 64)
+		if e1 != nil || e2 != nil {
+			return false
+		}
+		if op == "gt" {
+			return l > r
+		}
+		return l < r
+	default:
+		return false
+	}
+}
+
+// bagToken matches a {key} placeholder.
+var bagToken = regexp.MustCompile(`\{([a-zA-Z0-9_]+)\}`)
+
+// renderBag substitutes {key} placeholders with the bag's stringified values.
+// An unknown key renders empty.
+func renderBag(tmpl string, bag Bag) string {
+	if tmpl == "" || !strings.ContainsRune(tmpl, '{') {
+		return tmpl
+	}
+	return bagToken.ReplaceAllStringFunc(tmpl, func(m string) string {
+		key := bagToken.FindStringSubmatch(m)[1]
+		if _, ok := bag[key]; !ok {
+			return ""
+		}
+		return bag.str(key)
+	})
+}

--- a/internal/flow/nodes.go
+++ b/internal/flow/nodes.go
@@ -40,9 +40,9 @@ type nodeContext struct {
 	bag      Bag
 }
 
-// PostFunc posts a JSON payload to a URL (the webhook node's egress). Tests
-// substitute a recorder.
-type PostFunc func(ctx context.Context, url string, payload []byte) error
+// PostFunc sends a JSON payload to a URL with the given HTTP method (the
+// webhook node's egress). Tests substitute a recorder.
+type PostFunc func(ctx context.Context, method, url string, payload []byte) error
 
 // Handler runs one node. It mutates nc.bag and returns the output port to
 // follow next ("" for the default single output).
@@ -92,7 +92,7 @@ func init() {
 	Register(NodeType{Name: "notice", Ports: []string{""}, Config: map[string]any{"target": "string", "text": "string"}, Handler: nodeNotice})
 	Register(NodeType{Name: "effect", Ports: []string{""}, Config: map[string]any{"action": "kick|ban|mute|op|voice|mode|topic", "channel": "string", "target": "string", "modes": "string", "reason": "string"}, Handler: nodeEffect})
 	Register(NodeType{Name: "llm", Ports: []string{""}, Config: map[string]any{"prompt": "string", "system": "string", "model": "string", "into": "string"}, Handler: nodeLLM})
-	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string", "body": "string"}, Handler: nodeWebhook})
+	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string", "method": "GET|POST|PUT|PATCH|DELETE", "body": "string"}, Handler: nodeWebhook})
 	Register(NodeType{Name: "setvar", Ports: []string{""}, Config: map[string]any{"key": "string", "value": "string"}, Handler: nodeSetvar})
 	Register(NodeType{Name: "getvar", Ports: []string{""}, Config: map[string]any{"key": "string", "into": "string"}, Handler: nodeGetvar})
 	Register(NodeType{Name: "incr", Ports: []string{""}, Config: map[string]any{"key": "string", "by": "string", "into": "string"}, Handler: nodeIncr})
@@ -237,17 +237,36 @@ func nodeWebhook(ctx context.Context, n Node, nc *nodeContext) (string, error) {
 	if url == "" || nc.post == nil {
 		return "", nil
 	}
+	method := webhookMethod(cfg(n, "method", nc.bag))
 	// Optional custom body: a template rendered against the bag (e.g. your own
 	// JSON with {user}/{channel}/… placeholders). Empty falls back to posting
 	// the whole data bag as JSON.
 	if body := strings.TrimSpace(cfg(n, "body", nc.bag)); body != "" {
-		return "", nc.post(ctx, url, []byte(body))
+		return "", nc.post(ctx, method, url, []byte(body))
 	}
 	payload, err := jsonMarshal(nc.bag)
 	if err != nil {
 		return "", err
 	}
-	return "", nc.post(ctx, url, payload)
+	return "", nc.post(ctx, method, url, payload)
+}
+
+// webhookMethod normalizes a configured HTTP method to upper case and
+// validates it against the supported verbs, defaulting to POST for an empty or
+// unrecognized value.
+func webhookMethod(m string) string {
+	switch strings.ToUpper(strings.TrimSpace(m)) {
+	case "GET":
+		return "GET"
+	case "PUT":
+		return "PUT"
+	case "PATCH":
+		return "PATCH"
+	case "DELETE":
+		return "DELETE"
+	default:
+		return "POST"
+	}
 }
 
 func nodeSetvar(_ context.Context, n Node, nc *nodeContext) (string, error) {

--- a/internal/flow/nodes_test.go
+++ b/internal/flow/nodes_test.go
@@ -15,7 +15,7 @@ func TestTypesCatalogSortedAndComplete(t *testing.T) {
 	for i, nt := range types {
 		names[i] = nt.Name
 	}
-	for _, want := range []string{"set", "if", "switch", "stop", "say", "notice", "effect", "llm", "webhook", "setvar", "getvar"} {
+	for _, want := range []string{"set", "if", "switch", "stop", "say", "notice", "effect", "llm", "webhook", "setvar", "getvar", "incr"} {
 		assert.Contains(t, names, want)
 	}
 	// Sorted by name.
@@ -159,6 +159,18 @@ func TestNodeWebhookAndVars(t *testing.T) {
 	// Default into key for getvar + empty url / nil store no-ops.
 	_, _ = nodeGetvar(context.Background(), Node{Config: map[string]any{"key": "motd"}}, nc)
 	assert.Equal(t, "hello alice", nc.bag["var"])
+
+	// incr persists a monotonic counter (default step 1, or "by") and writes the
+	// new value into the bag; the key template renders against the bag.
+	_, _ = nodeIncr(context.Background(), Node{Config: map[string]any{"key": "score-{user}", "into": "s"}}, nc)
+	assert.Equal(t, "1", nc.bag["s"])
+	_, _ = nodeIncr(context.Background(), Node{Config: map[string]any{"key": "score-{user}", "by": "5", "into": "s"}}, nc)
+	assert.Equal(t, "6", nc.bag["s"])
+	// Default into = the key; empty key and nil store are no-ops.
+	_, _ = nodeIncr(context.Background(), Node{Config: map[string]any{"key": "n"}}, nc)
+	assert.Equal(t, "1", nc.bag["n"])
+	_, _ = nodeIncr(context.Background(), Node{Config: map[string]any{}}, nc)
+	_, _ = nodeIncr(context.Background(), Node{Config: map[string]any{"key": "x"}}, &nodeContext{})
 
 	_, err = nodeWebhook(context.Background(), Node{Config: map[string]any{"url": ""}}, nc)
 	require.NoError(t, err)

--- a/internal/flow/nodes_test.go
+++ b/internal/flow/nodes_test.go
@@ -145,6 +145,12 @@ func TestNodeWebhookAndVars(t *testing.T) {
 	assert.Equal(t, "https://h/#r", gotURL)
 	assert.Contains(t, string(gotBody), `"user":"alice"`)
 
+	// A custom body template renders against the bag and is posted verbatim
+	// (instead of the whole bag dump).
+	_, err = nodeWebhook(context.Background(), Node{Config: map[string]any{"url": "https://h", "body": `{"msg":"{user} in {channel}"}`}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, `{"msg":"alice in #r"}`, string(gotBody))
+
 	// setvar then getvar round-trips through the store.
 	_, _ = nodeSetvar(context.Background(), Node{Config: map[string]any{"key": "motd", "value": "hello {user}"}}, nc)
 	_, _ = nodeGetvar(context.Background(), Node{Config: map[string]any{"key": "motd", "into": "m"}}, nc)

--- a/internal/flow/nodes_test.go
+++ b/internal/flow/nodes_test.go
@@ -129,21 +129,31 @@ func TestNodeLLM(t *testing.T) {
 }
 
 func TestNodeWebhookAndVars(t *testing.T) {
-	var gotURL string
+	var gotMethod, gotURL string
 	var gotBody []byte
 	nc := &nodeContext{
 		bag:      Bag{"user": "alice", "channel": "#r"},
 		store:    skill.NewMemoryStore(),
 		flowName: "f1",
-		post: func(_ context.Context, url string, body []byte) error {
-			gotURL, gotBody = url, body
+		post: func(_ context.Context, method, url string, body []byte) error {
+			gotMethod, gotURL, gotBody = method, url, body
 			return nil
 		},
 	}
 	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{"url": "https://h/{channel}"}}, nc)
 	require.NoError(t, err)
 	assert.Equal(t, "https://h/#r", gotURL)
+	assert.Equal(t, "POST", gotMethod, "default method is POST")
 	assert.Contains(t, string(gotBody), `"user":"alice"`)
+
+	// An explicit method is upper-cased and passed through; unknown verbs fall
+	// back to POST.
+	_, err = nodeWebhook(context.Background(), Node{Config: map[string]any{"url": "https://h", "method": "delete"}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, "DELETE", gotMethod)
+	_, err = nodeWebhook(context.Background(), Node{Config: map[string]any{"url": "https://h", "method": "bogus"}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, "POST", gotMethod, "unknown method falls back to POST")
 
 	// A custom body template renders against the bag and is posted verbatim
 	// (instead of the whole bag dump).

--- a/internal/flow/nodes_test.go
+++ b/internal/flow/nodes_test.go
@@ -1,0 +1,176 @@
+package flow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+func TestTypesCatalogSortedAndComplete(t *testing.T) {
+	types := Types()
+	names := make([]string, len(types))
+	for i, nt := range types {
+		names[i] = nt.Name
+	}
+	for _, want := range []string{"set", "if", "switch", "stop", "say", "notice", "effect", "llm", "webhook", "setvar", "getvar"} {
+		assert.Contains(t, names, want)
+	}
+	// Sorted by name.
+	for i := 1; i < len(names); i++ {
+		assert.LessOrEqual(t, names[i-1], names[i])
+	}
+}
+
+func TestRenderBag(t *testing.T) {
+	bag := Bag{"user": "alice", "count": 3}
+	assert.Equal(t, "hi alice (3)", renderBag("hi {user} ({count})", bag))
+	assert.Equal(t, "plain", renderBag("plain", bag))
+	assert.Equal(t, "", renderBag("{missing}", bag), "unknown key renders empty")
+}
+
+func TestEvalCond(t *testing.T) {
+	assert.True(t, evalCond("eq", "a", "a"))
+	assert.True(t, evalCond("ne", "a", "b"))
+	assert.True(t, evalCond("contains", "hello world", "wor"))
+	assert.True(t, evalCond("matches", "abc123", `\d+`))
+	assert.False(t, evalCond("matches", "x", `[`)) // bad regex
+	assert.True(t, evalCond("gt", "5", "3"))
+	assert.True(t, evalCond("lt", "2", "9"))
+	assert.False(t, evalCond("gt", "x", "3")) // non-numeric
+	assert.False(t, evalCond("bogus", "a", "a"))
+}
+
+func TestNodeSetIfSwitchStop(t *testing.T) {
+	nc := &nodeContext{bag: Bag{"user": "alice"}}
+
+	port, err := nodeSet(context.Background(), Node{Config: map[string]any{"fields": map[string]any{"greeting": "hi {user}"}}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, "", port)
+	assert.Equal(t, "hi alice", nc.bag["greeting"])
+
+	port, _ = nodeIf(context.Background(), Node{Config: map[string]any{"left": "{user}", "op": "eq", "right": "alice"}}, nc)
+	assert.Equal(t, "true", port)
+	port, _ = nodeIf(context.Background(), Node{Config: map[string]any{"left": "{user}", "op": "eq", "right": "bob"}}, nc)
+	assert.Equal(t, "false", port)
+
+	nc.bag["color"] = "red"
+	port, _ = nodeSwitch(context.Background(), Node{Config: map[string]any{"value": "{color}", "cases": []any{"red", "green"}}}, nc)
+	assert.Equal(t, "red", port)
+	port, _ = nodeSwitch(context.Background(), Node{Config: map[string]any{"value": "{color}", "cases": []any{"green"}}}, nc)
+	assert.Equal(t, "default", port)
+
+	port, _ = nodeStop(context.Background(), Node{}, nc)
+	assert.Equal(t, "\x00stop", port)
+}
+
+func TestNodeActorHandlers(t *testing.T) {
+	act := &fakeActor{}
+	nc := &nodeContext{actor: act, bag: Bag{"channel": "#r", "user": "bob"}}
+
+	_, _ = nodeSay(context.Background(), Node{Config: map[string]any{"text": "hello {user}"}}, nc)
+	_, _ = nodeNotice(context.Background(), Node{Config: map[string]any{"text": "psst"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "kick", "reason": "bye"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "ban"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "mute"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "op"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "voice"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "mode", "modes": "+m"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "topic", "reason": "new"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "bogus"}}, nc)
+
+	calls := act.snapshot()
+	assert.Equal(t, []string{
+		"say #r hello bob",
+		"notice #r psst",
+		"kick #r bob bye",
+		"ban #r bob",
+		"mode #r +q bob",
+		"op #r bob",
+		"voice #r bob",
+		"mode #r +m",
+		"topic #r new",
+	}, calls)
+}
+
+func TestNodeActorNilAndEmpty(t *testing.T) {
+	// Nil actor → no-ops.
+	nc := &nodeContext{bag: Bag{"channel": "#r"}}
+	_, _ = nodeSay(context.Background(), Node{Config: map[string]any{"text": "x"}}, nc)
+	_, _ = nodeNotice(context.Background(), Node{Config: map[string]any{"text": "x"}}, nc)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "kick"}}, nc)
+
+	// Actor present but empty channel/text → no call.
+	act := &fakeActor{}
+	nc2 := &nodeContext{actor: act, bag: Bag{}}
+	_, _ = nodeSay(context.Background(), Node{Config: map[string]any{"text": ""}}, nc2)
+	_, _ = nodeEffect(context.Background(), Node{Config: map[string]any{"action": "kick"}}, nc2)
+	assert.Empty(t, act.snapshot())
+}
+
+func TestNodeLLM(t *testing.T) {
+	prov := &fakeProvider{resp: "tidy   answer\n"}
+	nc := &nodeContext{provider: prov, bag: Bag{"text": "q"}}
+	_, err := nodeLLM(context.Background(), Node{Config: map[string]any{"prompt": "answer {text}", "system": "be terse", "model": "m", "into": "result"}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, "tidy answer", nc.bag["result"])
+	assert.Equal(t, "answer q", prov.prompt)
+
+	// Default "into" key + nil provider.
+	nc2 := &nodeContext{provider: &fakeProvider{resp: "ok"}, bag: Bag{}}
+	_, _ = nodeLLM(context.Background(), Node{Config: map[string]any{"prompt": "x"}}, nc2)
+	assert.Equal(t, "ok", nc2.bag["llm"])
+
+	nc3 := &nodeContext{bag: Bag{}}
+	_, err = nodeLLM(context.Background(), Node{Config: map[string]any{"prompt": "x"}}, nc3)
+	require.NoError(t, err)
+}
+
+func TestNodeWebhookAndVars(t *testing.T) {
+	var gotURL string
+	var gotBody []byte
+	nc := &nodeContext{
+		bag:      Bag{"user": "alice", "channel": "#r"},
+		store:    skill.NewMemoryStore(),
+		flowName: "f1",
+		post: func(_ context.Context, url string, body []byte) error {
+			gotURL, gotBody = url, body
+			return nil
+		},
+	}
+	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{"url": "https://h/{channel}"}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, "https://h/#r", gotURL)
+	assert.Contains(t, string(gotBody), `"user":"alice"`)
+
+	// setvar then getvar round-trips through the store.
+	_, _ = nodeSetvar(context.Background(), Node{Config: map[string]any{"key": "motd", "value": "hello {user}"}}, nc)
+	_, _ = nodeGetvar(context.Background(), Node{Config: map[string]any{"key": "motd", "into": "m"}}, nc)
+	assert.Equal(t, "hello alice", nc.bag["m"])
+
+	// Default into key for getvar + empty url / nil store no-ops.
+	_, _ = nodeGetvar(context.Background(), Node{Config: map[string]any{"key": "motd"}}, nc)
+	assert.Equal(t, "hello alice", nc.bag["var"])
+
+	_, err = nodeWebhook(context.Background(), Node{Config: map[string]any{"url": ""}}, nc)
+	require.NoError(t, err)
+	nc4 := &nodeContext{bag: Bag{}}
+	_, _ = nodeSetvar(context.Background(), Node{Config: map[string]any{"key": "k"}}, nc4)
+	_, _ = nodeGetvar(context.Background(), Node{Config: map[string]any{"key": "k"}}, nc4)
+}
+
+func TestBagStr(t *testing.T) {
+	b := Bag{"s": "x", "n": 5}
+	assert.Equal(t, "x", b.str("s"))
+	assert.Equal(t, "5", b.str("n"))
+	assert.Equal(t, "", b.str("missing"))
+}
+
+func TestRegisterCustomNode(t *testing.T) {
+	Register(NodeType{Name: "test-custom", Ports: []string{""}, Handler: func(context.Context, Node, *nodeContext) (string, error) { return "", nil }})
+	_, ok := lookup("test-custom")
+	assert.True(t, ok)
+	delete(registry, "test-custom")
+}

--- a/internal/flow/nodes_test.go
+++ b/internal/flow/nodes_test.go
@@ -24,6 +24,15 @@ func TestTypesCatalogSortedAndComplete(t *testing.T) {
 	}
 }
 
+func TestWebhookMethod(t *testing.T) {
+	for in, want := range map[string]string{
+		"get": "GET", "GET": "GET", " put ": "PUT", "patch": "PATCH",
+		"delete": "DELETE", "post": "POST", "": "POST", "weird": "POST",
+	} {
+		assert.Equal(t, want, webhookMethod(in), "webhookMethod(%q)", in)
+	}
+}
+
 func TestRenderBag(t *testing.T) {
 	bag := Bag{"user": "alice", "count": 3}
 	assert.Equal(t, "hi alice (3)", renderBag("hi {user} ({count})", bag))

--- a/internal/flow/webhook_test.go
+++ b/internal/flow/webhook_test.go
@@ -1,0 +1,68 @@
+package flow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+// webhookFlow: a webhook-triggered flow that says the posted text to a channel.
+func webhookFlow(name string, channels ...string) Flow {
+	return Flow{
+		Name:    name,
+		Trigger: skill.Trigger{Kind: skill.KindWebhook, Channels: channels},
+		Nodes:   []Node{{ID: "s", Type: "say", Config: map[string]any{"channel": "{channel}", "text": "{text} from {user}"}}},
+	}
+}
+
+func TestFlowFireWebhookDispatch(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{webhookFlow("deploy")})
+
+	ok := e.FireWebhook("deploy", map[string]string{"channel": "#ops", "text": "ship", "user": "ci"})
+	assert.True(t, ok)
+	assert.Equal(t, []string{"say #ops ship from ci"}, act.snapshot())
+}
+
+func TestFlowFireWebhookCaseInsensitive(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{webhookFlow("Deploy")})
+
+	assert.True(t, e.FireWebhook("dEpLoY", map[string]string{"channel": "#c", "text": "x", "user": "u"}))
+	assert.Equal(t, []string{"say #c x from u"}, act.snapshot())
+}
+
+func TestFlowFireWebhookUnknownName(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceFlows([]Flow{webhookFlow("deploy")})
+
+	assert.False(t, e.FireWebhook("ghost", map[string]string{"channel": "#c", "text": "x"}))
+	assert.Empty(t, act.snapshot(), "no match must fire nothing")
+}
+
+func TestFlowFireWebhookTriggerChannelWins(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	// Trigger scopes the flow to #locked; a body-supplied channel must not override it.
+	e.ReplaceFlows([]Flow{webhookFlow("deploy", "#locked")})
+
+	assert.True(t, e.FireWebhook("deploy", map[string]string{"channel": "#attacker", "text": "x", "user": "u"}))
+	assert.Equal(t, []string{"say #locked x from u"}, act.snapshot())
+}
+
+func TestFlowFireWebhookNotIndexedForOtherKinds(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	// A match-trigger flow named "deploy" must not be reachable via the webhook index.
+	e.ReplaceFlows([]Flow{{
+		Name:    "deploy",
+		Trigger: skill.Trigger{Kind: skill.KindMatch, Match: "hi"},
+		Nodes:   []Node{{ID: "s", Type: "say", Config: map[string]any{"channel": "#c", "text": "x"}}},
+	}})
+	assert.False(t, e.FireWebhook("deploy", map[string]string{"text": "x"}))
+	assert.Empty(t, act.snapshot())
+}

--- a/internal/flowrefresh/refresh.go
+++ b/internal/flowrefresh/refresh.go
@@ -1,0 +1,145 @@
+// Package flowrefresh keeps a single single-instance agent's declarative
+// node-graph flow set current while it runs, without a reconnect.
+//
+// A single-instance agent boots with the flow set baked into TURBORG_FLOWS.
+// That set is fixed for the life of the process unless something tells the
+// running agent to reload it. This package polls an endpoint for the tenant's
+// current flow set and, when it changes, applies it in place via a
+// caller-supplied callback (which swaps the flow engine's set via
+// ReplaceFlows). It is the single-instance-runtime mirror of what the pooled
+// runtime already does from its tenant feed, so the two share identical
+// hot-reload semantics (an atomic in-place swap — no IRC reconnect).
+//
+// Wire contract the operator must serve at the configured URL:
+//
+//	GET <url>
+//	  Authorization: Bearer <token>
+//	  Status: 200 on success.
+//	  Body: a JSON array of flow definitions, the same wire shape as
+//	        TURBORG_FLOWS / the pooled tenant feed's `flows`:
+//	        [{"name","trigger","nodes","edges"}, ...]
+//
+// Failures are non-fatal: the last applied set stays in force and the loop
+// retries on the next tick.
+package flowrefresh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/turborg/turborg/internal/flow"
+)
+
+const (
+	defaultInterval = 15 * time.Second
+	minInterval     = 2 * time.Second
+	requestTimeout  = 10 * time.Second
+)
+
+// Apply installs a new flow set on the live agent. The runtime supplies a
+// closure that swaps the flow engine's set via flow.Engine.ReplaceFlows.
+type Apply func(flows []flow.Flow)
+
+// Refresher periodically pulls the tenant's flow set and applies changes.
+type Refresher struct {
+	endpoint string
+	token    string
+	interval time.Duration
+	apply    Apply
+	client   *http.Client
+	log      *slog.Logger
+
+	last     []flow.Flow
+	haveLast bool
+}
+
+// New returns nil when refresh is not configured (no endpoint/token or no
+// apply callback) — so the caller can plug the result into an optional field
+// and gate the feature with a single non-nil check. intervalSeconds <= 0 uses
+// the default; values below the floor are clamped up.
+func New(endpoint, token string, intervalSeconds int, apply Apply, log *slog.Logger) *Refresher {
+	if endpoint == "" || token == "" || apply == nil {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	interval := time.Duration(intervalSeconds) * time.Second
+	switch {
+	case intervalSeconds <= 0:
+		interval = defaultInterval
+	case interval < minInterval:
+		interval = minInterval
+	}
+	return &Refresher{
+		endpoint: endpoint,
+		token:    token,
+		interval: interval,
+		apply:    apply,
+		client:   &http.Client{Timeout: requestTimeout},
+		log:      log.With("component", "flow-refresh"),
+	}
+}
+
+// Run reloads once immediately, then on every interval tick, until ctx is
+// cancelled. Always returns nil (cancellation is the normal exit); the error
+// return exists for symmetry with the other runnables the runtime supervises.
+func (r *Refresher) Run(ctx context.Context) error {
+	r.refreshOnce(ctx)
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			r.refreshOnce(ctx)
+		}
+	}
+}
+
+func (r *Refresher) refreshOnce(ctx context.Context) {
+	defs, err := r.fetch(ctx)
+	if err != nil {
+		// Keep the last applied set; a brief stale flow set is safe.
+		r.log.Debug("flow refresh failed; keeping last set", "err", err)
+		return
+	}
+	// Skip the swap when nothing changed, mirroring the pooled runtime's
+	// gate so an unchanged poll is a no-op.
+	if r.haveLast && reflect.DeepEqual(r.last, defs) {
+		return
+	}
+	r.apply(defs)
+	r.last = defs
+	r.haveLast = true
+	r.log.Info("flows reloaded in place", "flows", len(defs))
+}
+
+func (r *Refresher) fetch(ctx context.Context) ([]flow.Flow, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+r.token)
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var defs []flow.Flow
+	if err := json.NewDecoder(resp.Body).Decode(&defs); err != nil {
+		return nil, fmt.Errorf("decode body: %w", err)
+	}
+	return defs, nil
+}

--- a/internal/flowrefresh/refresh_test.go
+++ b/internal/flowrefresh/refresh_test.go
@@ -1,0 +1,154 @@
+package flowrefresh
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/turborg/turborg/internal/flow"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+type spyApply struct {
+	mu    sync.Mutex
+	calls int
+	last  []flow.Flow
+}
+
+func (s *spyApply) apply(flows []flow.Flow) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.last = flows
+}
+
+func (s *spyApply) snapshot() (int, []flow.Flow) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls, s.last
+}
+
+func TestNewReturnsNilWhenUnconfigured(t *testing.T) {
+	s := &spyApply{}
+	assert.Nil(t, New("", "tok", 0, s.apply, nil), "no endpoint → nil")
+	assert.Nil(t, New("http://x", "", 0, s.apply, nil), "no token → nil")
+	assert.Nil(t, New("http://x", "tok", 0, nil, nil), "no apply → nil")
+	assert.NotNil(t, New("http://x", "tok", 0, s.apply, nil))
+}
+
+func TestRefreshAppliesFlowsAndSendsAuth(t *testing.T) {
+	var gotAuth atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`[{"name":"greet","trigger":{"kind":"match","match":"(?i)^hi"},"nodes":[{"id":"s","type":"say","config":{"text":"hi"}}],"edges":[{"from":"start","to":"s"}]}]`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "secret-tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	calls, last := s.snapshot()
+	assert.Equal(t, 1, calls)
+	require.Len(t, last, 1)
+	assert.Equal(t, "greet", last[0].Name)
+	require.Len(t, last[0].Nodes, 1)
+	assert.Equal(t, "say", last[0].Nodes[0].Type)
+	assert.Equal(t, "Bearer secret-tok", gotAuth.Load())
+}
+
+func TestRefreshSkipsApplyWhenUnchanged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"greet","trigger":{"kind":"command"},"nodes":[{"id":"s","type":"say","config":{"text":"hi"}}],"edges":[]}]`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+	r.refreshOnce(context.Background()) // identical response → no second apply
+
+	calls, _ := s.snapshot()
+	assert.Equal(t, 1, calls, "an unchanged flow set must not trigger a second swap")
+}
+
+func TestRefreshKeepsLastSetOnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	calls, _ := s.snapshot()
+	assert.Equal(t, 0, calls, "a non-200 must not apply a flow set")
+}
+
+func TestRefreshKeepsLastSetOnMalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 1, s.apply, nil)
+	require.NotNil(t, r)
+
+	r.refreshOnce(context.Background())
+
+	calls, _ := s.snapshot()
+	assert.Equal(t, 0, calls, "a body that fails to decode must not apply a flow set")
+}
+
+func TestRunRefreshesImmediatelyAndStopsOnCancel(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	s := &spyApply{}
+	r := New(srv.URL, "tok", 0, s.apply, nil)
+	require.NotNil(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Run(ctx) }()
+
+	require.Eventually(t, func() bool { return hits.Load() >= 1 }, time.Second, 10*time.Millisecond,
+		"Run must refresh once immediately")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestNewClampsSubFloorInterval(t *testing.T) {
+	r := New("http://x", "tok", 1, (&spyApply{}).apply, nil) // 1s < floor
+	require.NotNil(t, r)
+	assert.Equal(t, minInterval, r.interval)
+}

--- a/internal/runtime/flows_test.go
+++ b/internal/runtime/flows_test.go
@@ -1,0 +1,50 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+func TestParseFlows(t *testing.T) {
+	none, err := parseFlows("")
+	require.NoError(t, err)
+	assert.Nil(t, none)
+
+	flows, err := parseFlows(`[{"name":"f","trigger":{"kind":"event","event":"USER_JOIN"},"nodes":[{"id":"s","type":"say","config":{"text":"hi {user}"}}]}]`)
+	require.NoError(t, err)
+	require.Len(t, flows, 1)
+	assert.Equal(t, "f", flows[0].Name)
+	assert.Equal(t, "say", flows[0].Nodes[0].Type)
+
+	_, err = parseFlows("not json")
+	require.Error(t, err)
+}
+
+// TestWireCommonRunsFlows proves a flow installed via WireCommon fires on a
+// matching event through the live engine.
+func TestWireCommonRunsFlows(t *testing.T) {
+	a := agent.NewWithPrefix(nil, "!")
+	cfg := &irc.Settings{Hostname: "irc.example", Nick: "bot"}
+	cfg.ApplyDefaults()
+	conn := irc.New(cfg, nil, a.Events)
+
+	flows, err := parseFlows(`[{"name":"welcome","trigger":{"kind":"event","event":"USER_JOIN"},"nodes":[{"id":"s","type":"say","config":{"text":"welcome {user}"}}]}]`)
+	require.NoError(t, err)
+
+	wiring, err := WireCommon(a, conn, CommonParams{CustomCommandsMax: -1, Flows: flows}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, wiring.Flows)
+
+	// Not connected, so the actor's SendRaw errors — but the flow must still be
+	// dispatched (no panic, engine walks the graph). A nil-actor path is covered
+	// in the flow package; here we assert the wiring publishes to the engine.
+	a.Events.Publish(context.Background(), &agent.Event{
+		Type:   agent.EventUserJoin,
+		Fields: map[string]any{"channel": "#room", "nick": "newbie"},
+	})
+}

--- a/internal/runtime/messages_test.go
+++ b/internal/runtime/messages_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/config"
 	"github.com/turborg/turborg/internal/messages"
+	"github.com/turborg/turborg/internal/skill"
 )
 
 // White-box tests for the helpers in runtime.go. The full Build flow
@@ -176,4 +177,17 @@ func TestMakeStoreSubmitterOutboundSkipsWhenBotNickEmpty(t *testing.T) {
 	})
 	assert.Equal(t, 0, store.Len("#x"),
 		"empty bot nick → row would 422; must skip rather than write a half-formed entry")
+}
+
+func TestBuildSkillStoreNilWhenUnconfigured(t *testing.T) {
+	s := &config.Settings{} // No STATE_URL configured.
+	assert.Nil(t, buildSkillStore(s, nil), "no state URL → nil (engines default to in-process)")
+}
+
+func TestBuildSkillStoreHTTPWhenConfigured(t *testing.T) {
+	s := &config.Settings{StateURL: "https://state.example/agent", StateToken: "t"}
+	got := buildSkillStore(s, nil)
+	require.NotNil(t, got)
+	_, isHTTP := got.(*skill.HTTPStore)
+	assert.True(t, isHTTP, "with STATE_URL + token set → HTTPStore")
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -25,13 +25,13 @@ import (
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/budgetrefresh"
 	"github.com/turborg/turborg/internal/commandrefresh"
-	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/config"
 	"github.com/turborg/turborg/internal/configrefresh"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/messages"
 	"github.com/turborg/turborg/internal/messagesink"
+	"github.com/turborg/turborg/internal/skill"
 	"github.com/turborg/turborg/internal/statepush"
 	"github.com/turborg/turborg/internal/web"
 )
@@ -58,6 +58,10 @@ type Built struct {
 	// agent runs (the single-instance mirror of the pooled feed-driven reload). Nil
 	// when COMMANDS_URL is unset (self-host: the boot set is fixed).
 	CommandRefresh *commandrefresh.Refresher
+	// Scheduler drives schedule-trigger skills on their cadence. Supervised by
+	// Run alongside the background refreshers. Never nil (idle when no schedule
+	// skills are installed).
+	Scheduler *skill.Scheduler
 }
 
 // Build wires the agent + connectors + gateway from settings. Callers
@@ -142,7 +146,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	// The connector-agnostic, transport-independent wiring — builtins, owner
 	// guard, throttles, nudge, store submitters. The pooled runtime calls this
 	// same WireCommon from its tenant builder, so the two modes can't drift.
-	if err := WireCommon(a, ircConn, CommonParams{
+	wiring, err := WireCommon(a, ircConn, CommonParams{
 		CustomCommandsMax: s.CustomCommandsMax,
 		Commands:          cmds,
 		Platform:          ircCfg.Hostname,
@@ -169,7 +173,8 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		LLMOutputUsed:             s.LLMOutputTokensUsed,
 		ActivityHook:              activityHook,
 		Store:                     store,
-	}, log); err != nil {
+	}, log)
+	if err != nil {
 		return nil, err
 	}
 
@@ -190,6 +195,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		LLM:       provider,
 		Activity:  notifier,
 		StatePush: stateEmitter,
+		Scheduler: wiring.Scheduler,
 	}
 
 	// Live budget refresh: when the provider is budgeted and a refresh endpoint
@@ -216,7 +222,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		s.CommandsURL,
 		s.CommandsToken,
 		s.CommandsRefreshSeconds,
-		func(defs []commands.Definition) { ApplyCommands(a, defs, provider, owner, ircCfg.Hostname, log) },
+		func(skills []skill.Skill) { ApplySkills(a, wiring, skills, provider, owner, ircCfg.Hostname, log) },
 		log,
 	)
 
@@ -301,18 +307,20 @@ func buildLLM(s *config.Settings) (llm.Provider, error) {
 	return NewAnthropicProvider(s.AnthropicAPIKey, s.AnthropicModel)
 }
 
-// parseCommands decodes the TURBORG_COMMANDS JSON array into command
-// definitions. Empty input is not an error — it just means no commands.
-func parseCommands(raw string) ([]commands.Definition, error) {
+// parseCommands decodes the TURBORG_COMMANDS JSON array into skill
+// definitions. The flat wire is backward-compatible: a legacy command array
+// decodes to command-kind skills unchanged. Empty input is not an error — it
+// just means no skills.
+func parseCommands(raw string) ([]skill.Skill, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return nil, nil
 	}
-	var defs []commands.Definition
-	if err := json.Unmarshal([]byte(raw), &defs); err != nil {
+	var skills []skill.Skill
+	if err := json.Unmarshal([]byte(raw), &skills); err != nil {
 		return nil, fmt.Errorf("runtime: parsing TURBORG_COMMANDS: %w", err)
 	}
-	return defs, nil
+	return skills, nil
 }
 
 func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger, notifier *activity.Notifier, store messages.Store, llmProvider llm.Provider) (*web.Gateway, error) {
@@ -746,6 +754,9 @@ func Run(ctx context.Context, b *Built) error {
 	}
 	if b.ConfigRefresh != nil {
 		startRefresher(b.ConfigRefresh.Run)
+	}
+	if b.Scheduler != nil {
+		startRefresher(b.Scheduler.Run)
 	}
 	waitRefresh := func() {
 		for _, done := range refreshDones {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -28,6 +28,7 @@ import (
 	"github.com/turborg/turborg/internal/config"
 	"github.com/turborg/turborg/internal/configrefresh"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/flow"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/messages"
 	"github.com/turborg/turborg/internal/messagesink"
@@ -82,6 +83,11 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	}
 
 	cmds, err := parseCommands(s.Commands)
+	if err != nil {
+		return nil, err
+	}
+
+	flows, err := parseFlows(s.Flows)
 	if err != nil {
 		return nil, err
 	}
@@ -149,6 +155,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	wiring, err := WireCommon(a, ircConn, CommonParams{
 		CustomCommandsMax: s.CustomCommandsMax,
 		Commands:          cmds,
+		Flows:             flows,
 		Platform:          ircCfg.Hostname,
 		Limits: irc.ClientLimits{
 			NickLocked:             s.NickLocked,
@@ -268,6 +275,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		"gateway", built.Gateway != nil,
 		"llm", provider != nil,
 		"commands", len(cmds),
+		"flows", len(flows),
 	)
 
 	return built, nil
@@ -321,6 +329,20 @@ func parseCommands(raw string) ([]skill.Skill, error) {
 		return nil, fmt.Errorf("runtime: parsing TURBORG_COMMANDS: %w", err)
 	}
 	return skills, nil
+}
+
+// parseFlows decodes the TURBORG_FLOWS JSON array into node-graph flows. Empty
+// input is not an error — it just means no flows.
+func parseFlows(raw string) ([]flow.Flow, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var flows []flow.Flow
+	if err := json.Unmarshal([]byte(raw), &flows); err != nil {
+		return nil, fmt.Errorf("runtime: parsing TURBORG_FLOWS: %w", err)
+	}
+	return flows, nil
 }
 
 func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger, notifier *activity.Notifier, store messages.Store, llmProvider llm.Provider) (*web.Gateway, error) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -120,6 +120,10 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	store, sink := buildMessageStore(s, log)
 	_ = sink // referenced for lifecycle parity; closing happens with the agent
 
+	// Durable skill/flow state backend. Nil when TURBORG_STATE_URL is unset —
+	// the engines then keep state in-process (lost on restart), the default.
+	skillStore := buildSkillStore(s, log)
+
 	// Single-instance activity transport: a per-event POST to ACTIVITY_URL via
 	// the Notifier. Only wired when configured; the pooled runtime supplies its
 	// own coalescing hook instead (per-event POSTs to the control plane don't
@@ -180,6 +184,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		LLMOutputUsed:             s.LLMOutputTokensUsed,
 		ActivityHook:              activityHook,
 		Store:                     store,
+		SkillStore:                skillStore,
 	}, log)
 	if err != nil {
 		return nil, err
@@ -412,6 +417,22 @@ func buildMessageStore(s *config.Settings, log *slog.Logger) (messages.Store, *m
 	// locally; the sink keeps mirroring writes for whatever consumer
 	// runs on the other side.
 	return messages.NewMemoryStore(0), sink
+}
+
+// buildSkillStore picks the durable state backend for skills + flows.
+// When TURBORG_STATE_URL (+ token) is set it returns an HTTP-backed store so
+// counters, per-user values, and history survive a restart; otherwise it
+// returns nil and each engine falls back to its own in-process store (the
+// default, state lost on restart).
+func buildSkillStore(s *config.Settings, log *slog.Logger) skill.Store {
+	if log == nil {
+		log = slog.Default()
+	}
+	if hs := skill.NewHTTPStore(s.StateURL, s.StateToken, log); hs != nil {
+		log.Info("skill state store enabled (HTTP)", "endpoint", s.StateURL)
+		return hs
+	}
+	return nil
 }
 
 // makeStoreSubmitter returns an EventBus handler that mirrors every

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -266,7 +266,7 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 	)
 
 	if s.GatewayEnabled() {
-		gw, err := buildGateway(s, ircConn, a, log, notifier, store, provider)
+		gw, err := buildGateway(s, ircConn, a, log, notifier, store, provider, wiring.FireWebhook)
 		if err != nil {
 			return nil, err
 		}
@@ -350,7 +350,7 @@ func parseFlows(raw string) ([]flow.Flow, error) {
 	return flows, nil
 }
 
-func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger, notifier *activity.Notifier, store messages.Store, llmProvider llm.Provider) (*web.Gateway, error) {
+func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, log *slog.Logger, notifier *activity.Notifier, store messages.Store, llmProvider llm.Provider, webhookFire func(name string, bag map[string]string) bool) (*web.Gateway, error) {
 	verifier, err := web.NewStaticPasswordVerifier(s.GatewayPassword)
 	if err != nil {
 		return nil, fmt.Errorf("runtime: gateway verifier: %w", err)
@@ -373,6 +373,7 @@ func buildGateway(s *config.Settings, ircConn *irc.Connector, a *agent.Agent, lo
 		MessageStore:           store,
 		LLMProvider:            llmProvider,
 		TBSummarizeMaxMessages: s.TBSummarizeMaxMessages,
+		WebhookFire:            webhookFire,
 	}
 	if notifier.Enabled() {
 		opts.OnActivity = notifier.Hook

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -29,6 +29,7 @@ import (
 	"github.com/turborg/turborg/internal/configrefresh"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/flow"
+	"github.com/turborg/turborg/internal/flowrefresh"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/messages"
 	"github.com/turborg/turborg/internal/messagesink"
@@ -59,6 +60,10 @@ type Built struct {
 	// agent runs (the single-instance mirror of the pooled feed-driven reload). Nil
 	// when COMMANDS_URL is unset (self-host: the boot set is fixed).
 	CommandRefresh *commandrefresh.Refresher
+	// FlowRefresh hot-reloads the declarative node-graph flow set in place while
+	// the agent runs (the single-instance mirror of the pooled feed-driven
+	// reload). Nil when FLOWS_URL is unset (self-host: the boot set is fixed).
+	FlowRefresh *flowrefresh.Refresher
 	// Scheduler drives schedule-trigger skills on their cadence. Supervised by
 	// Run alongside the background refreshers. Never nil (idle when no schedule
 	// skills are installed).
@@ -235,6 +240,18 @@ func Build(s *config.Settings, ircCfg *irc.Settings, log *slog.Logger) (*Built, 
 		s.CommandsToken,
 		s.CommandsRefreshSeconds,
 		func(skills []skill.Skill) { ApplySkills(a, wiring, skills, provider, owner, ircCfg.Hostname, log) },
+		log,
+	)
+
+	// Live flow hot-reload: when FLOWS_URL is set, poll the per-container flows
+	// endpoint and swap the node-graph flow set in place — the same ReplaceFlows
+	// the pooled runtime does from its feed, so a single-instance container picks
+	// up flow add/remove/edit without a respawn/reconnect.
+	built.FlowRefresh = flowrefresh.New(
+		s.FlowsURL,
+		s.FlowsToken,
+		s.FlowsRefreshSeconds,
+		func(flows []flow.Flow) { ApplyFlows(wiring, flows) },
 		log,
 	)
 
@@ -795,6 +812,9 @@ func Run(ctx context.Context, b *Built) error {
 	}
 	if b.CommandRefresh != nil {
 		startRefresher(b.CommandRefresh.Run)
+	}
+	if b.FlowRefresh != nil {
+		startRefresher(b.FlowRefresh.Run)
 	}
 	if b.ConfigRefresh != nil {
 		startRefresher(b.ConfigRefresh.Run)

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -14,6 +14,7 @@ import (
 	"github.com/turborg/turborg/internal/llm/anthropic"
 	"github.com/turborg/turborg/internal/llm/openaicompat"
 	"github.com/turborg/turborg/internal/messages"
+	"github.com/turborg/turborg/internal/skill"
 )
 
 // CommonParams are the per-tenant inputs the shared agent wiring consumes,
@@ -48,9 +49,10 @@ type CommonParams struct {
 	// BouncerWelcomeReplayDepth is clamped to a sane window before use.
 	BouncerWelcomeReplayDepth int
 
-	// Commands is the tenant's data-driven command set, swapped into the
-	// registry via ReplaceDynamic. Empty → the agent dispatches nothing.
-	Commands []commands.Definition
+	// Commands is the tenant's data-driven skill set, swapped into the command
+	// registry (command-kind skills) and the skill engine/scheduler (event /
+	// match / schedule skills). Empty → the agent dispatches nothing.
+	Commands []skill.Skill
 
 	// Platform seeds the connector-agnostic {platform} template placeholder
 	// (and its IRC {network} alias) — the transport label a static skill can
@@ -105,11 +107,22 @@ type GuardParams struct {
 	CommandWindowSeconds int
 }
 
+// Wiring is the live skill machinery WireCommon constructs alongside the
+// command registry: the event/match Engine (subscribed to the agent's bus) and
+// the schedule Scheduler. The caller supervises Scheduler.Run and reaches both
+// from a hot reload (ApplySkills) to swap the skill set in place.
+type Wiring struct {
+	Engine    *skill.Engine
+	Scheduler *skill.Scheduler
+}
+
 // WireCommon installs the connector-agnostic agent wiring shared by the
 // single-instance (cmd/turborg) and pooled (internal/server) runtimes onto an
 // already-constructed agent + IRC connector: client limits, outbound throttle,
-// owner nudge, message store + event submitters, builtin commands, and the
-// command guard. It calls a.AddConnector itself.
+// owner nudge, message store + event submitters, builtin commands, the command
+// guard, and the skill engine + scheduler. It calls a.AddConnector itself and
+// returns the live Wiring so the caller can supervise the scheduler and hot-
+// reload the skill set.
 //
 // The caller owns everything that genuinely differs by mode — agent prefix,
 // gateway (listener vs router), bouncer listener mode, state-push transport —
@@ -117,8 +130,8 @@ type GuardParams struct {
 //
 // No process globals or shared mutable state: invoked once per single-instance
 // process and N times per pooled process, each call producing a fully
-// independent set of throttles/guards/submitters.
-func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slog.Logger) error {
+// independent set of throttles/guards/submitters/engine.
+func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slog.Logger) (*Wiring, error) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -137,7 +150,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 			nil,
 		)
 		if err != nil {
-			return fmt.Errorf("runtime: outbound throttle: %w", err)
+			return nil, fmt.Errorf("runtime: outbound throttle: %w", err)
 		}
 		ircConn.SetOutboundThrottle(t)
 	}
@@ -171,32 +184,59 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 
 	// Registry-wide guard: the ignore list + per-sender throttle, applied to
 	// every command. Per-command access (owner / allowlist / everyone) is
-	// layered on top by the guard each Definition carries.
+	// layered on top by the guard each skill carries.
 	a.Commands.SetGuard(buildRegistryGuard(p.Owner))
 
-	// Install the tenant's data-driven commands. The dynamic set is fully
-	// owned by ReplaceDynamic, so a later hot reload swaps it atomically.
-	ApplyCommands(a, p.Commands, provider, p.Owner, p.Platform, log)
-	return nil
+	// Skill engine (event/match) + scheduler, sharing the same provider and
+	// owner/platform render context as the command path. The engine acts on the
+	// network through the connector-agnostic IRC Actor and is subscribed to the
+	// agent's bus; the scheduler is supervised by the caller.
+	engine := skill.NewEngine(skill.Options{
+		Actor:     irc.NewActor(ircConn),
+		Provider:  provider,
+		Platform:  p.Platform,
+		Owner:     p.Owner.OwnerNick,
+		MaxSkills: p.CustomCommandsMax,
+		Log:       log,
+	})
+	engine.Subscribe(a.Events)
+	scheduler := skill.NewScheduler(engine, log)
+	wiring := &Wiring{Engine: engine, Scheduler: scheduler}
+
+	// Install the tenant's data-driven skill set. The command registry's
+	// dynamic set, the engine's event/match set, and the scheduler's schedule
+	// set are each fully owned by their Replace primitive, so a later hot reload
+	// swaps all three atomically.
+	ApplySkills(a, wiring, p.Commands, provider, p.Owner, p.Platform, log)
+	return wiring, nil
 }
 
-// ApplyCommands rebuilds the data-driven command set from defs and swaps it
-// into the agent's registry in place via ReplaceDynamic — an atomic, no-
-// reconnect hot reload. It is the single source of truth for turning command
-// Definitions into live handlers, shared by initial wiring (WireCommon), the
-// pooled runtime's feed-driven reload, and the single-instance runtime's command
-// refresher, so the three can't drift in how a command is built or
-// access-gated. The registry-wide ignore/throttle guard set at wire time is
-// untouched; per-command access (owner / allowlist / everyone) is reapplied
-// from each Definition.
-func ApplyCommands(a *agent.Agent, defs []commands.Definition, provider llm.Provider, owner GuardParams, platform string, log *slog.Logger) {
+// ApplySkills rebuilds the data-driven skill set from skills and swaps it into
+// the three live surfaces in place — an atomic, no-reconnect hot reload:
+// command-kind skills into the command registry (ReplaceDynamic), event/match
+// skills into the engine (ReplaceSkills), and schedule skills into the
+// scheduler (ReplaceSkills). It is the single source of truth for turning skill
+// definitions into live behavior, shared by initial wiring (WireCommon), the
+// pooled runtime's feed-driven reload, and the single-instance runtime's
+// refresher, so they can't drift. The registry-wide ignore/throttle guard set
+// at wire time is untouched; per-command access (owner / allowlist / everyone)
+// is reapplied from each skill.
+func ApplySkills(a *agent.Agent, w *Wiring, skills []skill.Skill, provider llm.Provider, owner GuardParams, platform string, log *slog.Logger) {
 	if log == nil {
 		log = slog.Default()
 	}
-	built := commands.Build(defs, provider, func(d commands.Definition) agent.CommandGuard {
-		return PerCommandGuard(string(d.Access), d.Allowlist, owner)
+	built := skill.Build(skills, provider, func(s skill.Skill) agent.CommandGuard {
+		return PerCommandGuard(string(s.Access), s.Allowlist, owner)
 	}, platform, owner.OwnerNick, log)
 	a.Commands.ReplaceDynamic(built)
+	if w != nil {
+		if w.Engine != nil {
+			w.Engine.ReplaceSkills(skills)
+		}
+		if w.Scheduler != nil {
+			w.Scheduler.ReplaceSkills(skills)
+		}
+	}
 }
 
 // ApplyRegistryGuard rebuilds the registry-wide guard (ignore list + per-sender

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -10,6 +10,7 @@ import (
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/flow"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/llm/anthropic"
 	"github.com/turborg/turborg/internal/llm/openaicompat"
@@ -53,6 +54,10 @@ type CommonParams struct {
 	// registry (command-kind skills) and the skill engine/scheduler (event /
 	// match / schedule skills). Empty → the agent dispatches nothing.
 	Commands []skill.Skill
+
+	// Flows is the tenant's declarative node-graph flow set, run by the flow
+	// engine on event/match triggers. Empty → no flows.
+	Flows []flow.Flow
 
 	// Platform seeds the connector-agnostic {platform} template placeholder
 	// (and its IRC {network} alias) — the transport label a static skill can
@@ -114,6 +119,7 @@ type GuardParams struct {
 type Wiring struct {
 	Engine    *skill.Engine
 	Scheduler *skill.Scheduler
+	Flows     *flow.Engine
 }
 
 // WireCommon installs the connector-agnostic agent wiring shared by the
@@ -201,13 +207,26 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	})
 	engine.Subscribe(a.Events)
 	scheduler := skill.NewScheduler(engine, log)
-	wiring := &Wiring{Engine: engine, Scheduler: scheduler}
+
+	// Flow engine: the node-graph layer above single-shot skills, sharing the
+	// same actor/provider/owner/platform context and subscribed to the same bus.
+	flowEngine := flow.NewEngine(flow.Options{
+		Actor:    irc.NewActor(ircConn),
+		Provider: provider,
+		Platform: p.Platform,
+		Owner:    p.Owner.OwnerNick,
+		MaxFlows: p.CustomCommandsMax,
+		Log:      log,
+	})
+	flowEngine.Subscribe(a.Events)
+	wiring := &Wiring{Engine: engine, Scheduler: scheduler, Flows: flowEngine}
 
 	// Install the tenant's data-driven skill set. The command registry's
 	// dynamic set, the engine's event/match set, and the scheduler's schedule
 	// set are each fully owned by their Replace primitive, so a later hot reload
 	// swaps all three atomically.
 	ApplySkills(a, wiring, p.Commands, provider, p.Owner, p.Platform, log)
+	ApplyFlows(wiring, p.Flows)
 	return wiring, nil
 }
 
@@ -236,6 +255,14 @@ func ApplySkills(a *agent.Agent, w *Wiring, skills []skill.Skill, provider llm.P
 		if w.Scheduler != nil {
 			w.Scheduler.ReplaceSkills(skills)
 		}
+	}
+}
+
+// ApplyFlows swaps the engine's node-graph flow set in place — an atomic,
+// no-reconnect hot reload, shared by initial wiring and any flow refresher.
+func ApplyFlows(w *Wiring, flows []flow.Flow) {
+	if w != nil && w.Flows != nil {
+		w.Flows.ReplaceFlows(flows)
 	}
 }
 

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -95,6 +95,12 @@ type CommonParams struct {
 	// Store backs bouncer welcome replay + web-shell scrollback + CHATHISTORY.
 	// Nil → no store wiring (no submitters, connector keeps its zero value).
 	Store messages.Store
+
+	// SkillStore backs durable skill/flow state (counters, per-user values,
+	// history). Shared by the skill engine and the flow engine so a value a
+	// skill writes is visible to a flow of the same namespace. Nil → each engine
+	// falls back to its own in-process store (state lost on restart).
+	SkillStore skill.Store
 }
 
 // GuardParams are the primitive inputs to the !command guard, lifted out of
@@ -200,6 +206,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	engine := skill.NewEngine(skill.Options{
 		Actor:     irc.NewActor(ircConn),
 		Provider:  provider,
+		Store:     p.SkillStore,
 		Platform:  p.Platform,
 		Owner:     p.Owner.OwnerNick,
 		MaxSkills: p.CustomCommandsMax,
@@ -213,6 +220,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	flowEngine := flow.NewEngine(flow.Options{
 		Actor:    irc.NewActor(ircConn),
 		Provider: provider,
+		Store:    p.SkillStore,
 		Platform: p.Platform,
 		Owner:    p.Owner.OwnerNick,
 		MaxFlows: p.CustomCommandsMax,

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -128,6 +128,24 @@ type Wiring struct {
 	Flows     *flow.Engine
 }
 
+// FireWebhook dispatches an inbound webhook (named by the per-flow ingress path,
+// seeded from the decoded request body) to both engines: the node-graph flow
+// engine and the single-shot skill engine. It returns true when either fired a
+// matching webhook trigger, which the gateway ingress handler maps onto a 200;
+// false means no flow or skill carries that name and the handler answers 404
+// with no detail. It is the seam the gateway holds so the ingress route can
+// reach the live engines without importing them.
+func (w *Wiring) FireWebhook(name string, bag map[string]string) bool {
+	if w == nil {
+		return false
+	}
+	// Both engines are consulted (a name could belong to either), so evaluate
+	// each — don't short-circuit — before OR-ing the outcomes.
+	flowFired := w.Flows != nil && w.Flows.FireWebhook(name, bag)
+	skillFired := w.Engine != nil && w.Engine.FireWebhook(name, bag)
+	return flowFired || skillFired
+}
+
 // WireCommon installs the connector-agnostic agent wiring shared by the
 // single-instance (cmd/turborg) and pooled (internal/server) runtimes onto an
 // already-constructed agent + IRC connector: client limits, outbound throttle,

--- a/internal/runtime/wire_coverage_test.go
+++ b/internal/runtime/wire_coverage_test.go
@@ -1,0 +1,38 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/turborg/turborg/internal/agent"
+)
+
+func TestBuildLLMProviderKinds(t *testing.T) {
+	// Anthropic path (default kind).
+	_, _ = BuildLLMProvider("anthropic", "", "", "")
+	_, _ = BuildLLMProvider("", "", "", "")
+
+	// openai_compat with no key is the explicit "no provider" signal.
+	p, err := BuildLLMProvider("openai_compat", "", "", "")
+	require.NoError(t, err)
+	require.Nil(t, p)
+
+	// openai_compat with a key builds a provider.
+	got, err := BuildLLMProvider("openai", "https://example/v1", "k", "m")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+func TestMatchesAllowlistAndRegistryGuard(t *testing.T) {
+	a := agent.New(nil)
+	ApplyRegistryGuard(a, GuardParams{}) // just exercise the wiring
+
+	set := map[string]struct{}{"alice": {}, "acc": {}}
+	assert.False(t, matchesAllowlist(nil, nil))
+	assert.True(t, matchesAllowlist(set, &agent.InboundEnvelope{Sender: "Alice"}))
+	assert.True(t, matchesAllowlist(set, &agent.InboundEnvelope{Metadata: map[string]any{"account": "Acc"}}))
+	assert.False(t, matchesAllowlist(set, &agent.InboundEnvelope{Sender: ""}))
+	assert.False(t, matchesAllowlist(set, &agent.InboundEnvelope{Sender: "bob"}))
+}

--- a/internal/runtime/wire_test.go
+++ b/internal/runtime/wire_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/turborg/turborg/internal/agent"
-	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/runtime"
+	"github.com/turborg/turborg/internal/skill"
 )
 
 // stubProvider is a minimal llm.Provider — enough for WireCommon to build an
@@ -34,22 +34,23 @@ func newWiredAgent(t *testing.T, p runtime.CommonParams) *agent.Agent {
 	cfg := &irc.Settings{Hostname: "irc.example", Nick: "bot"}
 	cfg.ApplyDefaults()
 	conn := irc.New(cfg, nil, a.Events)
-	require.NoError(t, runtime.WireCommon(a, conn, p, nil))
+	_, err := runtime.WireCommon(a, conn, p, nil)
+	require.NoError(t, err)
 	return a
 }
 
 func TestWireCommonInstallsConfiguredCommands(t *testing.T) {
 	a := newWiredAgent(t, runtime.CommonParams{
-		Commands: []commands.Definition{
-			{Name: "rules", Type: commands.TypeStatic, Template: "be nice", Access: commands.AccessEveryone},
+		Commands: []skill.Skill{
+			skill.Command("rules", skill.TypeStatic, "be nice", skill.AccessEveryone),
 		},
 	})
 	require.Contains(t, a.Commands.Names(), "rules")
 }
 
 func TestWireCommonSkipsLLMCommandsWithoutProvider(t *testing.T) {
-	defs := []commands.Definition{
-		{Name: "ask", Type: commands.TypeLLM, Template: "{args}", Access: commands.AccessOwner},
+	defs := []skill.Skill{
+		skill.Command("ask", skill.TypeLLM, "{args}", skill.AccessOwner),
 	}
 
 	withoutLLM := newWiredAgent(t, runtime.CommonParams{Commands: defs})
@@ -63,8 +64,8 @@ func TestWireCommonSkipsLLMCommandsWithoutProvider(t *testing.T) {
 
 func TestWireCommonEveryoneAccessDispatchesForAnyone(t *testing.T) {
 	a := newWiredAgent(t, runtime.CommonParams{
-		Commands: []commands.Definition{
-			{Name: "rules", Type: commands.TypeStatic, Template: "be nice", Access: commands.AccessEveryone},
+		Commands: []skill.Skill{
+			skill.Command("rules", skill.TypeStatic, "be nice", skill.AccessEveryone),
 		},
 	})
 	out, err := a.Commands.Dispatch(context.Background(), &agent.InboundEnvelope{Text: "!rules", Sender: "anyone"})
@@ -76,8 +77,8 @@ func TestWireCommonEveryoneAccessDispatchesForAnyone(t *testing.T) {
 func TestWireCommonOwnerAccessDeniesNoneMode(t *testing.T) {
 	// Default owner mode "none" denies an owner-access command for everyone.
 	a := newWiredAgent(t, runtime.CommonParams{
-		Commands: []commands.Definition{
-			{Name: "secret", Type: commands.TypeStatic, Template: "shh", Access: commands.AccessOwner},
+		Commands: []skill.Skill{
+			skill.Command("secret", skill.TypeStatic, "shh", skill.AccessOwner),
 		},
 	})
 	out, err := a.Commands.Dispatch(context.Background(), &agent.InboundEnvelope{Text: "!secret", Sender: "anyone"})
@@ -88,8 +89,8 @@ func TestWireCommonOwnerAccessDeniesNoneMode(t *testing.T) {
 func TestWireCommonOwnerAccessSelfMode(t *testing.T) {
 	a := newWiredAgent(t, runtime.CommonParams{
 		Owner: runtime.GuardParams{OwnerMode: "self", BotNick: "bot"},
-		Commands: []commands.Definition{
-			{Name: "secret", Type: commands.TypeStatic, Template: "shh", Access: commands.AccessOwner},
+		Commands: []skill.Skill{
+			skill.Command("secret", skill.TypeStatic, "shh", skill.AccessOwner),
 		},
 	})
 
@@ -106,8 +107,8 @@ func TestWireCommonOwnerAccessSelfMode(t *testing.T) {
 func TestWireCommonAllowlistAccess(t *testing.T) {
 	a := newWiredAgent(t, runtime.CommonParams{
 		Owner: runtime.GuardParams{OwnerMode: "self", BotNick: "bot"},
-		Commands: []commands.Definition{
-			{Name: "team", Type: commands.TypeStatic, Template: "ok", Access: commands.AccessAllowlist, Allowlist: []string{"alice"}},
+		Commands: []skill.Skill{
+			skill.Command("team", skill.TypeStatic, "ok", skill.AccessAllowlist, "alice"),
 		},
 	})
 
@@ -129,8 +130,8 @@ func TestWireCommonWrapsLLMWithBudget(t *testing.T) {
 		LLM:          stubProvider{},
 		LLMInputCap:  1000,
 		LLMOutputCap: 500,
-		Commands: []commands.Definition{
-			{Name: "ask", Type: commands.TypeLLM, Template: "hi", Access: commands.AccessEveryone},
+		Commands: []skill.Skill{
+			skill.Command("ask", skill.TypeLLM, "hi", skill.AccessEveryone),
 		},
 	})
 	require.Contains(t, a.Commands.Names(), "ask")
@@ -141,8 +142,8 @@ func TestWireCommonNoBudgetWhenCapsZero(t *testing.T) {
 		LLM:          stubProvider{},
 		LLMInputCap:  0,
 		LLMOutputCap: 0,
-		Commands: []commands.Definition{
-			{Name: "ask", Type: commands.TypeLLM, Template: "hi", Access: commands.AccessEveryone},
+		Commands: []skill.Skill{
+			skill.Command("ask", skill.TypeLLM, "hi", skill.AccessEveryone),
 		},
 	})
 	require.Contains(t, a.Commands.Names(), "ask")

--- a/internal/runtime/wire_webhook_test.go
+++ b/internal/runtime/wire_webhook_test.go
@@ -1,0 +1,46 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/flow"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+// TestWiringFireWebhook proves the combined dispatcher reaches both engines: a
+// webhook-trigger flow and a webhook-trigger skill installed via WireCommon are
+// each reachable by name, and an unknown name (or a nil wiring) returns false.
+func TestWiringFireWebhook(t *testing.T) {
+	a := agent.NewWithPrefix(nil, "!")
+	cfg := &irc.Settings{Hostname: "irc.example", Nick: "bot"}
+	cfg.ApplyDefaults()
+	conn := irc.New(cfg, nil, a.Events)
+
+	cmds := []skill.Skill{{
+		Name:    "skillhook",
+		Trigger: skill.Trigger{Kind: skill.KindWebhook, Channels: []string{"#c"}},
+		Action:  skill.Action{Type: skill.TypeStatic, Template: "{text}"},
+	}}
+	flows := []flow.Flow{{
+		Name:    "flowhook",
+		Trigger: skill.Trigger{Kind: skill.KindWebhook, Channels: []string{"#c"}},
+		Nodes:   []flow.Node{{ID: "s", Type: "say", Config: map[string]any{"channel": "#c", "text": "{text}"}}},
+	}}
+
+	wiring, err := WireCommon(a, conn, CommonParams{CustomCommandsMax: -1, Commands: cmds, Flows: flows}, nil)
+	if err != nil {
+		t.Fatalf("WireCommon: %v", err)
+	}
+
+	// The actor errors (not connected), but a found trigger still fires and
+	// FireWebhook reports true. Both engines are reachable through one call.
+	assert.True(t, wiring.FireWebhook("flowhook", map[string]string{"text": "hi"}), "flow reachable")
+	assert.True(t, wiring.FireWebhook("skillhook", map[string]string{"text": "hi"}), "skill reachable")
+	assert.False(t, wiring.FireWebhook("ghost", map[string]string{"text": "hi"}), "unknown name is false")
+
+	var nilWiring *Wiring
+	assert.False(t, nilWiring.FireWebhook("x", nil), "nil wiring is false, not a panic")
+}

--- a/internal/server/hot_reload_test.go
+++ b/internal/server/hot_reload_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/turborg/turborg/internal/agent"
-	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/skill"
 )
 
-func staticCmd(name, tmpl string) commands.Definition {
-	return commands.Definition{Name: name, Type: commands.TypeStatic, Template: tmpl, Access: commands.AccessEveryone}
+func staticCmd(name, tmpl string) skill.Skill {
+	return skill.Command(name, skill.TypeStatic, tmpl, skill.AccessEveryone)
 }
 
 func specWithChannel(id, channel string) TenantSpec {
@@ -115,7 +115,7 @@ func TestIdenticalUpsertDoesNotRestart(t *testing.T) {
 func TestCommandsOnlyChange(t *testing.T) {
 	base := specWithChannel("x", "#one")
 	withCmds := specWithChannel("x", "#one")
-	withCmds.Commands = []commands.Definition{staticCmd("a", "x")}
+	withCmds.Commands = []skill.Skill{staticCmd("a", "x")}
 	require.True(t, commandsOnlyChange(base, withCmds),
 		"specs differing only in their command set is a commands-only change")
 
@@ -168,18 +168,18 @@ func TestReloadCommandsSwapsInPlace(t *testing.T) {
 		ircConn:  conn,
 	}
 
-	require.True(t, tn.reloadCommands([]commands.Definition{staticCmd("rules", "be nice")}))
+	require.True(t, tn.reloadCommands([]skill.Skill{staticCmd("rules", "be nice")}))
 	require.Contains(t, a.Commands.Names(), "rules")
 
 	// A second reload fully replaces the prior set — no reconnect involved.
-	require.True(t, tn.reloadCommands([]commands.Definition{staticCmd("hi", "yo")}))
+	require.True(t, tn.reloadCommands([]skill.Skill{staticCmd("hi", "yo")}))
 	require.NotContains(t, a.Commands.Names(), "rules")
 	require.Contains(t, a.Commands.Names(), "hi")
 }
 
 func TestReloadCommandsFallsBackWhenNotRunning(t *testing.T) {
 	tn := &Tenant{ID: "t1", log: testLogger()}
-	require.False(t, tn.reloadCommands([]commands.Definition{staticCmd("x", "y")}),
+	require.False(t, tn.reloadCommands([]skill.Skill{staticCmd("x", "y")}),
 		"no live agent/connector → reload defers to a restart")
 }
 
@@ -228,7 +228,7 @@ func TestUpdateCommandsOnlyReloadsWithoutRestart(t *testing.T) {
 
 	// Command-only upsert: must reload in place, not restart.
 	cmdSpec := base
-	cmdSpec.Commands = []commands.Definition{staticCmd("rules", "be nice")}
+	cmdSpec.Commands = []skill.Skill{staticCmd("rules", "be nice")}
 	events <- TenantEvent{Kind: TenantUpserted, Spec: cmdSpec}
 
 	require.Eventually(t, func() bool {
@@ -369,7 +369,7 @@ func TestReloadGuardSwapsIgnoreInPlace(t *testing.T) {
 		agentRef: a,
 		ircConn:  conn,
 	}
-	require.True(t, tn.reloadCommands([]commands.Definition{staticCmd("ping", "pong")}))
+	require.True(t, tn.reloadCommands([]skill.Skill{staticCmd("ping", "pong")}))
 
 	ctx := context.Background()
 	send := func(sender string) bool {

--- a/internal/server/hot_reload_test.go
+++ b/internal/server/hot_reload_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/flow"
+	"github.com/turborg/turborg/internal/runtime"
 	"github.com/turborg/turborg/internal/skill"
 )
 
@@ -181,6 +183,36 @@ func TestReloadCommandsFallsBackWhenNotRunning(t *testing.T) {
 	tn := &Tenant{ID: "t1", log: testLogger()}
 	require.False(t, tn.reloadCommands([]skill.Skill{staticCmd("x", "y")}),
 		"no live agent/connector → reload defers to a restart")
+}
+
+func TestReloadFlowsSwapsInPlace(t *testing.T) {
+	eng := flow.NewEngine(flow.Options{})
+	eng.SetMaxFlows(-1)
+	tn := &Tenant{ID: "t1", log: testLogger(), wiring: &runtime.Wiring{Flows: eng}}
+
+	require.True(t, tn.reloadFlows([]flow.Flow{{
+		Name:    "greet",
+		Trigger: skill.Trigger{Kind: skill.KindEvent, Event: skill.EventUserJoin},
+		Nodes:   []flow.Node{{ID: "s", Type: "say", Config: map[string]any{"text": "hi"}}},
+		Edges:   []flow.Edge{{From: "start", To: "s"}},
+	}}))
+	// A second reload replaces the set in place — no reconnect involved.
+	require.True(t, tn.reloadFlows(nil))
+}
+
+func TestReloadFlowsFallsBackWhenNotRunning(t *testing.T) {
+	tn := &Tenant{ID: "t1", log: testLogger()}
+	require.False(t, tn.reloadFlows([]flow.Flow{}),
+		"no live wiring → reload defers to a restart")
+}
+
+func TestServerAccessorsAndSuspendFallback(t *testing.T) {
+	s := New(nil, testLogger())
+	_ = s.Idents()
+	s.SetLLM(nil)
+	// applySuspend with no live connector defers to a restart.
+	tn := &Tenant{ID: "t1", log: testLogger()}
+	require.False(t, tn.applySuspend(TenantSpec{}))
 }
 
 // TestUpdateCommandsOnlyReloadsWithoutRestart is the no-reconnect deliverable:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -241,6 +241,22 @@ func (s *Server) RouteWS(turborgID string, w http.ResponseWriter, r *http.Reques
 	return true
 }
 
+// RouteHook hands one inbound-webhook request (POST /c/<id>/hook/<name>) to the
+// named tenant's web gateway. Returns false (and does not touch w) when no such
+// tenant is attached, so the router can answer 404 without revealing whether the
+// id exists. The gateway does the auth + trigger dispatch (and the 404 on a
+// between-runs tenant with no live gateway).
+func (s *Server) RouteHook(turborgID string, w http.ResponseWriter, r *http.Request) bool {
+	s.mu.Lock()
+	t, ok := s.tenants[turborgID]
+	s.mu.Unlock()
+	if !ok {
+		return false
+	}
+	t.ServeHook(w, r)
+	return true
+}
+
 // Status returns a tenant's supervision phase, and whether it is attached.
 func (s *Server) Status(id string) (TenantStatus, bool) {
 	s.mu.Lock()

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/turborg/turborg/internal/agent"
-	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/ident"
 	"github.com/turborg/turborg/internal/llm"
@@ -22,6 +21,7 @@ import (
 	"github.com/turborg/turborg/internal/messagesink"
 	"github.com/turborg/turborg/internal/runtime"
 	"github.com/turborg/turborg/internal/safe"
+	"github.com/turborg/turborg/internal/skill"
 	"github.com/turborg/turborg/internal/statepush"
 	"github.com/turborg/turborg/internal/web"
 )
@@ -92,6 +92,11 @@ type Tenant struct {
 	// swap the command set in place (ReplaceDynamic) when ONLY the commands
 	// changed — no reconnect. nil between runs → reload falls back to restart.
 	agentRef *agent.Agent
+	// wiring is the live skill engine + scheduler for the current run, captured
+	// in buildConnectors and cleared when the run ends. reloadCommands swaps the
+	// skill set in place through it (engine/scheduler ReplaceSkills) alongside
+	// the command registry. nil between runs.
+	wiring *runtime.Wiring
 	// gateway is the live web shell for the current run, built in
 	// buildConnectors when the spec carries a GatewayToken and cleared when the
 	// run ends. The web router reaches it via ServeWS to upgrade an attached
@@ -282,9 +287,30 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 		t.buildConnectors(a)
 		t.mu.Lock()
 		t.agentRef = a
+		var sched *skill.Scheduler
+		if t.wiring != nil {
+			sched = t.wiring.Scheduler
+		}
 		t.mu.Unlock()
 		t.log.Info("tenant attached", "connectors", t.connectorTypes())
+
+		// Drive schedule-trigger skills under a child context for the life of
+		// this run. schedCancel + the wait keep the goroutine goleak-clean across
+		// restarts (it always exits before defaultWork returns).
+		schedCtx, schedCancel := context.WithCancel(ctx)
+		schedDone := make(chan struct{})
+		if sched != nil {
+			safe.Go("skill-scheduler/"+t.ID, func() {
+				defer close(schedDone)
+				_ = sched.Run(schedCtx)
+			})
+		} else {
+			close(schedDone)
+		}
+
 		err := a.Run(ctx)
+		schedCancel()
+		<-schedDone
 		// Run ended (ctx cancelled / restart) — the connector's bouncer, web
 		// gateway, and state emitter are stopping, so drop the handles. A late
 		// inbound conn/WS then closes cleanly instead of hitting a torn-down run,
@@ -298,6 +324,7 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 		t.stateEmitter = nil
 		t.messageSink = nil
 		t.agentRef = nil
+		t.wiring = nil
 		t.mu.Unlock()
 		if gw != nil {
 			gw.Stop()
@@ -401,13 +428,15 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			cp.Platform = settings.Hostname
 			budgetedProvider := runtime.BuildBudgetedProvider(a, cp.LLM, cp.LLMInputCap, cp.LLMOutputCap, cp.LLMInputUsed, cp.LLMOutputUsed, t.log)
 			cp.LLM = budgetedProvider
-			if err := runtime.WireCommon(a, conn, cp, t.log); err != nil {
+			wiring, err := runtime.WireCommon(a, conn, cp, t.log)
+			if err != nil {
 				t.log.Error("skipping irc connector: wiring failed", "err", err)
 				continue
 			}
 
 			t.mu.Lock()
 			t.ircConn = conn
+			t.wiring = wiring
 			t.mu.Unlock()
 
 			// Connector-state sync: mirror upstream status / channels / nick to
@@ -485,7 +514,7 @@ func (t *Tenant) applyTierSettings(s *irc.Settings, caps *PlanCapabilities) {
 // CustomCommandsMax + Commands carry the tenant's data-driven command set
 // and its cap, so pooled tenants get user-defined commands the same way the
 // single-instance runtime does (from TURBORG_COMMANDS).
-func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick string, store messages.Store, ignoredNicks []string, cmds []commands.Definition) runtime.CommonParams {
+func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick string, store messages.Store, ignoredNicks []string, cmds []skill.Skill) runtime.CommonParams {
 	var limits irc.ClientLimits
 	var outMax, outWin, nudge, cmdMax, cmdWin, customCmdMax, llmInCap, llmOutCap, llmInUsed, llmOutUsed int
 	if caps != nil {
@@ -762,7 +791,7 @@ func capsWithoutTokenUsage(caps *PlanCapabilities) *PlanCapabilities {
 }
 
 // commandSetsEqual reports whether two command slices are identical.
-func commandSetsEqual(a, b []commands.Definition) bool {
+func commandSetsEqual(a, b []skill.Skill) bool {
 	return reflect.DeepEqual(a, b)
 }
 
@@ -772,10 +801,11 @@ func commandSetsEqual(a, b []commands.Definition) bool {
 // connector), so the caller falls back to a restart. The per-command guards
 // reuse the same owner-trust config the connector spec carries (the registry-
 // wide ignore + throttle guard set at wire time is untouched).
-func (t *Tenant) reloadCommands(defs []commands.Definition) bool {
+func (t *Tenant) reloadCommands(defs []skill.Skill) bool {
 	t.mu.Lock()
 	a := t.agentRef
 	conn := t.ircConn
+	wiring := t.wiring
 	cs := firstIRCConnectorSpec(t.spec.Connectors)
 	ignoredNicks := t.spec.IgnoredNicks
 	t.mu.Unlock()
@@ -794,8 +824,9 @@ func (t *Tenant) reloadCommands(defs []commands.Definition) bool {
 	// {platform} echoes the IRC server hostname; the connector spec carries it
 	// as "host:port", so reuse the same split the spec→settings mapping does.
 	platform, _, _ := splitNetwork(stringField(cs.Config, "network"))
-	// Same in-place swap the single-instance runtime's command refresher uses.
-	runtime.ApplyCommands(a, defs, t.llmProvider, owner, platform, t.log)
+	// Same in-place swap the single-instance runtime's refresher uses: command
+	// registry + skill engine + scheduler, all atomic, no reconnect.
+	runtime.ApplySkills(a, wiring, defs, t.llmProvider, owner, platform, t.log)
 	return true
 }
 

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -426,6 +426,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			// below. WireCommon's own wrap is idempotent on this.
 			cp := t.commonParams(cs, caps, settings.Nick, store, ignoredNicks, cmds)
 			cp.Platform = settings.Hostname
+			cp.Flows = t.spec.Flows
 			budgetedProvider := runtime.BuildBudgetedProvider(a, cp.LLM, cp.LLMInputCap, cp.LLMOutputCap, cp.LLMInputUsed, cp.LLMOutputUsed, t.log)
 			cp.LLM = budgetedProvider
 			wiring, err := runtime.WireCommon(a, conn, cp, t.log)

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
+	"github.com/turborg/turborg/internal/flow"
 	"github.com/turborg/turborg/internal/ident"
 	"github.com/turborg/turborg/internal/llm"
 	"github.com/turborg/turborg/internal/messages"
@@ -665,10 +666,11 @@ func (t *Tenant) update(spec TenantSpec) {
 // applies nothing and returns true (nothing to reconnect for).
 func (t *Tenant) applyLiveUpdate(prev, spec TenantSpec) bool {
 	commandsChanged := !commandSetsEqual(prev.Commands, spec.Commands)
+	flowsChanged := !reflect.DeepEqual(prev.Flows, spec.Flows)
 	ignoresChanged := !reflect.DeepEqual(prev.IgnoredNicks, spec.IgnoredNicks)
 	nickChanged, channelsChanged := ircNickChannelsChanged(prev, spec)
 	suspendChanged := ircSuspendChanged(prev, spec)
-	if !commandsChanged && !ignoresChanged && !nickChanged && !channelsChanged && !suspendChanged {
+	if !commandsChanged && !flowsChanged && !ignoresChanged && !nickChanged && !channelsChanged && !suspendChanged {
 		return true // only the usage baseline moved — nothing to reconnect for
 	}
 	// Apply each changed facet in place. The command set swaps via
@@ -676,12 +678,13 @@ func (t *Tenant) applyLiveUpdate(prev, spec TenantSpec) bool {
 	// channels apply live via NICK / JOIN+PART; the connect/disconnect intent
 	// parks/resumes the upstream link.
 	okCommands := !commandsChanged || t.reloadCommands(spec.Commands)
+	okFlows := !flowsChanged || t.reloadFlows(spec.Flows)
 	okIgnores := !ignoresChanged || t.reloadGuard()
 	okNickChan := (!nickChanged && !channelsChanged) || t.applyNickChannels(spec)
 	okSuspend := !suspendChanged || t.applySuspend(spec)
-	if okCommands && okIgnores && okNickChan && okSuspend {
+	if okCommands && okFlows && okIgnores && okNickChan && okSuspend {
 		t.log.Info("tenant settings reloaded in place",
-			"commands", len(spec.Commands), "ignored", len(spec.IgnoredNicks),
+			"commands", len(spec.Commands), "flows", len(spec.Flows), "ignored", len(spec.IgnoredNicks),
 			"nick_changed", nickChanged, "channels_changed", channelsChanged,
 			"suspend_changed", suspendChanged)
 		return true
@@ -706,6 +709,7 @@ func commandsOnlyChange(a, b TenantSpec) bool {
 // hot-swapped in place, so an ignore edit must not drop the connection.
 func liveUpdatableOnlyChange(a, b TenantSpec) bool {
 	a.Commands, b.Commands = nil, nil
+	a.Flows, b.Flows = nil, nil
 	a.IgnoredNicks, b.IgnoredNicks = nil, nil
 	a.PlanCapabilities = capsWithoutTokenUsage(a.PlanCapabilities)
 	b.PlanCapabilities = capsWithoutTokenUsage(b.PlanCapabilities)
@@ -846,6 +850,21 @@ func (t *Tenant) reloadCommands(defs []skill.Skill) bool {
 	// Same in-place swap the single-instance runtime's refresher uses: command
 	// registry + skill engine + scheduler, all atomic, no reconnect.
 	runtime.ApplySkills(a, wiring, defs, t.llmProvider, owner, platform, t.log)
+	return true
+}
+
+// reloadFlows swaps the live tenant's node-graph flow set in place — the same
+// atomic, no-reconnect ApplyFlows the runtime uses at build time — without
+// touching the connection. Returns false when the tenant isn't running (no live
+// wiring), so the caller falls back to a restart that re-seeds flows at build.
+func (t *Tenant) reloadFlows(flows []flow.Flow) bool {
+	t.mu.Lock()
+	wiring := t.wiring
+	t.mu.Unlock()
+	if wiring == nil {
+		return false
+	}
+	runtime.ApplyFlows(wiring, flows)
 	return true
 }
 

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -572,6 +572,7 @@ func (t *Tenant) commonParams(cs ConnectorSpec, caps *PlanCapabilities, botNick 
 		LLMOutputUsed:         llmOutUsed,
 		ActivityHook:          activityHook,
 		Store:                 store,
+		SkillStore:            t.buildSkillStore(),
 	}
 }
 
@@ -591,6 +592,23 @@ func (t *Tenant) buildMessageStore() (messages.Store, *messagesink.Sink) {
 		return hs, sink
 	}
 	return messages.NewMemoryStore(0), sink
+}
+
+// buildSkillStore builds this tenant's durable skill/flow state backend. With a
+// control plane configured it's an HTTP store pointed at the per-tenant
+// control-plane base (so quiz scores, counters, seen-dbs, and history survive a
+// pool restart); the store appends /state/{ns}/{key} per value. Without a
+// control plane it returns nil and the engines keep state in-process — the
+// OSS/file-source path.
+func (t *Tenant) buildSkillStore() skill.Store {
+	if t.controlPlaneURL == "" {
+		return nil
+	}
+	base := strings.TrimRight(t.controlPlaneURL, "/") + "/turborg/" + t.ID
+	if hs := skill.NewHTTPStore(base, t.controlPlaneToken, t.log); hs != nil {
+		return hs
+	}
+	return nil
 }
 
 // update applies a new desired spec to a running tenant (M7 hot reload). An

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -465,7 +465,7 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 						t.activity.Mark(t.ID)
 					}
 				}
-				gw, err := buildTenantGateway(conn, gatewayToken, t.log, store, budgetedProvider, tbCap, gwActivity)
+				gw, err := buildTenantGateway(conn, gatewayToken, t.log, store, budgetedProvider, tbCap, gwActivity, wiring.FireWebhook)
 				if err != nil {
 					t.log.Error("skipping web gateway", "err", err)
 					continue
@@ -926,6 +926,25 @@ func (t *Tenant) ServeWS(w http.ResponseWriter, r *http.Request) {
 	// The shared mux routes on `/ws`; rewrite the path the router matched
 	// (`/c/<id>`) to it. Query (the token) is untouched.
 	r.URL.Path = "/ws"
+	gw.Handler().ServeHTTP(w, r)
+}
+
+// ServeHook hands one inbound-webhook request (POST /c/<id>/hook/<name>) to this
+// tenant's live web gateway. The web router calls it after resolving the tenant
+// from the request path. Returns 404 when the tenant has no running gateway
+// (between runs / quarantined / no web shell configured). The gateway's shared
+// handler does the token auth, body cap, and trigger dispatch; the `{name}` path
+// segment the router matched is preserved by rewriting to the gateway's own
+// `/hook/<name>` route so PathValue resolves there.
+func (t *Tenant) ServeHook(w http.ResponseWriter, r *http.Request) {
+	t.mu.Lock()
+	gw := t.gateway
+	t.mu.Unlock()
+	if gw == nil {
+		http.Error(w, "no web shell for tenant", http.StatusNotFound)
+		return
+	}
+	r.URL.Path = "/hook/" + r.PathValue("name")
 	gw.Handler().ServeHTTP(w, r)
 }
 

--- a/internal/server/tenant_gateway.go
+++ b/internal/server/tenant_gateway.go
@@ -30,7 +30,7 @@ const (
 // No Host/Port: the pooled gateway never binds its own listener — the web
 // router serves the shared Handler() per request. No MessageStore: durable
 // pooled scrollback is a follow-up; live streaming works without it.
-func buildTenantGateway(bridge *irc.Connector, token string, log *slog.Logger, store messages.Store, llmProvider llm.Provider, tbSummarizeCap int, onActivity func(reason string)) (*web.Gateway, error) {
+func buildTenantGateway(bridge *irc.Connector, token string, log *slog.Logger, store messages.Store, llmProvider llm.Provider, tbSummarizeCap int, onActivity func(reason string), webhookFire func(name string, bag map[string]string) bool) (*web.Gateway, error) {
 	verifier, err := web.NewStaticPasswordVerifier(token)
 	if err != nil {
 		return nil, fmt.Errorf("gateway verifier: %w", err)
@@ -50,6 +50,9 @@ func buildTenantGateway(bridge *irc.Connector, token string, log *slog.Logger, s
 		// in the pool's coalescing aggregator (same sink the bouncer attach
 		// hook uses) — engaged web session / owner /tb keep it alive.
 		OnActivity: onActivity,
+		// Inbound-webhook ingress: POST /c/<id>/hook/<name> dispatches to this
+		// tenant's flow/skill engines through the live wiring.
+		WebhookFire: webhookFire,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/turborg/turborg/internal/flow"
 	"github.com/turborg/turborg/internal/safe"
 	"github.com/turborg/turborg/internal/skill"
 )
@@ -51,6 +52,10 @@ type TenantSpec struct {
 	// wire is backward-compatible: a legacy command array decodes to
 	// command-kind skills unchanged.
 	Commands []skill.Skill `json:"commands,omitempty"`
+
+	// Flows is the tenant's declarative node-graph flow set, run by the flow
+	// engine on event/match triggers. Ordered; an empty slice means no flows.
+	Flows []flow.Flow `json:"flows,omitempty"`
 
 	// GatewayToken authorizes the per-tenant web shell (the `/ws` surface).
 	// An empty token means "no web shell for this tenant" and the pooled

--- a/internal/server/tenant_source.go
+++ b/internal/server/tenant_source.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/safe"
+	"github.com/turborg/turborg/internal/skill"
 )
 
 // ConnectorSpec describes one connector instance a tenant runs. The Type field
@@ -47,8 +47,10 @@ type TenantSpec struct {
 	// the single-instance runtime carries as TURBORG_COMMANDS). The pooled runtime
 	// swaps it into the agent's registry, and — uniquely — a change to ONLY
 	// this field is applied in place without dropping the IRC connection
-	// (see Tenant.update). Ordered; an empty slice means no commands.
-	Commands []commands.Definition `json:"commands,omitempty"`
+	// (see Tenant.update). Ordered; an empty slice means no commands. The flat
+	// wire is backward-compatible: a legacy command array decodes to
+	// command-kind skills unchanged.
+	Commands []skill.Skill `json:"commands,omitempty"`
 
 	// GatewayToken authorizes the per-tenant web shell (the `/ws` surface).
 	// An empty token means "no web shell for this tenant" and the pooled

--- a/internal/server/tenant_wire_test.go
+++ b/internal/server/tenant_wire_test.go
@@ -7,16 +7,16 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/turborg/turborg/internal/agent"
-	"github.com/turborg/turborg/internal/commands"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/messages"
+	"github.com/turborg/turborg/internal/skill"
 )
 
 // newIRCTenant builds a Tenant whose spec carries one IRC connector with the
 // given extra config keys merged in. No control plane / gateway token, so
 // buildConnectors wires only the connector + shared agent wiring. cmds is the
 // tenant's data-driven command set (with an unrestricted cap for the tests).
-func newIRCTenant(configOverrides map[string]any, caps *PlanCapabilities, cmds ...commands.Definition) *Tenant {
+func newIRCTenant(configOverrides map[string]any, caps *PlanCapabilities, cmds ...skill.Skill) *Tenant {
 	cfg := map[string]any{"network": "irc.example:6697", "nick": "bot"}
 	for k, v := range configOverrides {
 		cfg[k] = v
@@ -45,7 +45,7 @@ func TestBuildConnectorsWiresCommands(t *testing.T) {
 	tn := newIRCTenant(
 		map[string]any{"owner_mode": "self"},
 		&PlanCapabilities{MaxChannels: 3},
-		commands.Definition{Name: "rules", Type: commands.TypeStatic, Template: "be nice", Access: commands.AccessEveryone},
+		skill.Command("rules", skill.TypeStatic, "be nice", skill.AccessEveryone),
 	)
 	a := agent.NewWithPrefix(tn.log, "!")
 	tn.buildConnectors(a)
@@ -64,7 +64,7 @@ func TestBuildConnectorsWiresCommands(t *testing.T) {
 func TestBuildConnectorsOwnerGuardFromConfig(t *testing.T) {
 	tn := newIRCTenant(
 		map[string]any{"owner_mode": "self"}, nil,
-		commands.Definition{Name: "secret", Type: commands.TypeStatic, Template: "shh", Access: commands.AccessOwner},
+		skill.Command("secret", skill.TypeStatic, "shh", skill.AccessOwner),
 	)
 	a := agent.NewWithPrefix(tn.log, "!")
 	tn.buildConnectors(a)
@@ -86,7 +86,7 @@ func TestBuildConnectorsOwnerGuardFromConfig(t *testing.T) {
 func TestBuildConnectorsOwnerGuardDefaultDenies(t *testing.T) {
 	tn := newIRCTenant(
 		nil, nil,
-		commands.Definition{Name: "secret", Type: commands.TypeStatic, Template: "shh", Access: commands.AccessOwner},
+		skill.Command("secret", skill.TypeStatic, "shh", skill.AccessOwner),
 	)
 	a := agent.NewWithPrefix(tn.log, "!")
 	tn.buildConnectors(a)

--- a/internal/server/web_router.go
+++ b/internal/server/web_router.go
@@ -41,6 +41,16 @@ func (s *Server) serveWebGatewayRouter(ctx context.Context, ln net.Listener) err
 			http.Error(w, "no such tenant", http.StatusNotFound)
 		}
 	})
+	// Inbound-webhook ingress: an external system POSTs to /c/<id>/hook/<name>
+	// to fire that tenant's per-flow webhook trigger. The tenant gateway does the
+	// auth + dispatch; an unknown tenant is a 404 with no detail (never leaks
+	// which ids exist), same as the WS route.
+	mux.HandleFunc("POST /c/{turborg_id}/hook/{name}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("turborg_id")
+		if id == "" || !s.RouteHook(id, w, r) {
+			http.Error(w, "no such tenant", http.StatusNotFound)
+		}
+	})
 
 	srv := &http.Server{
 		Handler:           mux,

--- a/internal/server/web_router_test.go
+++ b/internal/server/web_router_test.go
@@ -31,7 +31,7 @@ func liveGatewayTenant(t *testing.T, id, token string) *Tenant {
 		Username: "bot",
 		RealName: "pooled tenant",
 	}, testLogger(), bus)
-	gw, err := buildTenantGateway(conn, token, testLogger(), nil, nil, 0, nil)
+	gw, err := buildTenantGateway(conn, token, testLogger(), nil, nil, 0, nil, nil)
 	require.NoError(t, err)
 	gw.Subscribe(bus)
 	t.Cleanup(gw.Stop)
@@ -144,7 +144,7 @@ func TestWebGatewayRouterUpgradeAndAuth(t *testing.T) {
 // the guard is the StaticPasswordVerifier's, so prove it here.
 func TestBuildTenantGatewayEmptyToken(t *testing.T) {
 	conn := irc.New(&irc.Settings{Hostname: "127.0.0.1", Port: 6667, Nick: "bot"}, testLogger(), nil)
-	_, err := buildTenantGateway(conn, "", testLogger(), nil, nil, 0, nil)
+	_, err := buildTenantGateway(conn, "", testLogger(), nil, nil, 0, nil, nil)
 	require.Error(t, err)
 }
 

--- a/internal/server/webhook_router_test.go
+++ b/internal/server/webhook_router_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/connector/irc"
+)
+
+// liveHookTenant builds a tenant whose web gateway is live and whose inbound
+// webhook dispatches to the supplied fire func — the auth + routing surface the
+// hook ingress adds, without needing an upstream IRC connection.
+func liveHookTenant(t *testing.T, id, token string, fire func(string, map[string]string) bool) *Tenant {
+	t.Helper()
+	bus := agent.NewEventBus(testLogger())
+	conn := irc.New(&irc.Settings{
+		Hostname: "127.0.0.1", Port: 6667, Nick: "bot", Username: "bot", RealName: "pooled tenant",
+	}, testLogger(), bus)
+	gw, err := buildTenantGateway(conn, token, testLogger(), nil, nil, 0, nil, fire)
+	require.NoError(t, err)
+	gw.Subscribe(bus)
+	t.Cleanup(gw.Stop)
+	return &Tenant{ID: id, log: testLogger(), gateway: gw}
+}
+
+// TestRouteHookLookup: RouteHook returns false for an unknown tenant (router
+// 404s), and true for an attached one whose ServeHook answers 404 when it has no
+// live gateway between runs.
+func TestRouteHookLookup(t *testing.T) {
+	s := New(nil, testLogger())
+	s.tenants["known"] = &Tenant{ID: "known", log: testLogger()} // no live gateway
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/c/missing/hook/x?token=x", strings.NewReader("{}"))
+	assert.False(t, s.RouteHook("missing", rec, req), "missing tenant routes false")
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/c/known/hook/x?token=x", strings.NewReader("{}"))
+	assert.True(t, s.RouteHook("known", rec2, req2), "attached tenant routes true")
+	assert.Equal(t, http.StatusNotFound, rec2.Code, "a tenant with no live gateway answers 404")
+}
+
+// TestWebRouterHookEndToEnd drives the pooled route POST /c/<id>/hook/<name>
+// through the real listener: a valid token fires the tenant's dispatcher, a bad
+// token is 401, and an unknown tenant is 404.
+func TestWebRouterHookEndToEnd(t *testing.T) {
+	var mu sync.Mutex
+	var gotName string
+	var gotBag map[string]string
+	fire := func(name string, bag map[string]string) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		gotName, gotBag = name, bag
+		return true
+	}
+
+	s := New(nil, testLogger())
+	s.tenants["alice"] = liveHookTenant(t, "alice", "good-token", fire)
+	addr, stop := startWebRouter(t, s)
+	defer stop()
+
+	// Valid token → 200, dispatcher saw the name + flattened body.
+	resp, err := http.Post("http://"+addr+"/c/alice/hook/deploy?token=good-token",
+		"application/json", strings.NewReader(`{"text":"ship","from":"ci"}`))
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", body)
+	mu.Lock()
+	assert.Equal(t, "deploy", gotName)
+	assert.Equal(t, "ship", gotBag["text"])
+	assert.Equal(t, "ci", gotBag["user"], "{user} seeded from from")
+	mu.Unlock()
+
+	// Bad token → 401.
+	resp2, err := http.Post("http://"+addr+"/c/alice/hook/deploy?token=nope",
+		"application/json", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp2.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+
+	// Unknown tenant → 404.
+	resp3, err := http.Post("http://"+addr+"/c/ghost/hook/deploy?token=good-token",
+		"application/json", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp3.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp3.StatusCode)
+}

--- a/internal/skill/build.go
+++ b/internal/skill/build.go
@@ -1,0 +1,46 @@
+package skill
+
+import (
+	"log/slog"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/commands"
+	"github.com/turborg/turborg/internal/llm"
+)
+
+// GuardFactory builds the per-command guard for a command-kind skill. A nil
+// factory or a nil return means "no per-command guard" (the registry-wide
+// guard still runs).
+type GuardFactory func(Skill) agent.CommandGuard
+
+// Build turns the command-kind skills in the batch into a ReplaceDynamic
+// batch of agent commands, producing the SAME handlers as the historical
+// command builder (it delegates to it per skill, preserving every
+// placeholder, the LLM system-prompt fallback, and the budget-exhausted
+// reply). Non-command skills are ignored here — they belong to the Engine.
+// platform/owner seed the {platform}/{owner} template placeholders.
+func Build(skills []Skill, provider llm.Provider, guardFor GuardFactory, platform, owner string, log *slog.Logger) []agent.DynamicCommand {
+	if log == nil {
+		log = slog.Default()
+	}
+	out := make([]agent.DynamicCommand, 0, len(skills))
+	for _, s := range skills {
+		if !s.IsCommand() {
+			continue
+		}
+		sk := s
+		built := commands.Build(
+			[]commands.Definition{sk.ToDefinition()},
+			provider,
+			func(commands.Definition) agent.CommandGuard {
+				if guardFor != nil {
+					return guardFor(sk)
+				}
+				return nil
+			},
+			platform, owner, log,
+		)
+		out = append(out, built...)
+	}
+	return out
+}

--- a/internal/skill/build_test.go
+++ b/internal/skill/build_test.go
@@ -1,0 +1,56 @@
+package skill
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+)
+
+func TestBuildOnlyCommandSkills(t *testing.T) {
+	skills := []Skill{
+		Command("rules", TypeStatic, "be nice {nick}", AccessEveryone),
+		{Name: "greet", Trigger: Trigger{Kind: KindEvent, Event: EventUserJoin}, Action: Action{Type: TypeStatic, Template: "hi"}},
+		{Name: "flood", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeEffect}},
+	}
+	built := Build(skills, nil, nil, "", "", nil)
+	require.Len(t, built, 1, "only the command-kind skill becomes a command handler")
+	assert.Equal(t, "rules", built[0].Name)
+
+	env := agent.NewInbound("irc", "#c", "alice", "!rules")
+	out, err := built[0].Handler(context.Background(), env, nil)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	assert.Equal(t, "be nice alice", out.Text)
+}
+
+func TestBuildAppliesGuardFactory(t *testing.T) {
+	var seen []string
+	guardFor := func(s Skill) agent.CommandGuard {
+		seen = append(seen, s.Name)
+		return func(env *agent.InboundEnvelope) bool { return env.Sender == "owner" }
+	}
+	built := Build([]Skill{Command("x", TypeStatic, "ok", AccessOwner)}, nil, guardFor, "", "", nil)
+	require.Len(t, built, 1)
+	require.Equal(t, []string{"x"}, seen)
+	require.NotNil(t, built[0].Guard)
+	assert.True(t, built[0].Guard(&agent.InboundEnvelope{Sender: "owner"}))
+	assert.False(t, built[0].Guard(&agent.InboundEnvelope{Sender: "nobody"}))
+}
+
+func TestBuildSkipsLLMWithoutProvider(t *testing.T) {
+	built := Build([]Skill{Command("ask", TypeLLM, "{args}", AccessOwner)}, nil, nil, "", "", nil)
+	assert.Empty(t, built, "an llm command with no provider is skipped")
+}
+
+func TestBuildLLMWithProvider(t *testing.T) {
+	prov := &fakeProvider{resp: "the answer"}
+	built := Build([]Skill{Command("ask", TypeLLM, "Q: {args}", AccessOwner)}, prov, nil, "", "", nil)
+	require.Len(t, built, 1)
+	out, err := built[0].Handler(context.Background(), agent.NewInbound("irc", "#c", "u", "!ask why"), []string{"why"})
+	require.NoError(t, err)
+	assert.Equal(t, "the answer", out.Text)
+	assert.Equal(t, "Q: why", prov.lastPrompt())
+}

--- a/internal/skill/coverage_test.go
+++ b/internal/skill/coverage_test.go
@@ -3,6 +3,7 @@ package skill
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,14 +30,23 @@ func (erroringActor) Invite(string, string) error             { return errors.Ne
 func (erroringActor) SetMode(string, string, ...string) error { return errors.New("boom") }
 
 func TestDefaultPostSuccessAndError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var gotMethod string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	require.NoError(t, defaultPost(context.Background(), srv.URL, []byte(`{}`)))
+	require.NoError(t, defaultPost(context.Background(), "", srv.URL, []byte(`{}`)))
+	assert.Equal(t, http.MethodPost, gotMethod, "empty method defaults to POST")
+	// A GET carries no body.
+	require.NoError(t, defaultPost(context.Background(), http.MethodGet, srv.URL, []byte(`{"x":1}`)))
+	assert.Equal(t, http.MethodGet, gotMethod)
+	assert.Empty(t, gotBody, "GET sends no body")
 
-	require.Error(t, defaultPost(context.Background(), "http://127.0.0.1:0/nope", []byte(`{}`)))
-	require.Error(t, defaultPost(context.Background(), "://bad-url", []byte(`{}`)))
+	require.Error(t, defaultPost(context.Background(), http.MethodPost, "http://127.0.0.1:0/nope", []byte(`{}`)))
+	require.Error(t, defaultPost(context.Background(), http.MethodPost, "://bad-url", []byte(`{}`)))
 }
 
 func TestDoWebhookEmptyURLAndError(t *testing.T) {
@@ -51,7 +61,7 @@ func TestDoWebhookEmptyURLAndError(t *testing.T) {
 
 	// Post error path is logged, not fatal.
 	called := false
-	e2, bus2 := newEngine(t, Options{Post: func(context.Context, string, []byte) error {
+	e2, bus2 := newEngine(t, Options{Post: func(context.Context, string, string, []byte) error {
 		called = true
 		return errors.New("down")
 	}})

--- a/internal/skill/coverage_test.go
+++ b/internal/skill/coverage_test.go
@@ -1,0 +1,214 @@
+package skill
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/llm"
+)
+
+// erroringActor returns an error from every method so the engine's error
+// branches are exercised.
+type erroringActor struct{}
+
+func (erroringActor) Say(string, string) error                { return errors.New("boom") }
+func (erroringActor) Notice(string, string) error             { return errors.New("boom") }
+func (erroringActor) Kick(string, string, string) error       { return errors.New("boom") }
+func (erroringActor) Ban(string, string) error                { return errors.New("boom") }
+func (erroringActor) Op(string, string) error                 { return errors.New("boom") }
+func (erroringActor) Voice(string, string) error              { return errors.New("boom") }
+func (erroringActor) Topic(string, string) error              { return errors.New("boom") }
+func (erroringActor) Invite(string, string) error             { return errors.New("boom") }
+func (erroringActor) SetMode(string, string, ...string) error { return errors.New("boom") }
+
+func TestDefaultPostSuccessAndError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	require.NoError(t, defaultPost(context.Background(), srv.URL, []byte(`{}`)))
+
+	require.Error(t, defaultPost(context.Background(), "http://127.0.0.1:0/nope", []byte(`{}`)))
+	require.Error(t, defaultPost(context.Background(), "://bad-url", []byte(`{}`)))
+}
+
+func TestDoWebhookEmptyURLAndError(t *testing.T) {
+	// Empty URL → no-op (no panic).
+	e, bus := newEngine(t, Options{})
+	e.ReplaceSkills([]Skill{{
+		Name:    "noop",
+		Trigger: Trigger{Kind: KindMatch, Match: ".*"},
+		Action:  Action{Type: TypeWebhook},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x")) // must not panic
+
+	// Post error path is logged, not fatal.
+	called := false
+	e2, bus2 := newEngine(t, Options{Post: func(context.Context, string, []byte) error {
+		called = true
+		return errors.New("down")
+	}})
+	e2.ReplaceSkills([]Skill{{
+		Name:    "w",
+		Trigger: Trigger{Kind: KindMatch, Match: ".*"},
+		Action:  Action{Type: TypeWebhook, Webhook: "http://x"},
+	}})
+	bus2.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.True(t, called)
+}
+
+func TestDoReplyEdgeCases(t *testing.T) {
+	// Nil actor → no-op.
+	e, bus := newEngine(t, Options{})
+	e.ReplaceSkills([]Skill{{Name: "r", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeStatic, Template: "hi"}}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x")) // no panic
+
+	// Empty rendered text → no Say.
+	act := &fakeActor{}
+	e2, bus2 := newEngine(t, Options{Actor: act})
+	e2.ReplaceSkills([]Skill{{Name: "blank", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeStatic, Template: "   "}}})
+	bus2.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot())
+
+	// Actor error → logged, not fatal.
+	e3, bus3 := newEngine(t, Options{Actor: erroringActor{}})
+	e3.ReplaceSkills([]Skill{{Name: "e", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeStatic, Template: "hi"}}})
+	bus3.Publish(context.Background(), msgEvent("#r", "u", "x"))
+}
+
+func TestDoLLMEdgeCases(t *testing.T) {
+	// No provider → no-op.
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{Name: "ai", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeLLM, Template: "x"}}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot())
+
+	// Empty template falls back to the message text as the prompt.
+	prov := &fakeProvider{resp: "ok"}
+	act2 := &fakeActor{}
+	e2, bus2 := newEngine(t, Options{Actor: act2, Provider: prov})
+	e2.ReplaceSkills([]Skill{{Name: "ai", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeLLM, Template: "  ", Model: "m1"}}})
+	bus2.Publish(context.Background(), msgEvent("#r", "u", "the message"))
+	assert.Equal(t, "the message", prov.lastPrompt())
+	assert.Equal(t, []string{"say #r ok"}, act2.snapshot())
+
+	// Empty response → no Say.
+	prov3 := &fakeProvider{resp: "   "}
+	act3 := &fakeActor{}
+	e3, bus3 := newEngine(t, Options{Actor: act3, Provider: prov3})
+	e3.ReplaceSkills([]Skill{{Name: "ai", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeLLM, Template: "x"}}})
+	bus3.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act3.snapshot())
+
+	// Provider error → no Say, no crash.
+	prov4 := &fakeProvider{err: errors.New("rate limited")}
+	act4 := &fakeActor{}
+	e4, bus4 := newEngine(t, Options{Actor: act4, Provider: prov4})
+	e4.ReplaceSkills([]Skill{{Name: "ai", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeLLM, Template: "x"}}})
+	bus4.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act4.snapshot())
+}
+
+func TestDoLLMBudgetExhausted(t *testing.T) {
+	prov := &fakeProvider{err: llm.ErrBudgetExhausted}
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act, Provider: prov})
+	e.ReplaceSkills([]Skill{{Name: "ai", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeLLM, Template: "x"}}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot(), "budget exhausted degrades silently")
+}
+
+func TestDoClassifyWithModelOverrideAndInstructions(t *testing.T) {
+	prov := &fakeProvider{resp: `{"severity":2,"action":"mute","reason":"r"}`}
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act, Provider: prov})
+	e.ReplaceSkills([]Skill{{
+		Name:    "mod",
+		Trigger: Trigger{Kind: KindMatch, Match: ".*"},
+		Action:  Action{Type: TypeLLMClassify, Instructions: "house rules", Model: "guard-1", Effect: &Effect{Thresholds: &Thresholds{Mute: 2}}},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Equal(t, []string{"mode #r +q u"}, act.snapshot())
+	assert.Contains(t, prov.system, "house rules")
+}
+
+func TestDoClassifyNoThresholds(t *testing.T) {
+	prov := &fakeProvider{resp: `{"severity":3}`}
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act, Provider: prov})
+	e.ReplaceSkills([]Skill{{
+		Name:    "mod",
+		Trigger: Trigger{Kind: KindMatch, Match: ".*"},
+		Action:  Action{Type: TypeLLMClassify, Effect: &Effect{}}, // no thresholds → nothing
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot())
+}
+
+func TestFireUnknownActionType(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{Name: "weird", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: "mystery"}}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot())
+}
+
+func TestApplyEffectNilActorAndEmptyChannel(t *testing.T) {
+	// Nil actor → applyEffect returns early (no panic).
+	e, bus := newEngine(t, Options{})
+	e.ReplaceSkills([]Skill{{Name: "k", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeEffect, Effect: &Effect{Action: EffectKick}}}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+
+	// Event with no channel (nick change) → applyEffect no-op on empty channel.
+	act := &fakeActor{}
+	e2 := NewEngine(Options{Actor: act, MaxSkills: -1})
+	bus2 := agent.NewEventBus(nil)
+	e2.Subscribe(bus2)
+	e2.ReplaceSkills([]Skill{{Name: "k", Trigger: Trigger{Kind: KindEvent, Event: EventUserNickChange}, Action: Action{Type: TypeEffect, Effect: &Effect{Action: EffectKick}}}})
+	bus2.Publish(context.Background(), &agent.Event{Type: agent.EventUserNickChange, Fields: map[string]any{"old": "a", "new": "b"}})
+	assert.Empty(t, act.snapshot())
+}
+
+func TestOnUserEventNoEventSkills(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	// Only a match skill installed; a user event must early-return.
+	e.ReplaceSkills([]Skill{{Name: "m", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeStatic, Template: "x"}}})
+	bus.Publish(context.Background(), &agent.Event{Type: agent.EventTopicChanged, Fields: map[string]any{"channel": "#r", "by": "u"}})
+	assert.Empty(t, act.snapshot())
+}
+
+func TestSchedulerTickCronAdvance(t *testing.T) {
+	act := &fakeActor{}
+	s := NewScheduler(NewEngine(Options{Actor: act}), nil)
+	base := time.Date(2026, 1, 1, 10, 1, 0, 0, time.UTC)
+	s.now = func() time.Time { return base }
+	s.ReplaceSkills([]Skill{{
+		Name:    "cron",
+		Trigger: Trigger{Kind: KindSchedule, Schedule: "*/5 * * * *", Channels: []string{"#r"}},
+		Action:  Action{Type: TypeStatic, Template: "tick"},
+	}})
+	// nextDue is 10:05 → tick at 10:06 fires and advances to 10:10.
+	s.tick(context.Background(), time.Date(2026, 1, 1, 10, 6, 0, 0, time.UTC))
+	assert.Equal(t, []string{"say #r tick"}, act.snapshot())
+	s.mu.Lock()
+	next := s.items[0].nextDue
+	s.mu.Unlock()
+	assert.Equal(t, time.Date(2026, 1, 1, 10, 10, 0, 0, time.UTC), next)
+}
+
+func TestPublishModerationNilBus(t *testing.T) {
+	// An engine that was never Subscribed has a nil bus; publishModeration must
+	// not panic.
+	e := NewEngine(Options{Actor: &fakeActor{}, MaxSkills: -1})
+	e.ReplaceSkills([]Skill{{Name: "k", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeEffect, Effect: &Effect{Action: EffectKick}}}})
+	e.onMessage(context.Background(), msgEvent("#r", "u", "x"))
+}

--- a/internal/skill/cron.go
+++ b/internal/skill/cron.go
@@ -1,0 +1,129 @@
+package skill
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cronSpec is a parsed 5-field cron expression (minute hour day-of-month
+// month day-of-week), evaluated in UTC. It supports "*", numbers, comma lists,
+// "a-b" ranges, and "*/n" / "a-b/n" steps — enough for the common cadences
+// without a third-party dependency.
+type cronSpec struct {
+	minute  fieldSet
+	hour    fieldSet
+	dom     fieldSet
+	month   fieldSet
+	dow     fieldSet
+	domStar bool // day-of-month was "*"
+	dowStar bool // day-of-week was "*"
+}
+
+// fieldSet is the set of permitted values for one cron field.
+type fieldSet map[int]struct{}
+
+func (f fieldSet) has(v int) bool { _, ok := f[v]; return ok }
+
+// parseCron parses a 5-field cron expression.
+func parseCron(spec string) (*cronSpec, error) {
+	fields := strings.Fields(spec)
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("cron: want 5 fields, got %d", len(fields))
+	}
+	c := &cronSpec{domStar: fields[2] == "*", dowStar: fields[4] == "*"}
+	var err error
+	if c.minute, err = parseField(fields[0], 0, 59); err != nil {
+		return nil, fmt.Errorf("cron minute: %w", err)
+	}
+	if c.hour, err = parseField(fields[1], 0, 23); err != nil {
+		return nil, fmt.Errorf("cron hour: %w", err)
+	}
+	if c.dom, err = parseField(fields[2], 1, 31); err != nil {
+		return nil, fmt.Errorf("cron day-of-month: %w", err)
+	}
+	if c.month, err = parseField(fields[3], 1, 12); err != nil {
+		return nil, fmt.Errorf("cron month: %w", err)
+	}
+	if c.dow, err = parseField(fields[4], 0, 6); err != nil {
+		return nil, fmt.Errorf("cron day-of-week: %w", err)
+	}
+	return c, nil
+}
+
+// parseField parses one cron field into the set of values it permits.
+func parseField(field string, lo, hi int) (fieldSet, error) {
+	out := fieldSet{}
+	for _, part := range strings.Split(field, ",") {
+		rng := part
+		step := 1
+		if slash := strings.IndexByte(part, '/'); slash >= 0 {
+			s, err := strconv.Atoi(part[slash+1:])
+			if err != nil || s < 1 {
+				return nil, fmt.Errorf("bad step %q", part)
+			}
+			step = s
+			rng = part[:slash]
+		}
+		start, end := lo, hi
+		switch {
+		case rng == "*":
+			// full range
+		case strings.ContainsRune(rng, '-'):
+			ab := strings.SplitN(rng, "-", 2)
+			a, err1 := strconv.Atoi(ab[0])
+			b, err2 := strconv.Atoi(ab[1])
+			if err1 != nil || err2 != nil {
+				return nil, fmt.Errorf("bad range %q", part)
+			}
+			start, end = a, b
+		default:
+			v, err := strconv.Atoi(rng)
+			if err != nil {
+				return nil, fmt.Errorf("bad value %q", part)
+			}
+			start, end = v, v
+		}
+		if start < lo || end > hi || start > end {
+			return nil, fmt.Errorf("field %q out of range [%d,%d]", part, lo, hi)
+		}
+		for v := start; v <= end; v += step {
+			out[v] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("empty field")
+	}
+	return out, nil
+}
+
+// next returns the earliest minute strictly after `from` that the spec
+// matches, evaluated in UTC. It scans minute-by-minute up to a bounded
+// horizon (~366 days) so a never-matching spec returns a far-future time
+// rather than looping forever.
+func (c *cronSpec) next(from time.Time) time.Time {
+	t := from.UTC().Truncate(time.Minute).Add(time.Minute)
+	limit := t.AddDate(1, 0, 1)
+	for ; t.Before(limit); t = t.Add(time.Minute) {
+		if c.matches(t) {
+			return t
+		}
+	}
+	return limit
+}
+
+// matches reports whether t satisfies the spec. Per cron convention, when both
+// day-of-month and day-of-week are restricted (neither is "*"), a match on
+// either is sufficient; otherwise both restricted fields must match.
+func (c *cronSpec) matches(t time.Time) bool {
+	if !c.minute.has(t.Minute()) || !c.hour.has(t.Hour()) || !c.month.has(int(t.Month())) {
+		return false
+	}
+	domOK := c.dom.has(t.Day())
+	dowOK := c.dow.has(int(t.Weekday()))
+	if !c.domStar && !c.dowStar {
+		return domOK || dowOK
+	}
+	return domOK && dowOK
+}

--- a/internal/skill/cron_test.go
+++ b/internal/skill/cron_test.go
@@ -1,0 +1,59 @@
+package skill
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCronErrors(t *testing.T) {
+	for _, spec := range []string{
+		"* * * *",     // too few fields
+		"60 * * * *",  // minute out of range
+		"* 24 * * *",  // hour out of range
+		"a * * * *",   // non-numeric
+		"*/0 * * * *", // bad step
+		"5-1 * * * *", // reversed range
+		"1- * * * *",  // bad range
+	} {
+		_, err := parseCron(spec)
+		require.Error(t, err, "spec %q must fail", spec)
+	}
+}
+
+func TestParseCronNextEveryFiveMinutes(t *testing.T) {
+	c, err := parseCron("*/5 * * * *")
+	require.NoError(t, err)
+	from := time.Date(2026, 1, 1, 10, 2, 30, 0, time.UTC)
+	got := c.next(from)
+	assert.Equal(t, time.Date(2026, 1, 1, 10, 5, 0, 0, time.UTC), got)
+}
+
+func TestParseCronNextDailyAtHour(t *testing.T) {
+	c, err := parseCron("0 9 * * *")
+	require.NoError(t, err)
+	from := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	got := c.next(from)
+	assert.Equal(t, time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC), got)
+}
+
+func TestParseCronListAndRange(t *testing.T) {
+	c, err := parseCron("0,30 9-17 * * 1-5")
+	require.NoError(t, err)
+	// Saturday 2026-01-03 10:05 → next is Monday 2026-01-05 09:00.
+	from := time.Date(2026, 1, 3, 10, 5, 0, 0, time.UTC)
+	got := c.next(from)
+	assert.Equal(t, time.Date(2026, 1, 5, 9, 0, 0, 0, time.UTC), got)
+}
+
+func TestCronMatchesDomOrDow(t *testing.T) {
+	// Both dom and dow restricted → match on either (cron convention).
+	c, err := parseCron("0 0 1 * 1")
+	require.NoError(t, err)
+	// 2026-06-01 is a Monday → matches via both. Pick a plain Monday.
+	assert.True(t, c.matches(time.Date(2026, 6, 8, 0, 0, 0, 0, time.UTC)), "a Monday matches via dow")
+	assert.True(t, c.matches(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)), "the 1st matches via dom")
+	assert.False(t, c.matches(time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)), "a non-1st Tuesday matches neither")
+}

--- a/internal/skill/engine.go
+++ b/internal/skill/engine.go
@@ -58,7 +58,10 @@ type Engine struct {
 	maxSkills int
 	events    []compiled
 	matches   []compiled
-	bus       *agent.EventBus
+	// webhooks indexes inbound-webhook-trigger skills by lowercased name so
+	// FireWebhook can dispatch an external POST in O(1) without leaking the set.
+	webhooks map[string]compiled
+	bus      *agent.EventBus
 
 	// Timed-effect reversals: applied modes that auto-lift after a duration.
 	// Persisted via the Store so they resume across restarts.
@@ -146,6 +149,7 @@ func (e *Engine) SetMaxSkills(n int) {
 // The MaxSkills cap is enforced as a safety net.
 func (e *Engine) ReplaceSkills(skills []Skill) {
 	var events, matches []compiled
+	webhooks := map[string]compiled{}
 	e.mu.RLock()
 	limit := e.maxSkills
 	e.mu.RUnlock()
@@ -171,6 +175,14 @@ func (e *Engine) ReplaceSkills(skills []Skill) {
 			}
 			events = append(events, compiled{skill: s, channels: channelSet(s.Trigger.Channels)})
 			installed++
+		case KindWebhook:
+			key := strings.ToLower(strings.TrimSpace(s.Name))
+			if key == "" {
+				e.log.Warn("skipping webhook skill: empty name")
+				continue
+			}
+			webhooks[key] = compiled{skill: s, channels: channelSet(s.Trigger.Channels)}
+			installed++
 		default:
 			// command / schedule kinds are not the Engine's concern.
 		}
@@ -179,7 +191,48 @@ func (e *Engine) ReplaceSkills(skills []Skill) {
 	e.mu.Lock()
 	e.events = events
 	e.matches = matches
+	e.webhooks = webhooks
 	e.mu.Unlock()
+}
+
+// FireWebhook dispatches an inbound webhook to the skill whose webhook trigger
+// matches name (case-insensitive), seeding the render context from bag. It
+// returns true when a matching webhook skill fired, false when no skill carries
+// that name — the ingress handler maps false onto a 404 with no detail, so a
+// caller can't enumerate the installed set. The firing channel is the trigger's
+// first scoped channel when set, else the bag's "channel" field.
+func (e *Engine) FireWebhook(name string, bag map[string]string) bool {
+	e.mu.RLock()
+	c, ok := e.webhooks[strings.ToLower(strings.TrimSpace(name))]
+	e.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	f := fieldsFromBag(bag)
+	if chans := c.skill.Trigger.Channels; len(chans) > 0 {
+		f.channel = chans[0]
+	}
+	f.platform = e.platform
+	f.owner = e.owner
+	e.fire(context.Background(), c.skill, f)
+	return true
+}
+
+// fieldsFromBag maps a flat webhook bag onto the render fields a skill template
+// can reference. Only the recognized keys are lifted; the full body remains
+// available to callers that seeded it into the bag.
+func fieldsFromBag(bag map[string]string) renderFields {
+	return renderFields{
+		user:    bag["user"],
+		channel: bag["channel"],
+		text:    bag["text"],
+		target:  bag["target"],
+		reason:  bag["reason"],
+		topic:   bag["topic"],
+		modes:   bag["modes"],
+		oldNick: bag["old"],
+		newNick: bag["new"],
+	}
 }
 
 // Subscribe wires the engine onto the agent's EventBus: inbound messages drive

--- a/internal/skill/engine.go
+++ b/internal/skill/engine.go
@@ -1,0 +1,598 @@
+package skill
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/llm"
+)
+
+// webhookTimeout bounds a single outbound webhook POST so a slow endpoint
+// can't stall the engine.
+const webhookTimeout = 5 * time.Second
+
+// PostFunc posts a JSON payload to a URL. It is the seam external flow engines
+// (n8n and the like) plug into; the default uses net/http and tests substitute
+// a recorder.
+type PostFunc func(ctx context.Context, url string, payload []byte) error
+
+// floodWindow is the sliding window over which an effect skill with severity
+// thresholds counts a sender's messages. Kept a package constant — operators
+// tune the action via the threshold counts, not the window.
+const floodWindow = 10 * time.Second
+
+// classifyMaxTokens caps an llm_classify verdict — a tiny JSON object.
+const classifyMaxTokens = 128
+
+// classifySystemPrompt steers an llm_classify action toward a compact,
+// machine-parseable verdict.
+const classifySystemPrompt = "You are a chat moderation classifier. Reply with ONLY a compact JSON " +
+	"object and nothing else: {\"severity\":N,\"action\":\"...\",\"reason\":\"...\"} where severity is an " +
+	"integer 0-3 (0 harmless, 3 severe), and action is one of none|warn|mute|kick|ban. No prose."
+
+// Engine runs the event/match skills: it subscribes to the agent's EventBus,
+// tests each inbound message (match) and lifecycle event (event) against its
+// skills, and executes the matching skill's action via the connector-agnostic
+// Actor or the LLM provider. The skill set is hot-swappable (ReplaceSkills)
+// under a write lock, mirroring CommandRegistry.ReplaceDynamic semantics with
+// a MaxSkills cap.
+type Engine struct {
+	actor    agent.Actor
+	provider llm.Provider
+	store    Store
+	post     PostFunc
+	platform string
+	owner    string
+	log      *slog.Logger
+
+	mu        sync.RWMutex
+	maxSkills int
+	events    []compiled
+	matches   []compiled
+	bus       *agent.EventBus
+}
+
+// compiled is a runtime-ready skill: the definition plus the compiled match
+// regex (match kind only) and a normalized channel-scope set.
+type compiled struct {
+	skill    Skill
+	re       *regexp.Regexp
+	channels map[string]struct{} // nil = all channels
+}
+
+// Options configures an Engine. A nil Store defaults to an in-process one; a
+// nil Actor/Provider degrades the corresponding actions to no-ops gracefully.
+type Options struct {
+	Actor     agent.Actor
+	Provider  llm.Provider
+	Store     Store
+	Platform  string
+	Owner     string
+	MaxSkills int
+	// Post overrides the outbound webhook poster. Nil uses a net/http default.
+	Post PostFunc
+	Log  *slog.Logger
+}
+
+// NewEngine builds an Engine. It holds no skills until ReplaceSkills is called.
+func NewEngine(o Options) *Engine {
+	log := o.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	store := o.Store
+	if store == nil {
+		store = NewMemoryStore()
+	}
+	post := o.Post
+	if post == nil {
+		post = defaultPost
+	}
+	return &Engine{
+		actor:     o.Actor,
+		provider:  o.Provider,
+		store:     store,
+		post:      post,
+		platform:  o.Platform,
+		owner:     o.Owner,
+		log:       log.With("component", "skill-engine"),
+		maxSkills: o.MaxSkills,
+	}
+}
+
+// defaultPost POSTs payload as application/json with a bounded timeout.
+func defaultPost(ctx context.Context, url string, payload []byte) error {
+	ctx, cancel := context.WithTimeout(ctx, webhookTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
+}
+
+// SetMaxSkills caps how many engine skills ReplaceSkills installs: 0 = none
+// (default), -1 = unrestricted, N = at most N. Mirrors the command registry's
+// MaxDynamic cap.
+func (e *Engine) SetMaxSkills(n int) {
+	e.mu.Lock()
+	e.maxSkills = n
+	e.mu.Unlock()
+}
+
+// ReplaceSkills atomically swaps the engine's event/match skill set for the
+// given batch (command and schedule kinds are ignored). A skill with an
+// invalid match regex or an unknown event name is dropped with a log line.
+// The MaxSkills cap is enforced as a safety net.
+func (e *Engine) ReplaceSkills(skills []Skill) {
+	var events, matches []compiled
+	e.mu.RLock()
+	limit := e.maxSkills
+	e.mu.RUnlock()
+
+	installed := 0
+	for _, s := range skills {
+		if limit != -1 && installed >= limit {
+			break
+		}
+		switch s.Trigger.Kind {
+		case KindMatch:
+			re, err := regexp.Compile(s.Trigger.Match)
+			if err != nil {
+				e.log.Warn("skipping match skill: bad regex", "skill", s.Name, "err", err)
+				continue
+			}
+			matches = append(matches, compiled{skill: s, re: re, channels: channelSet(s.Trigger.Channels)})
+			installed++
+		case KindEvent:
+			if !validEvent(s.Trigger.Event) {
+				e.log.Warn("skipping event skill: unknown event", "skill", s.Name, "event", s.Trigger.Event)
+				continue
+			}
+			events = append(events, compiled{skill: s, channels: channelSet(s.Trigger.Channels)})
+			installed++
+		default:
+			// command / schedule kinds are not the Engine's concern.
+		}
+	}
+
+	e.mu.Lock()
+	e.events = events
+	e.matches = matches
+	e.mu.Unlock()
+}
+
+// Subscribe wires the engine onto the agent's EventBus: inbound messages drive
+// match skills and the user-event types drive event skills. Call once.
+func (e *Engine) Subscribe(bus *agent.EventBus) {
+	e.mu.Lock()
+	e.bus = bus
+	e.mu.Unlock()
+	bus.Subscribe(agent.EventMessage, e.onMessage)
+	for _, t := range []agent.EventType{
+		agent.EventUserJoin, agent.EventUserLeave, agent.EventUserKicked,
+		agent.EventUserNickChange, agent.EventTopicChanged, agent.EventModeChanged,
+	} {
+		bus.Subscribe(t, e.onUserEvent)
+	}
+}
+
+func (e *Engine) onMessage(ctx context.Context, ev *agent.Event) {
+	env, ok := ev.Fields["envelope"].(*agent.InboundEnvelope)
+	if !ok || env == nil {
+		return
+	}
+	e.mu.RLock()
+	matches := e.matches
+	e.mu.RUnlock()
+	if len(matches) == 0 {
+		return
+	}
+	f := renderFields{
+		user:     env.Sender,
+		channel:  env.Channel,
+		text:     env.Text,
+		platform: e.platform,
+		owner:    e.owner,
+	}
+	for _, m := range matches {
+		if !channelAllowed(m.channels, env.Channel) {
+			continue
+		}
+		if m.re != nil && !m.re.MatchString(env.Text) {
+			continue
+		}
+		e.fire(ctx, m.skill, f)
+	}
+}
+
+func (e *Engine) onUserEvent(ctx context.Context, ev *agent.Event) {
+	e.mu.RLock()
+	events := e.events
+	e.mu.RUnlock()
+	if len(events) == 0 {
+		return
+	}
+	name := string(ev.Type)
+	f := fieldsFromEvent(ev)
+	f.platform = e.platform
+	f.owner = e.owner
+	for _, m := range events {
+		if m.skill.Trigger.Event != name {
+			continue
+		}
+		if !channelAllowed(m.channels, f.channel) {
+			continue
+		}
+		e.fire(ctx, m.skill, f)
+	}
+}
+
+// fire executes a skill's action against the rendered fields.
+func (e *Engine) fire(ctx context.Context, s Skill, f renderFields) {
+	switch s.Action.Type {
+	case TypeStatic:
+		e.doReply(s, f)
+	case TypeLLM:
+		e.doLLM(ctx, s, f)
+	case TypeEffect:
+		e.doEffect(ctx, s, f)
+	case TypeLLMClassify:
+		e.doClassify(ctx, s, f)
+	case TypeWebhook:
+		e.doWebhook(ctx, s, f)
+	default:
+		e.log.Warn("skill has unknown action type", "skill", s.Name, "type", s.Action.Type)
+	}
+}
+
+// doWebhook POSTs the trigger context (plus the rendered template as "message")
+// as JSON to the skill's webhook URL — the bridge to external flow engines.
+func (e *Engine) doWebhook(ctx context.Context, s Skill, f renderFields) {
+	if s.Action.Webhook == "" {
+		return
+	}
+	payload, err := json.Marshal(map[string]any{
+		"skill":    s.Name,
+		"trigger":  string(s.Trigger.Kind),
+		"event":    s.Trigger.Event,
+		"channel":  f.channel,
+		"user":     f.user,
+		"text":     f.text,
+		"target":   f.target,
+		"reason":   f.reason,
+		"topic":    f.topic,
+		"modes":    f.modes,
+		"old":      f.oldNick,
+		"new":      f.newNick,
+		"platform": f.platform,
+		"message":  e.renderTmpl(s.Name, s.Action.Template, f),
+	})
+	if err != nil {
+		return
+	}
+	if err := e.post(ctx, s.Action.Webhook, payload); err != nil {
+		e.log.Warn("skill webhook failed", "skill", s.Name, "err", err)
+	}
+}
+
+// doReply renders the template and sends it to the channel. Empty channel or
+// empty rendered text is a no-op.
+func (e *Engine) doReply(s Skill, f renderFields) {
+	if e.actor == nil || f.channel == "" {
+		return
+	}
+	text := strings.TrimSpace(e.renderTmpl(s.Name, s.Action.Template, f))
+	if text == "" {
+		return
+	}
+	if err := e.actor.Say(f.channel, text); err != nil {
+		e.log.Warn("skill reply failed", "skill", s.Name, "err", err)
+	}
+}
+
+func (e *Engine) doLLM(ctx context.Context, s Skill, f renderFields) {
+	if e.provider == nil || e.actor == nil || f.channel == "" {
+		return
+	}
+	prompt := e.renderTmpl(s.Name, s.Action.Template, f)
+	if strings.TrimSpace(prompt) == "" {
+		prompt = f.text
+	}
+	system := strings.TrimSpace(s.Action.Instructions)
+	opts := []llm.CallOption{llm.WithMaxTokens(classifyMaxTokens * 4)}
+	if system != "" {
+		opts = append(opts, llm.WithSystem(system))
+	}
+	if s.Action.Model != "" {
+		opts = append(opts, llm.WithModel(s.Action.Model))
+	}
+	answer, _, err := e.provider.Ask(ctx, prompt, opts...)
+	if err != nil {
+		if !errors.Is(err, llm.ErrBudgetExhausted) {
+			e.log.Warn("skill llm failed", "skill", s.Name, "err", err)
+		}
+		return
+	}
+	answer = strings.Join(strings.Fields(answer), " ")
+	if answer == "" {
+		return
+	}
+	if err := e.actor.Say(f.channel, answer); err != nil {
+		e.log.Warn("skill reply failed", "skill", s.Name, "err", err)
+	}
+}
+
+// doEffect runs a moderation effect. With effect thresholds it is a flood gate
+// keyed off a per-sender sliding-window message count; without thresholds it
+// runs the effect's action directly.
+func (e *Engine) doEffect(ctx context.Context, s Skill, f renderFields) {
+	eff := s.Action.Effect
+	if eff == nil {
+		return
+	}
+	act := eff.Action
+	if eff.Thresholds != nil {
+		count, _ := e.store.Incr(s.Name, strings.ToLower(f.user), floodWindow)
+		f.count = count
+		act = actionForSeverity(count, eff.Thresholds)
+		if act == "" {
+			return
+		}
+	}
+	e.applyEffect(ctx, s, f, eff, act)
+}
+
+func (e *Engine) doClassify(ctx context.Context, s Skill, f renderFields) {
+	eff := s.Action.Effect
+	if eff == nil || eff.Thresholds == nil {
+		return
+	}
+	// Degrade gracefully to no action when the LLM is unavailable: the regex
+	// prefilter already matched, but classification (and therefore any
+	// punitive effect) requires the model — fail safe rather than guess.
+	if e.provider == nil {
+		return
+	}
+	system := classifySystemPrompt
+	if instr := strings.TrimSpace(s.Action.Instructions); instr != "" {
+		system = instr + "\n" + classifySystemPrompt
+	}
+	opts := []llm.CallOption{llm.WithSystem(system), llm.WithMaxTokens(classifyMaxTokens)}
+	if s.Action.Model != "" {
+		opts = append(opts, llm.WithModel(s.Action.Model))
+	}
+	answer, _, err := e.provider.Ask(ctx, f.text, opts...)
+	if err != nil {
+		// Budget exhausted (or any provider error) degrades to no action.
+		if !errors.Is(err, llm.ErrBudgetExhausted) {
+			e.log.Warn("skill classify failed", "skill", s.Name, "err", err)
+		}
+		return
+	}
+	verdict, ok := parseVerdict(answer)
+	if !ok {
+		e.log.Debug("skill classify: unparseable verdict", "skill", s.Name)
+		return
+	}
+	f.reason = verdict.Reason
+	act := actionForSeverity(verdict.Severity, eff.Thresholds)
+	if act == "" {
+		return
+	}
+	e.applyEffect(ctx, s, f, eff, act)
+}
+
+// applyEffect performs a single resolved moderation action via the Actor and
+// emits an audit MODERATION event.
+func (e *Engine) applyEffect(ctx context.Context, s Skill, f renderFields, eff *Effect, act EffectAction) {
+	if e.actor == nil || f.channel == "" {
+		return
+	}
+	// The offender is the acting user for message/effect triggers, or the
+	// affected target for events that name one (kick/nick-change).
+	offender := f.user
+	if f.target != "" {
+		offender = f.target
+	}
+	reason := eff.Reason
+	if reason != "" {
+		reason = e.renderTmpl(s.Name, reason, f)
+	}
+	var err error
+	switch act {
+	case EffectKick:
+		err = e.actor.Kick(f.channel, offender, reason)
+	case EffectBan:
+		err = e.actor.Ban(f.channel, offender)
+	case EffectMute:
+		err = e.actor.SetMode(f.channel, "+q", offender)
+	case EffectOp:
+		err = e.actor.Op(f.channel, offender)
+	case EffectVoice:
+		err = e.actor.Voice(f.channel, offender)
+	case EffectMode:
+		err = e.actor.SetMode(f.channel, eff.Modes)
+	case EffectNotice:
+		text := reason
+		if text == "" {
+			text = e.renderTmpl(s.Name, s.Action.Template, f)
+		}
+		err = e.actor.Notice(f.channel, text)
+	case EffectTopic:
+		err = e.actor.Topic(f.channel, e.renderTmpl(s.Name, s.Action.Template, f))
+	default:
+		return
+	}
+	if err != nil {
+		e.log.Warn("skill effect failed", "skill", s.Name, "action", act, "err", err)
+	}
+	e.publishModeration(ctx, s.Name, string(act), f.channel, offender, reason)
+}
+
+func (e *Engine) publishModeration(ctx context.Context, skill, action, channel, target, reason string) {
+	e.mu.RLock()
+	bus := e.bus
+	e.mu.RUnlock()
+	if bus == nil {
+		return
+	}
+	bus.Publish(ctx, &agent.Event{
+		Type: agent.EventModeration,
+		Fields: map[string]any{
+			"skill":   skill,
+			"action":  action,
+			"channel": channel,
+			"target":  target,
+			"reason":  reason,
+		},
+	})
+}
+
+// verdict is the structured llm_classify response.
+type verdict struct {
+	Severity int    `json:"severity"`
+	Action   string `json:"action"`
+	Reason   string `json:"reason"`
+}
+
+// parseVerdict extracts the JSON verdict object from an LLM reply, tolerating
+// surrounding prose by slicing between the first '{' and last '}'.
+func parseVerdict(answer string) (verdict, bool) {
+	start := strings.IndexByte(answer, '{')
+	end := strings.LastIndexByte(answer, '}')
+	if start < 0 || end <= start {
+		return verdict{}, false
+	}
+	var v verdict
+	if err := json.Unmarshal([]byte(answer[start:end+1]), &v); err != nil {
+		return verdict{}, false
+	}
+	if v.Severity < 0 {
+		v.Severity = 0
+	}
+	return v, true
+}
+
+// actionForSeverity maps a 0..3 severity (or a flood count) onto the highest
+// matched threshold tier. Returns "" when no tier is reached.
+func actionForSeverity(s int, th *Thresholds) EffectAction {
+	if th == nil {
+		return ""
+	}
+	switch {
+	case th.Ban > 0 && s >= th.Ban:
+		return EffectBan
+	case th.Kick > 0 && s >= th.Kick:
+		return EffectKick
+	case th.Mute > 0 && s >= th.Mute:
+		return EffectMute
+	case th.Warn > 0 && s >= th.Warn:
+		return EffectNotice
+	default:
+		return ""
+	}
+}
+
+// Store-helper patterns: {getvar:key} reads, {setvar:key,value} writes (and
+// renders empty). They run before the field substitution.
+var (
+	getvarRe = regexp.MustCompile(`\{getvar:([^},]*)\}`)
+	setvarRe = regexp.MustCompile(`\{setvar:([^},]*),([^}]*)\}`)
+)
+
+// renderTmpl expands the store helpers (scoped to the skill), then the
+// standard placeholders and dynamic helpers.
+func (e *Engine) renderTmpl(skillName, tmpl string, f renderFields) string {
+	tmpl = setvarRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		sm := setvarRe.FindStringSubmatch(m)
+		e.store.Set(skillName, strings.TrimSpace(sm[1]), strings.TrimSpace(sm[2]), 0)
+		return ""
+	})
+	tmpl = getvarRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		key := strings.TrimSpace(getvarRe.FindStringSubmatch(m)[1])
+		v, _ := e.store.Get(skillName, key)
+		return v
+	})
+	return render(tmpl, f)
+}
+
+// fieldsFromEvent maps an EventBus user-event's fields onto renderFields.
+func fieldsFromEvent(ev *agent.Event) renderFields {
+	get := func(k string) string {
+		v, _ := ev.Fields[k].(string)
+		return v
+	}
+	f := renderFields{
+		channel: get("channel"),
+		reason:  get("reason"),
+		topic:   get("topic"),
+		modes:   get("modes"),
+	}
+	switch ev.Type {
+	case agent.EventUserKicked:
+		f.user = get("by")
+		f.target = get("nick")
+	case agent.EventUserNickChange:
+		f.oldNick = get("old")
+		f.newNick = get("new")
+		f.user = get("old")
+		f.target = get("new")
+	case agent.EventTopicChanged, agent.EventModeChanged:
+		f.user = get("by")
+	default: // join / leave
+		f.user = get("nick")
+	}
+	return f
+}
+
+func validEvent(name string) bool {
+	switch name {
+	case EventUserJoin, EventUserLeave, EventUserKicked,
+		EventUserNickChange, EventTopicChanged, EventModeChanged:
+		return true
+	default:
+		return false
+	}
+}
+
+// channelSet normalizes a channel scope list into a lowercase lookup set, or
+// nil when the scope is empty (all channels).
+func channelSet(channels []string) map[string]struct{} {
+	if len(channels) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(channels))
+	for _, c := range channels {
+		c = strings.ToLower(strings.TrimSpace(c))
+		if c != "" {
+			out[c] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func channelAllowed(set map[string]struct{}, channel string) bool {
+	if set == nil {
+		return true
+	}
+	_, ok := set[strings.ToLower(channel)]
+	return ok
+}

--- a/internal/skill/engine.go
+++ b/internal/skill/engine.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -20,10 +21,10 @@ import (
 // can't stall the engine.
 const webhookTimeout = 5 * time.Second
 
-// PostFunc posts a JSON payload to a URL. It is the seam external flow engines
-// (n8n and the like) plug into; the default uses net/http and tests substitute
-// a recorder.
-type PostFunc func(ctx context.Context, url string, payload []byte) error
+// PostFunc sends a JSON payload to a URL with the given HTTP method. It is the
+// seam external flow engines (n8n and the like) plug into; the default uses
+// net/http and tests substitute a recorder.
+type PostFunc func(ctx context.Context, method, url string, payload []byte) error
 
 // floodWindow is the sliding window over which an effect skill with severity
 // thresholds counts a sender's messages. Kept a package constant — operators
@@ -118,15 +119,25 @@ func NewEngine(o Options) *Engine {
 	}
 }
 
-// defaultPost POSTs payload as application/json with a bounded timeout.
-func defaultPost(ctx context.Context, url string, payload []byte) error {
+// defaultPost sends payload as application/json with the given method (default
+// POST) and a bounded timeout. A GET carries no request body.
+func defaultPost(ctx context.Context, method, url string, payload []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, webhookTimeout)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if method == "" {
+		method = http.MethodPost
+	}
+	var body io.Reader
+	if method != http.MethodGet {
+		body = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
@@ -344,7 +355,7 @@ func (e *Engine) doWebhook(ctx context.Context, s Skill, f renderFields) {
 	if err != nil {
 		return
 	}
-	if err := e.post(ctx, s.Action.Webhook, payload); err != nil {
+	if err := e.post(ctx, http.MethodPost, s.Action.Webhook, payload); err != nil {
 		e.log.Warn("skill webhook failed", "skill", s.Name, "err", err)
 	}
 }

--- a/internal/skill/engine.go
+++ b/internal/skill/engine.go
@@ -59,6 +59,12 @@ type Engine struct {
 	events    []compiled
 	matches   []compiled
 	bus       *agent.EventBus
+
+	// Timed-effect reversals: applied modes that auto-lift after a duration.
+	// Persisted via the Store so they resume across restarts.
+	liftsMu     sync.Mutex
+	lifts       []pendingLift
+	liftsLoaded bool
 }
 
 // compiled is a runtime-ready skill: the definition plus the compiled match
@@ -440,8 +446,146 @@ func (e *Engine) applyEffect(ctx context.Context, s Skill, f renderFields, eff *
 	}
 	if err != nil {
 		e.log.Warn("skill effect failed", "skill", s.Name, "action", act, "err", err)
+	} else if eff.DurationSeconds > 0 {
+		// Timed effect: schedule the reverse mode so it auto-lifts. Only
+		// reversible actions qualify (kick/notice/topic return ok=false).
+		if modes, arg, ok := reverseEffect(act, offender, eff.Modes); ok {
+			e.scheduleLift(f.channel, modes, arg, eff.DurationSeconds)
+		}
 	}
 	e.publishModeration(ctx, s.Name, string(act), f.channel, offender, reason)
+}
+
+const (
+	liftNS  = "__lifts"
+	liftKey = "pending"
+)
+
+// pendingLift is one scheduled mode reversal: at/after Due (unix seconds),
+// SetMode(Channel, Modes[, Arg]) is issued to undo a timed effect.
+type pendingLift struct {
+	Channel string `json:"c"`
+	Modes   string `json:"m"`
+	Arg     string `json:"a,omitempty"`
+	Due     int64  `json:"d"`
+}
+
+// reverseEffect returns the SetMode arguments that undo a timed effect, and
+// whether the action is reversible at all.
+func reverseEffect(act EffectAction, offender, modes string) (revModes, arg string, ok bool) {
+	switch act {
+	case EffectMute:
+		return "-q", offender, true
+	case EffectBan:
+		return "-b", offender, true
+	case EffectOp:
+		return "-o", offender, true
+	case EffectVoice:
+		return "-v", offender, true
+	case EffectMode:
+		return flipModeSign(modes), "", modes != ""
+	default:
+		return "", "", false
+	}
+}
+
+// flipModeSign turns "+m" into "-m" (and vice versa); a bare mode string is
+// treated as a removal.
+func flipModeSign(m string) string {
+	if m == "" {
+		return m
+	}
+	switch m[0] {
+	case '+':
+		return "-" + m[1:]
+	case '-':
+		return "+" + m[1:]
+	default:
+		return "-" + m
+	}
+}
+
+// ensureLiftsLoaded lazily hydrates the pending-lift set from the Store on
+// first use so restarts resume scheduled reversals. Caller holds liftsMu.
+func (e *Engine) ensureLiftsLoaded() {
+	if e.liftsLoaded {
+		return
+	}
+	e.liftsLoaded = true
+	raw, ok := e.store.Get(liftNS, liftKey)
+	if !ok || raw == "" {
+		return
+	}
+	var ls []pendingLift
+	if err := json.Unmarshal([]byte(raw), &ls); err == nil {
+		e.lifts = ls
+	}
+}
+
+func (e *Engine) scheduleLift(channel, modes, arg string, secs int) {
+	e.liftsMu.Lock()
+	defer e.liftsMu.Unlock()
+	e.ensureLiftsLoaded()
+	e.lifts = append(e.lifts, pendingLift{
+		Channel: channel,
+		Modes:   modes,
+		Arg:     arg,
+		Due:     time.Now().Add(time.Duration(secs) * time.Second).Unix(),
+	})
+	e.persistLifts()
+}
+
+// SweepLifts issues any pending mode reversals whose deadline has passed. The
+// scheduler calls it on every tick, so timed effects auto-lift (within the
+// tick granularity) and survive a restart via the Store.
+func (e *Engine) SweepLifts(now time.Time) {
+	e.liftsMu.Lock()
+	e.ensureLiftsLoaded()
+	if len(e.lifts) == 0 {
+		e.liftsMu.Unlock()
+		return
+	}
+	cutoff := now.Unix()
+	due := make([]pendingLift, 0)
+	keep := make([]pendingLift, 0, len(e.lifts))
+	for _, l := range e.lifts {
+		if l.Due <= cutoff {
+			due = append(due, l)
+		} else {
+			keep = append(keep, l)
+		}
+	}
+	if len(due) == 0 {
+		e.liftsMu.Unlock()
+		return
+	}
+	e.lifts = keep
+	e.persistLifts()
+	e.liftsMu.Unlock()
+
+	if e.actor == nil {
+		return
+	}
+	for _, l := range due {
+		var err error
+		if l.Arg != "" {
+			err = e.actor.SetMode(l.Channel, l.Modes, l.Arg)
+		} else {
+			err = e.actor.SetMode(l.Channel, l.Modes)
+		}
+		if err != nil {
+			e.log.Warn("skill effect lift failed", "channel", l.Channel, "modes", l.Modes, "err", err)
+		}
+	}
+}
+
+// persistLifts writes the pending-lift set to the Store. Caller holds liftsMu.
+func (e *Engine) persistLifts() {
+	b, err := json.Marshal(e.lifts)
+	if err != nil {
+		return
+	}
+	e.store.Set(liftNS, liftKey, string(b), 0)
 }
 
 func (e *Engine) publishModeration(ctx context.Context, skill, action, channel, target, reason string) {

--- a/internal/skill/engine_lift_test.go
+++ b/internal/skill/engine_lift_test.go
@@ -1,0 +1,107 @@
+package skill
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+// applyTimed is a small helper that runs a resolved effect with a duration.
+func applyTimed(e *Engine, act EffectAction, modes string, secs int) {
+	eff := &Effect{Action: act, Modes: modes, DurationSeconds: secs}
+	e.applyEffect(context.Background(), Skill{Name: "guard"}, renderFields{channel: "#c", user: "spammer"}, eff, act)
+}
+
+func TestTimedEffectAppliesThenAutoLifts(t *testing.T) {
+	fa := &fakeActor{}
+	e := NewEngine(Options{Actor: fa, Store: NewMemoryStore()})
+
+	applyTimed(e, EffectMute, "", 60)
+	if got := fa.snapshot(); !slices.Contains(got, "mode #c +q spammer") {
+		t.Fatalf("expected +q applied, got %v", got)
+	}
+
+	// Before the deadline: no reversal.
+	e.SweepLifts(time.Now())
+	if slices.Contains(fa.snapshot(), "mode #c -q spammer") {
+		t.Fatal("lift fired before its deadline")
+	}
+
+	// After the deadline: the mute auto-lifts.
+	e.SweepLifts(time.Now().Add(61 * time.Second))
+	if got := fa.snapshot(); !slices.Contains(got, "mode #c -q spammer") {
+		t.Fatalf("expected -q lift after deadline, got %v", got)
+	}
+
+	// Idempotent: a second sweep does not re-issue the reversal.
+	before := len(fa.snapshot())
+	e.SweepLifts(time.Now().Add(120 * time.Second))
+	if len(fa.snapshot()) != before {
+		t.Fatal("lift re-fired after it was already applied")
+	}
+}
+
+func TestTimedEffectSurvivesRestartViaStore(t *testing.T) {
+	store := NewMemoryStore()
+
+	// Engine A applies a timed +m channel lockdown, then goes away.
+	a := NewEngine(Options{Actor: &fakeActor{}, Store: store})
+	applyTimed(a, EffectMode, "+m", 60)
+
+	// Engine B shares the store (a fresh process/tenant restart) and must
+	// resume the pending lift.
+	fb := &fakeActor{}
+	b := NewEngine(Options{Actor: fb, Store: store})
+	b.SweepLifts(time.Now().Add(61 * time.Second))
+	if got := fb.snapshot(); !slices.Contains(got, "mode #c -m") {
+		t.Fatalf("restart engine did not resume the lift, got %v", got)
+	}
+}
+
+func TestNonReversibleEffectSchedulesNoLift(t *testing.T) {
+	fa := &fakeActor{}
+	e := NewEngine(Options{Actor: fa, Store: NewMemoryStore()})
+	applyTimed(e, EffectKick, "", 60)
+	e.SweepLifts(time.Now().Add(120 * time.Second))
+	for _, c := range fa.snapshot() {
+		if len(c) >= 4 && c[:4] == "mode" {
+			t.Fatalf("kick must not schedule a mode lift, got %v", fa.snapshot())
+		}
+	}
+}
+
+func TestReverseEffect(t *testing.T) {
+	cases := []struct {
+		act      EffectAction
+		modes    string
+		wantMode string
+		wantArg  string
+		wantOK   bool
+	}{
+		{EffectMute, "", "-q", "spammer", true},
+		{EffectBan, "", "-b", "spammer", true},
+		{EffectOp, "", "-o", "spammer", true},
+		{EffectVoice, "", "-v", "spammer", true},
+		{EffectMode, "+m", "-m", "", true},
+		{EffectMode, "-i", "+i", "", true},
+		{EffectMode, "", "", "", false},
+		{EffectKick, "", "", "", false},
+		{EffectNotice, "", "", "", false},
+	}
+	for _, c := range cases {
+		m, arg, ok := reverseEffect(c.act, "spammer", c.modes)
+		if m != c.wantMode || arg != c.wantArg || ok != c.wantOK {
+			t.Errorf("reverseEffect(%q,%q) = (%q,%q,%v), want (%q,%q,%v)",
+				c.act, c.modes, m, arg, ok, c.wantMode, c.wantArg, c.wantOK)
+		}
+	}
+}
+
+func TestFlipModeSign(t *testing.T) {
+	for in, want := range map[string]string{"+m": "-m", "-m": "+m", "m": "-m", "": ""} {
+		if got := flipModeSign(in); got != want {
+			t.Errorf("flipModeSign(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/skill/engine_test.go
+++ b/internal/skill/engine_test.go
@@ -2,6 +2,7 @@ package skill
 
 import (
 	"context"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -195,11 +196,11 @@ func TestEngineLLMAction(t *testing.T) {
 
 func TestEngineWebhook(t *testing.T) {
 	var mu sync.Mutex
-	var gotURL string
+	var gotMethod, gotURL string
 	var gotBody []byte
-	e, bus := newEngine(t, Options{Post: func(_ context.Context, url string, body []byte) error {
+	e, bus := newEngine(t, Options{Post: func(_ context.Context, method, url string, body []byte) error {
 		mu.Lock()
-		gotURL, gotBody = url, body
+		gotMethod, gotURL, gotBody = method, url, body
 		mu.Unlock()
 		return nil
 	}})
@@ -215,6 +216,7 @@ func TestEngineWebhook(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	assert.Equal(t, "https://flow.example/hook", gotURL)
+	assert.Equal(t, http.MethodPost, gotMethod, "skill webhook posts via POST")
 	assert.Contains(t, string(gotBody), `"user":"newbie"`)
 	assert.Contains(t, string(gotBody), `"message":"joined newbie"`)
 }

--- a/internal/skill/engine_test.go
+++ b/internal/skill/engine_test.go
@@ -1,0 +1,341 @@
+package skill
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/llm"
+)
+
+// newEngine builds an engine with an unrestricted skill cap and a captured bus.
+func newEngine(t *testing.T, o Options) (*Engine, *agent.EventBus) {
+	t.Helper()
+	if o.MaxSkills == 0 {
+		o.MaxSkills = -1
+	}
+	e := NewEngine(o)
+	bus := agent.NewEventBus(nil)
+	e.Subscribe(bus)
+	return e, bus
+}
+
+func msgEvent(channel, sender, text string) *agent.Event {
+	return &agent.Event{
+		Type:   agent.EventMessage,
+		Fields: map[string]any{"envelope": agent.NewInbound("irc", channel, sender, text)},
+	}
+}
+
+func TestEngineMatchStaticReply(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{
+		Name:    "hi",
+		Trigger: Trigger{Kind: KindMatch, Match: `(?i)hello`},
+		Action:  Action{Type: TypeStatic, Template: "hey {user}"},
+	}})
+	bus.Publish(context.Background(), msgEvent("#room", "alice", "well Hello there"))
+	assert.Equal(t, []string{"say #room hey alice"}, act.snapshot())
+
+	act2 := act.snapshot()
+	bus.Publish(context.Background(), msgEvent("#room", "bob", "nope"))
+	assert.Len(t, act2, 1, "a non-matching message fires nothing")
+}
+
+func TestEngineChannelScoping(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{
+		Name:    "ops-only",
+		Trigger: Trigger{Kind: KindMatch, Match: ".*", Channels: []string{"#ops"}},
+		Action:  Action{Type: TypeStatic, Template: "seen"},
+	}})
+	bus.Publish(context.Background(), msgEvent("#general", "a", "x"))
+	assert.Empty(t, act.snapshot(), "out-of-scope channel is ignored")
+	bus.Publish(context.Background(), msgEvent("#ops", "a", "x"))
+	assert.Equal(t, []string{"say #ops seen"}, act.snapshot())
+}
+
+func TestEngineEventJoinReply(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{
+		Name:    "welcome",
+		Trigger: Trigger{Kind: KindEvent, Event: EventUserJoin},
+		Action:  Action{Type: TypeStatic, Template: "welcome {nick}"},
+	}})
+	bus.Publish(context.Background(), &agent.Event{
+		Type:   agent.EventUserJoin,
+		Fields: map[string]any{"channel": "#room", "nick": "newbie"},
+	})
+	assert.Equal(t, []string{"say #room welcome newbie"}, act.snapshot())
+}
+
+func TestEngineEffectDirect(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{
+		Name:    "nolink",
+		Trigger: Trigger{Kind: KindMatch, Match: `http://`},
+		Action:  Action{Type: TypeEffect, Effect: &Effect{Action: EffectKick, Reason: "no links"}},
+	}})
+	bus.Publish(context.Background(), msgEvent("#room", "spammer", "see http://x"))
+	assert.Equal(t, []string{"kick #room spammer no links"}, act.snapshot())
+}
+
+func TestEngineEffectFloodThresholds(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{
+		Name:    "flood",
+		Trigger: Trigger{Kind: KindMatch, Match: ".*"},
+		Action:  Action{Type: TypeEffect, Effect: &Effect{Thresholds: &Thresholds{Warn: 2, Kick: 3}}},
+	}})
+	// 1st: below warn → nothing. 2nd: warn (notice). 3rd: kick.
+	bus.Publish(context.Background(), msgEvent("#r", "alice", "1"))
+	bus.Publish(context.Background(), msgEvent("#r", "alice", "2"))
+	bus.Publish(context.Background(), msgEvent("#r", "alice", "3"))
+	calls := act.snapshot()
+	require.Len(t, calls, 2)
+	assert.Contains(t, calls[0], "notice #r")
+	assert.Equal(t, "kick #r alice ", calls[1])
+}
+
+func TestEngineModerationAuditEvent(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	var mu sync.Mutex
+	var got *agent.Event
+	bus.Subscribe(agent.EventModeration, func(_ context.Context, ev *agent.Event) {
+		mu.Lock()
+		got = ev
+		mu.Unlock()
+	})
+	e.ReplaceSkills([]Skill{{
+		Name:    "ban-it",
+		Trigger: Trigger{Kind: KindMatch, Match: `badword`},
+		Action:  Action{Type: TypeEffect, Effect: &Effect{Action: EffectBan}},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "troll", "badword"))
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, got)
+	assert.Equal(t, "ban", got.Fields["action"])
+	assert.Equal(t, "troll", got.Fields["target"])
+}
+
+func TestEngineLLMClassifyMapsSeverity(t *testing.T) {
+	prov := &fakeProvider{resp: `here is the verdict {"severity":3,"action":"ban","reason":"abuse"} done`}
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act, Provider: prov})
+	e.ReplaceSkills([]Skill{{
+		Name:    "ai-mod",
+		Trigger: Trigger{Kind: KindMatch, Match: `.*`},
+		Action:  Action{Type: TypeLLMClassify, Effect: &Effect{Thresholds: &Thresholds{Warn: 1, Mute: 2, Ban: 3}}},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "troll", "something nasty"))
+	require.Equal(t, []string{"ban #r troll"}, act.snapshot())
+}
+
+func TestEngineLLMClassifyDegradesWithoutProvider(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act}) // no provider
+	e.ReplaceSkills([]Skill{{
+		Name:    "ai-mod",
+		Trigger: Trigger{Kind: KindMatch, Match: `.*`},
+		Action:  Action{Type: TypeLLMClassify, Effect: &Effect{Thresholds: &Thresholds{Kick: 2}}},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot(), "no LLM → fail safe, no punitive action")
+}
+
+func TestEngineLLMClassifyBudgetExhaustedNoAction(t *testing.T) {
+	prov := &fakeProvider{err: llm.ErrBudgetExhausted}
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act, Provider: prov})
+	e.ReplaceSkills([]Skill{{
+		Name:    "ai-mod",
+		Trigger: Trigger{Kind: KindMatch, Match: `.*`},
+		Action:  Action{Type: TypeLLMClassify, Effect: &Effect{Thresholds: &Thresholds{Kick: 2}}},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot())
+}
+
+func TestEngineLLMClassifyUnparseable(t *testing.T) {
+	prov := &fakeProvider{resp: "I cannot comply"}
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act, Provider: prov})
+	e.ReplaceSkills([]Skill{{
+		Name:    "ai-mod",
+		Trigger: Trigger{Kind: KindMatch, Match: `.*`},
+		Action:  Action{Type: TypeLLMClassify, Effect: &Effect{Thresholds: &Thresholds{Kick: 2}}},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "x"))
+	assert.Empty(t, act.snapshot())
+}
+
+func TestEngineLLMAction(t *testing.T) {
+	prov := &fakeProvider{resp: "a   tidy   reply\n"}
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act, Provider: prov})
+	e.ReplaceSkills([]Skill{{
+		Name:    "ai-reply",
+		Trigger: Trigger{Kind: KindMatch, Match: `\?$`},
+		Action:  Action{Type: TypeLLM, Template: "answer: {text}", Instructions: "be terse"},
+	}})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "what time is it?"))
+	assert.Equal(t, []string{"say #r a tidy reply"}, act.snapshot())
+	assert.Equal(t, "answer: what time is it?", prov.lastPrompt())
+}
+
+func TestEngineWebhook(t *testing.T) {
+	var mu sync.Mutex
+	var gotURL string
+	var gotBody []byte
+	e, bus := newEngine(t, Options{Post: func(_ context.Context, url string, body []byte) error {
+		mu.Lock()
+		gotURL, gotBody = url, body
+		mu.Unlock()
+		return nil
+	}})
+	e.ReplaceSkills([]Skill{{
+		Name:    "to-flow",
+		Trigger: Trigger{Kind: KindEvent, Event: EventUserJoin},
+		Action:  Action{Type: TypeWebhook, Webhook: "https://flow.example/hook", Template: "joined {nick}"},
+	}})
+	bus.Publish(context.Background(), &agent.Event{
+		Type:   agent.EventUserJoin,
+		Fields: map[string]any{"channel": "#room", "nick": "newbie"},
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "https://flow.example/hook", gotURL)
+	assert.Contains(t, string(gotBody), `"user":"newbie"`)
+	assert.Contains(t, string(gotBody), `"message":"joined newbie"`)
+}
+
+func TestEngineStoreHelpers(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{
+		{Name: "set", Trigger: Trigger{Kind: KindMatch, Match: `^!setmotd`}, Action: Action{Type: TypeStatic, Template: "{setvar:motd,hello world}saved"}},
+		{Name: "set", Trigger: Trigger{Kind: KindMatch, Match: `^!getmotd`}, Action: Action{Type: TypeStatic, Template: "motd: {getvar:motd}"}},
+	})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "!setmotd"))
+	bus.Publish(context.Background(), msgEvent("#r", "u", "!getmotd"))
+	calls := act.snapshot()
+	require.Len(t, calls, 2)
+	assert.Equal(t, "say #r saved", calls[0])
+	assert.Equal(t, "say #r motd: hello world", calls[1])
+}
+
+func TestEngineReplaceSkillsCapAndValidation(t *testing.T) {
+	e := NewEngine(Options{MaxSkills: 1})
+	e.ReplaceSkills([]Skill{
+		{Name: "bad", Trigger: Trigger{Kind: KindMatch, Match: `[`}, Action: Action{Type: TypeStatic}}, // bad regex: dropped
+		{Name: "m1", Trigger: Trigger{Kind: KindMatch, Match: `a`}, Action: Action{Type: TypeStatic, Template: "x"}},
+		{Name: "m2", Trigger: Trigger{Kind: KindMatch, Match: `b`}, Action: Action{Type: TypeStatic, Template: "y"}}, // over cap
+		{Name: "ev-bad", Trigger: Trigger{Kind: KindEvent, Event: "NOPE"}, Action: Action{Type: TypeStatic}},         // unknown event
+	})
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Len(t, e.matches, 1, "bad regex dropped; cap of 1 keeps only the first valid match")
+	assert.Equal(t, "m1", e.matches[0].skill.Name)
+}
+
+func TestEngineSetMaxSkills(t *testing.T) {
+	e := NewEngine(Options{MaxSkills: 0})
+	e.SetMaxSkills(-1)
+	e.ReplaceSkills([]Skill{{Name: "m", Trigger: Trigger{Kind: KindMatch, Match: `a`}, Action: Action{Type: TypeStatic, Template: "x"}}})
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Len(t, e.matches, 1)
+}
+
+func TestEngineIgnoresNonEnvelopeMessage(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{Name: "m", Trigger: Trigger{Kind: KindMatch, Match: `.*`}, Action: Action{Type: TypeStatic, Template: "x"}}})
+	bus.Publish(context.Background(), &agent.Event{Type: agent.EventMessage, Fields: map[string]any{"nope": 1}})
+	assert.Empty(t, act.snapshot())
+}
+
+func TestParseVerdict(t *testing.T) {
+	v, ok := parseVerdict(`prefix {"severity":2,"action":"mute","reason":"x"} suffix`)
+	require.True(t, ok)
+	assert.Equal(t, 2, v.Severity)
+	assert.Equal(t, "mute", v.Action)
+
+	_, ok = parseVerdict("no json here")
+	assert.False(t, ok)
+	_, ok = parseVerdict(`{not valid}`)
+	assert.False(t, ok)
+
+	v, ok = parseVerdict(`{"severity":-5}`)
+	require.True(t, ok)
+	assert.Equal(t, 0, v.Severity, "negative severity clamps to 0")
+}
+
+func TestActionForSeverity(t *testing.T) {
+	th := &Thresholds{Warn: 1, Mute: 2, Kick: 3, Ban: 4}
+	assert.Equal(t, EffectAction(""), actionForSeverity(0, th))
+	assert.Equal(t, EffectNotice, actionForSeverity(1, th))
+	assert.Equal(t, EffectMute, actionForSeverity(2, th))
+	assert.Equal(t, EffectKick, actionForSeverity(3, th))
+	assert.Equal(t, EffectBan, actionForSeverity(5, th))
+	assert.Equal(t, EffectAction(""), actionForSeverity(9, nil))
+}
+
+func TestApplyEffectModesAndModerationActions(t *testing.T) {
+	act := &fakeActor{}
+	e, bus := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{
+		{Name: "mute", Trigger: Trigger{Kind: KindMatch, Match: `m`}, Action: Action{Type: TypeEffect, Effect: &Effect{Action: EffectMute}}},
+		{Name: "op", Trigger: Trigger{Kind: KindMatch, Match: `o`}, Action: Action{Type: TypeEffect, Effect: &Effect{Action: EffectOp}}},
+		{Name: "voice", Trigger: Trigger{Kind: KindMatch, Match: `v`}, Action: Action{Type: TypeEffect, Effect: &Effect{Action: EffectVoice}}},
+		{Name: "mode", Trigger: Trigger{Kind: KindMatch, Match: `g`}, Action: Action{Type: TypeEffect, Effect: &Effect{Action: EffectMode, Modes: "+m"}}},
+		{Name: "notice", Trigger: Trigger{Kind: KindMatch, Match: `n`}, Action: Action{Type: TypeEffect, Template: "rules!", Effect: &Effect{Action: EffectNotice}}},
+		{Name: "topic", Trigger: Trigger{Kind: KindMatch, Match: `t`}, Action: Action{Type: TypeEffect, Template: "new topic", Effect: &Effect{Action: EffectTopic}}},
+	})
+	bus.Publish(context.Background(), msgEvent("#r", "u", "movgnt"))
+	calls := act.snapshot()
+	assert.Contains(t, calls, "mode #r +q u")
+	assert.Contains(t, calls, "op #r u")
+	assert.Contains(t, calls, "voice #r u")
+	assert.Contains(t, calls, "mode #r +m")
+	assert.Contains(t, calls, "notice #r rules!")
+	assert.Contains(t, calls, "topic #r new topic")
+}
+
+func TestFieldsFromEvent(t *testing.T) {
+	kick := fieldsFromEvent(&agent.Event{Type: agent.EventUserKicked, Fields: map[string]any{"channel": "#r", "nick": "victim", "by": "op", "reason": "bye"}})
+	assert.Equal(t, "op", kick.user)
+	assert.Equal(t, "victim", kick.target)
+
+	nick := fieldsFromEvent(&agent.Event{Type: agent.EventUserNickChange, Fields: map[string]any{"old": "a", "new": "b"}})
+	assert.Equal(t, "a", nick.oldNick)
+	assert.Equal(t, "b", nick.newNick)
+
+	topic := fieldsFromEvent(&agent.Event{Type: agent.EventTopicChanged, Fields: map[string]any{"channel": "#r", "by": "setter", "topic": "hi"}})
+	assert.Equal(t, "setter", topic.user)
+	assert.Equal(t, "hi", topic.topic)
+}
+
+func TestValidEvent(t *testing.T) {
+	assert.True(t, validEvent(EventModeChanged))
+	assert.False(t, validEvent("BOGUS"))
+}
+
+func TestChannelSetAndAllowed(t *testing.T) {
+	assert.Nil(t, channelSet(nil))
+	assert.Nil(t, channelSet([]string{"", "  "}))
+	set := channelSet([]string{"#Ops"})
+	assert.True(t, channelAllowed(set, "#ops"))
+	assert.False(t, channelAllowed(set, "#other"))
+	assert.True(t, channelAllowed(nil, "#anything"))
+}

--- a/internal/skill/helpers_test.go
+++ b/internal/skill/helpers_test.go
@@ -1,0 +1,82 @@
+package skill
+
+import (
+	"context"
+	"iter"
+	"sync"
+	"testing"
+
+	"github.com/turborg/turborg/internal/llm"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+// fakeActor records every action call so tests can assert on the wire-agnostic
+// surface the engine drives.
+type fakeActor struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (f *fakeActor) rec(s string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, s)
+}
+
+func (f *fakeActor) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.calls...)
+}
+
+func (f *fakeActor) Say(channel, text string) error { f.rec("say " + channel + " " + text); return nil }
+func (f *fakeActor) Notice(target, text string) error {
+	f.rec("notice " + target + " " + text)
+	return nil
+}
+func (f *fakeActor) Kick(c, n, r string) error { f.rec("kick " + c + " " + n + " " + r); return nil }
+func (f *fakeActor) Ban(c, m string) error     { f.rec("ban " + c + " " + m); return nil }
+func (f *fakeActor) Op(c, n string) error      { f.rec("op " + c + " " + n); return nil }
+func (f *fakeActor) Voice(c, n string) error   { f.rec("voice " + c + " " + n); return nil }
+func (f *fakeActor) Topic(c, t string) error   { f.rec("topic " + c + " " + t); return nil }
+func (f *fakeActor) Invite(c, n string) error  { f.rec("invite " + c + " " + n); return nil }
+func (f *fakeActor) SetMode(c, modes string, a ...string) error {
+	line := "mode " + c + " " + modes
+	for _, x := range a {
+		line += " " + x
+	}
+	f.rec(line)
+	return nil
+}
+
+// fakeProvider returns a fixed response (or error) and records the last prompt.
+type fakeProvider struct {
+	mu     sync.Mutex
+	resp   string
+	err    error
+	prompt string
+	system string
+}
+
+func (p *fakeProvider) Model() string { return "fake" }
+func (p *fakeProvider) Ask(_ context.Context, prompt string, opts ...llm.CallOption) (string, llm.Usage, error) {
+	co := llm.ApplyOptions(opts)
+	p.mu.Lock()
+	p.prompt = prompt
+	p.system = co.System
+	p.mu.Unlock()
+	return p.resp, llm.Usage{}, p.err
+}
+func (p *fakeProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
+	return func(func(string, error) bool) {}
+}
+
+func (p *fakeProvider) lastPrompt() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.prompt
+}

--- a/internal/skill/httpstore.go
+++ b/internal/skill/httpstore.go
@@ -1,0 +1,203 @@
+package skill
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// HTTPStore is a durable Store backed by an external HTTP service. It gives
+// skills and flows state that survives a process restart — quiz scores, a
+// seen-database, counters, per-user history — by reading and writing each value
+// over HTTP instead of holding it in memory. The per-key flood counter (Incr)
+// stays in-process: its windows are short (seconds), it fires on the hot
+// message path, and it never needs to outlive the process, so persisting it
+// would add a round-trip for no benefit. Incr therefore delegates to an
+// embedded MemoryStore.
+//
+// Every network operation degrades gracefully: a failed Get reports "not
+// found", a failed Set or Delete is dropped with a debug log. A state-service
+// outage never propagates an error into message handling — a skill that can't
+// reach its backend behaves as if the key were simply absent.
+//
+// Namespacing mirrors the MemoryStore: the "skill" argument is the namespace
+// (the skill or flow name) and "key" is the value key. They map onto the path
+// {base}/state/{ns}/{key}.
+//
+// Wire contract the operator must serve at the configured base URL:
+//
+//	GET    <base>/state/<ns>/<key>
+//	  Authorization: Bearer <token>
+//	  Status: 200 with body {"value": "..."} when present;
+//	          404 when absent or expired.
+//
+//	PUT    <base>/state/<ns>/<key>
+//	  Authorization: Bearer <token>
+//	  Content-Type: application/json
+//	  Body: {"value": "...", "ttl_seconds": <int, optional>}
+//	  Status: 2xx on success. A positive ttl_seconds expires the value
+//	          after that many seconds; omitted / zero stores it without expiry.
+//
+//	DELETE <base>/state/<ns>/<key>
+//	  Authorization: Bearer <token>
+//	  Status: 2xx on success (also treated as success when the key was absent).
+type HTTPStore struct {
+	base   string
+	token  string
+	client *http.Client
+	log    *slog.Logger
+
+	// mem serves Incr (in-process sliding-window flood counters). It is never
+	// consulted for Get/Set/Delete — those always go over HTTP.
+	mem *MemoryStore
+}
+
+// httpStoreTimeout caps how long any single state operation may block. Get runs
+// on the message-handling path, so a slow backend must not stall a reply; the
+// timeout keeps a degraded state service from freezing the bot.
+const httpStoreTimeout = 5 * time.Second
+
+// NewHTTPStore returns nil when either base or token is empty — mirroring the
+// convention the message HTTPStore uses, so the caller can plug the result into
+// a Store-typed field behind a single non-nil check and fall back to a
+// MemoryStore otherwise.
+func NewHTTPStore(base, token string, log *slog.Logger) *HTTPStore {
+	if base == "" || token == "" {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	// Trim a trailing slash so joining "/state/..." never doubles it.
+	for len(base) > 0 && base[len(base)-1] == '/' {
+		base = base[:len(base)-1]
+	}
+	return &HTTPStore{
+		base:   base,
+		token:  token,
+		client: &http.Client{Timeout: httpStoreTimeout},
+		log:    log.With("component", "skill-store"),
+		mem:    NewMemoryStore(),
+	}
+}
+
+// endpoint builds the per-key URL. Both segments are path-escaped so a
+// namespace or key containing a slash or other reserved byte maps to a single,
+// unambiguous path segment on the wire.
+func (s *HTTPStore) endpoint(ns, key string) string {
+	return s.base + "/state/" + url.PathEscape(ns) + "/" + url.PathEscape(key)
+}
+
+// Get fetches the value for (skill,key). A missing key (404), any non-200
+// status, or a network/decoding failure all report "not found" so callers treat
+// a state outage the same as an absent key.
+func (s *HTTPStore) Get(skill, key string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), httpStoreTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.endpoint(skill, key), nil)
+	if err != nil {
+		s.log.Debug("skill state: build get request", "err", err, "ns", skill)
+		return "", false
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.log.Debug("skill state: get", "err", err, "ns", skill)
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+
+	var body struct {
+		Value string `json:"value"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		s.log.Debug("skill state: decode get", "err", err, "ns", skill)
+		return "", false
+	}
+	return body.Value, true
+}
+
+// Set stores val for (skill,key) via PUT. A positive ttl is sent as
+// ttl_seconds; a non-positive ttl is omitted (store without expiry). Failures
+// are logged and dropped — writes are best-effort so a state outage never
+// breaks message handling.
+func (s *HTTPStore) Set(skill, key, val string, ttl time.Duration) {
+	payload := struct {
+		Value      string `json:"value"`
+		TTLSeconds int    `json:"ttl_seconds,omitempty"`
+	}{Value: val}
+	if ttl > 0 {
+		payload.TTLSeconds = int(ttl / time.Second)
+		// Round sub-second TTLs up to 1s so a small positive TTL doesn't
+		// collapse to "no expiry".
+		if payload.TTLSeconds == 0 {
+			payload.TTLSeconds = 1
+		}
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		s.log.Debug("skill state: marshal set", "err", err, "ns", skill)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), httpStoreTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, s.endpoint(skill, key), bytes.NewReader(buf))
+	if err != nil {
+		s.log.Debug("skill state: build set request", "err", err, "ns", skill)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.log.Debug("skill state: set", "err", err, "ns", skill)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.log.Debug("skill state: set non-2xx", "status", resp.StatusCode, "ns", skill)
+	}
+}
+
+// Delete removes the value for (skill,key) via DELETE. Failures are logged and
+// dropped for the same best-effort reason as Set.
+func (s *HTTPStore) Delete(skill, key string) {
+	ctx, cancel := context.WithTimeout(context.Background(), httpStoreTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.endpoint(skill, key), nil)
+	if err != nil {
+		s.log.Debug("skill state: build delete request", "err", err, "ns", skill)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		s.log.Debug("skill state: delete", "err", err, "ns", skill)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		s.log.Debug("skill state: delete non-2xx", "status", resp.StatusCode, "ns", skill)
+	}
+}
+
+// Incr delegates to the embedded in-process counter — flood windows are short
+// and per-process by design, so they are never persisted over HTTP.
+func (s *HTTPStore) Incr(skill, key string, window time.Duration) (int, error) {
+	return s.mem.Incr(skill, key, window)
+}

--- a/internal/skill/httpstore_test.go
+++ b/internal/skill/httpstore_test.go
@@ -1,0 +1,209 @@
+package skill
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPStoreNilWhenUnconfigured(t *testing.T) {
+	assert.Nil(t, NewHTTPStore("", "tok", nil), "empty base → nil")
+	assert.Nil(t, NewHTTPStore("http://x", "", nil), "empty token → nil")
+	assert.NotNil(t, NewHTTPStore("http://x", "tok", nil), "both set → non-nil")
+}
+
+// stateBackend is a minimal in-memory stand-in for the HTTP state service,
+// exercising the GET/PUT/DELETE wire contract HTTPStore speaks.
+type stateBackend struct {
+	mu       sync.Mutex
+	values   map[string]string
+	lastAuth string
+	lastTTL  int
+}
+
+func newStateBackend() *stateBackend {
+	return &stateBackend{values: map[string]string{}}
+}
+
+func (b *stateBackend) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		b.lastAuth = r.Header.Get("Authorization")
+
+		// Path shape: /state/{ns}/{key}
+		trimmed := strings.TrimPrefix(r.URL.Path, "/state/")
+		require.NotEqual(t, r.URL.Path, trimmed, "path must be under /state/")
+		key := trimmed // ns/key together identify the row for this test
+
+		switch r.Method {
+		case http.MethodGet:
+			v, ok := b.values[key]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"value": v})
+		case http.MethodPut:
+			var body struct {
+				Value      string `json:"value"`
+				TTLSeconds int    `json:"ttl_seconds"`
+			}
+			raw, _ := io.ReadAll(r.Body)
+			require.NoError(t, json.Unmarshal(raw, &body))
+			b.lastTTL = body.TTLSeconds
+			b.values[key] = body.Value
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodDelete:
+			delete(b.values, key)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func TestHTTPStoreSetGetDelete(t *testing.T) {
+	b := newStateBackend()
+	srv := httptest.NewServer(b.handler(t))
+	defer srv.Close()
+
+	s := NewHTTPStore(srv.URL, "sekret", nil)
+	require.NotNil(t, s)
+
+	// Missing key → not found.
+	_, ok := s.Get("quiz", "score")
+	assert.False(t, ok)
+
+	// Set then Get round-trips the value.
+	s.Set("quiz", "score", "42", 0)
+	got, ok := s.Get("quiz", "score")
+	require.True(t, ok)
+	assert.Equal(t, "42", got)
+
+	// Bearer token forwarded.
+	b.mu.Lock()
+	assert.Equal(t, "Bearer sekret", b.lastAuth)
+	assert.Equal(t, 0, b.lastTTL, "no ttl → ttl_seconds omitted (0)")
+	b.mu.Unlock()
+
+	// Delete removes it.
+	s.Delete("quiz", "score")
+	_, ok = s.Get("quiz", "score")
+	assert.False(t, ok)
+}
+
+func TestHTTPStoreSetSendsTTL(t *testing.T) {
+	b := newStateBackend()
+	srv := httptest.NewServer(b.handler(t))
+	defer srv.Close()
+	s := NewHTTPStore(srv.URL, "tok", nil)
+
+	s.Set("ns", "k", "v", 90*time.Second)
+	b.mu.Lock()
+	assert.Equal(t, 90, b.lastTTL)
+	b.mu.Unlock()
+
+	// Sub-second positive TTL rounds up to 1 rather than collapsing to "no expiry".
+	s.Set("ns", "k2", "v", 500*time.Millisecond)
+	b.mu.Lock()
+	assert.Equal(t, 1, b.lastTTL)
+	b.mu.Unlock()
+}
+
+func TestHTTPStoreNamespaceAndKeyEscaped(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	s := NewHTTPStore(srv.URL, "tok", nil)
+
+	s.Set("my skill", "a/b c", "v", 0)
+	// Both segments must be percent-escaped so the slash in the key is not read
+	// as an extra path segment.
+	assert.Equal(t, "/state/"+url.PathEscape("my skill")+"/"+url.PathEscape("a/b c"), gotPath)
+}
+
+func TestHTTPStoreTrailingSlashBaseTrimmed(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	s := NewHTTPStore(srv.URL+"/", "tok", nil)
+	s.Set("ns", "k", "v", 0)
+	assert.Equal(t, "/state/ns/k", gotPath, "no doubled slash from trailing-slash base")
+}
+
+func TestHTTPStoreGetDegradesOnErrors(t *testing.T) {
+	// Non-200 (e.g. 500) → not found.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	s := NewHTTPStore(srv.URL, "tok", nil)
+	_, ok := s.Get("ns", "k")
+	assert.False(t, ok)
+	srv.Close()
+
+	// Malformed JSON body on 200 → not found.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv2.Close()
+	s2 := NewHTTPStore(srv2.URL, "tok", nil)
+	_, ok = s2.Get("ns", "k")
+	assert.False(t, ok)
+}
+
+func TestHTTPStoreWritesDropOnNetworkError(t *testing.T) {
+	// Point at a closed server so every request fails at the transport layer.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	base := srv.URL
+	srv.Close()
+
+	s := NewHTTPStore(base, "tok", nil)
+	// None of these should panic or block; a state outage is silently degraded.
+	s.Set("ns", "k", "v", 0)
+	s.Delete("ns", "k")
+	_, ok := s.Get("ns", "k")
+	assert.False(t, ok)
+}
+
+func TestHTTPStoreSetNon2xxLogged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	s := NewHTTPStore(srv.URL, "tok", nil)
+	// Best-effort: a non-2xx is dropped without surfacing an error.
+	s.Set("ns", "k", "v", 0)
+	s.Delete("ns", "k")
+}
+
+func TestHTTPStoreIncrUsesInProcessCounter(t *testing.T) {
+	// Incr must never hit the network; a nil/unreachable backend still counts.
+	s := NewHTTPStore("http://127.0.0.1:1", "tok", nil)
+	n, err := s.Incr("ns", "user", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	n, err = s.Incr("ns", "user", time.Minute)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+// HTTPStore must satisfy the Store interface.
+var _ Store = (*HTTPStore)(nil)

--- a/internal/skill/render.go
+++ b/internal/skill/render.go
@@ -1,0 +1,105 @@
+package skill
+
+import (
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Helper-placeholder patterns mirror the command builder's: each captures the
+// comma-separated argument list (or the bound, for random) and never spans a
+// closing brace.
+var (
+	choiceRe  = regexp.MustCompile(`\{choice:([^}]*)\}`)
+	randomRe  = regexp.MustCompile(`\{random:([^}]*)\}`)
+	shuffleRe = regexp.MustCompile(`\{shuffle:([^}]*)\}`)
+)
+
+// renderFields carries the per-fire values an engine skill's template can
+// reference. They are populated from the event/message that triggered the
+// skill; unset fields render empty.
+type renderFields struct {
+	user     string // the acting nick (sender / joiner / setter / offender)
+	channel  string
+	text     string // the message text (match triggers)
+	target   string // the affected nick (kick victim, nick-change subject)
+	reason   string
+	topic    string
+	modes    string
+	oldNick  string
+	newNick  string
+	platform string
+	owner    string
+	count    int // per-sender flood count, when computed
+}
+
+// render substitutes the supported placeholders in a template. The dynamic
+// helpers ({choice}/{random}/{shuffle}) are expanded first, over the
+// author-supplied template only, so a value substituted afterwards (e.g.
+// {text}) can never inject a helper.
+func render(tmpl string, f renderFields) string {
+	tmpl = expandHelpers(tmpl)
+	now := time.Now().UTC()
+	return strings.NewReplacer(
+		"{user}", f.user,
+		"{nick}", f.user,
+		"{channel}", f.channel,
+		"{room}", f.channel,
+		"{text}", f.text,
+		"{message}", f.text,
+		"{target}", f.target,
+		"{reason}", f.reason,
+		"{topic}", f.topic,
+		"{modes}", f.modes,
+		"{old}", f.oldNick,
+		"{new}", f.newNick,
+		"{platform}", f.platform,
+		"{network}", f.platform,
+		"{owner}", f.owner,
+		"{count}", strconv.Itoa(f.count),
+		"{date}", now.Format("2006-01-02"),
+		"{time}", now.Format("15:04:05"),
+		"{datetime}", now.Format("2006-01-02 15:04:05 UTC"),
+	).Replace(tmpl)
+}
+
+// expandHelpers evaluates the random dynamic-placeholder helpers in a
+// template. A {random:N} with a missing or non-positive bound is left literal
+// so a typo is visible rather than silent.
+func expandHelpers(tmpl string) string {
+	tmpl = choiceRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		opts := splitOptions(choiceRe.FindStringSubmatch(m)[1])
+		if len(opts) == 0 {
+			return ""
+		}
+		return opts[rand.Intn(len(opts))]
+	})
+	tmpl = shuffleRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		opts := splitOptions(shuffleRe.FindStringSubmatch(m)[1])
+		rand.Shuffle(len(opts), func(i, j int) { opts[i], opts[j] = opts[j], opts[i] })
+		return strings.Join(opts, ",")
+	})
+	tmpl = randomRe.ReplaceAllStringFunc(tmpl, func(m string) string {
+		n, err := strconv.Atoi(strings.TrimSpace(randomRe.FindStringSubmatch(m)[1]))
+		if err != nil || n < 1 {
+			return m
+		}
+		return strconv.Itoa(rand.Intn(n) + 1)
+	})
+	return tmpl
+}
+
+// splitOptions splits a comma-separated helper argument into trimmed,
+// non-empty options.
+func splitOptions(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/skill/render_test.go
+++ b/internal/skill/render_test.go
@@ -1,0 +1,49 @@
+package skill
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderPlaceholders(t *testing.T) {
+	f := renderFields{
+		user: "alice", channel: "#room", text: "hello", target: "bob",
+		reason: "spam", topic: "welcome", modes: "+o", oldNick: "a", newNick: "b",
+		platform: "irc.example", owner: "stefan", count: 4,
+	}
+	got := render("{user}/{nick} {channel}/{room} {text}/{message} {target} {reason} {topic} {modes} {old}>{new} {platform}/{network} {owner} {count}", f)
+	assert.Equal(t, "alice/alice #room/#room hello/hello bob spam welcome +o a>b irc.example/irc.example stefan 4", got)
+}
+
+func TestRenderClockTokens(t *testing.T) {
+	got := render("{date} | {time} | {datetime}", renderFields{})
+	parts := strings.Split(got, " | ")
+	require.Len(t, parts, 3)
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2}$`, parts[0])
+	assert.Regexp(t, `^\d{2}:\d{2}:\d{2}$`, parts[1])
+	assert.Regexp(t, `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC$`, parts[2])
+}
+
+func TestExpandHelpers(t *testing.T) {
+	assert.Contains(t, []string{"red", "green"}, render("{choice:red,green}", renderFields{}))
+	assert.Equal(t, "", render("{choice:}", renderFields{}), "empty choice list yields empty")
+
+	for range 30 {
+		n, err := strconv.Atoi(render("{random:6}", renderFields{}))
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, n, 1)
+		assert.LessOrEqual(t, n, 6)
+	}
+	assert.Equal(t, "{random:0}", render("{random:0}", renderFields{}), "bad bound left literal")
+	assert.Equal(t, "{random:x}", render("{random:x}", renderFields{}))
+
+	shuffled := render("{shuffle:a,b,c}", renderFields{})
+	got := strings.Split(shuffled, ",")
+	sort.Strings(got)
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}

--- a/internal/skill/scheduler.go
+++ b/internal/skill/scheduler.go
@@ -98,6 +98,9 @@ func (s *Scheduler) tick(ctx context.Context, now time.Time) {
 		}
 		s.engine.fire(ctx, sk, f)
 	}
+	// Auto-lift any timed effects whose deadline has passed (mute/ban/mode
+	// with duration_seconds). Runs every tick regardless of due schedules.
+	s.engine.SweepLifts(now)
 }
 
 // advance computes the next due time after now for this schedule.

--- a/internal/skill/scheduler.go
+++ b/internal/skill/scheduler.go
@@ -1,0 +1,139 @@
+package skill
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// schedTick is how often the scheduler wakes to evaluate due schedules. A
+// 30-second tick bounds cron/interval granularity without busy-spinning.
+const schedTick = 30 * time.Second
+
+// Scheduler fires schedule-trigger skills on their cadence. One ticker drives
+// every scheduled skill; the set is hot-swappable via ReplaceSkills and the
+// loop is goleak-clean — Run returns when its context is cancelled.
+type Scheduler struct {
+	engine *Engine
+	log    *slog.Logger
+	now    clock
+
+	mu    sync.Mutex
+	items []*scheduled
+}
+
+// scheduled is one schedule skill plus its parsed cadence and next-due time.
+type scheduled struct {
+	skill    Skill
+	interval time.Duration // > 0 for interval cadences
+	cron     *cronSpec     // non-nil for cron cadences
+	nextDue  time.Time
+}
+
+// NewScheduler builds a scheduler that fires actions through engine.
+func NewScheduler(engine *Engine, log *slog.Logger) *Scheduler {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Scheduler{engine: engine, log: log.With("component", "skill-scheduler"), now: time.Now}
+}
+
+// ReplaceSkills atomically swaps the scheduled skill set. Only schedule-kind
+// skills are kept; an unparseable schedule is dropped with a log line. Each
+// surviving skill's next-due time is computed from now.
+func (s *Scheduler) ReplaceSkills(skills []Skill) {
+	now := s.now()
+	var items []*scheduled
+	for _, sk := range skills {
+		if sk.Trigger.Kind != KindSchedule {
+			continue
+		}
+		it, err := parseSchedule(sk, now)
+		if err != nil {
+			s.log.Warn("skipping schedule skill: bad schedule", "skill", sk.Name, "err", err)
+			continue
+		}
+		items = append(items, it)
+	}
+	s.mu.Lock()
+	s.items = items
+	s.mu.Unlock()
+}
+
+// Run drives the scheduler until ctx is cancelled. Always returns nil
+// (cancellation is the normal exit); the error return mirrors the other
+// supervised runnables.
+func (s *Scheduler) Run(ctx context.Context) error {
+	t := time.NewTicker(schedTick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			s.tick(ctx, s.now())
+		}
+	}
+}
+
+// tick fires every skill whose next-due time has passed and reschedules it.
+func (s *Scheduler) tick(ctx context.Context, now time.Time) {
+	s.mu.Lock()
+	due := make([]Skill, 0)
+	for _, it := range s.items {
+		if now.Before(it.nextDue) {
+			continue
+		}
+		due = append(due, it.skill)
+		it.nextDue = it.advance(now)
+	}
+	s.mu.Unlock()
+	for _, sk := range due {
+		f := renderFields{platform: s.engine.platform, owner: s.engine.owner}
+		if len(sk.Trigger.Channels) > 0 {
+			f.channel = sk.Trigger.Channels[0]
+		}
+		s.engine.fire(ctx, sk, f)
+	}
+}
+
+// advance computes the next due time after now for this schedule.
+func (it *scheduled) advance(now time.Time) time.Time {
+	if it.cron != nil {
+		return it.cron.next(now)
+	}
+	return now.Add(it.interval)
+}
+
+// parseSchedule parses a skill's schedule into either an interval or a cron
+// spec and stamps the first due time.
+func parseSchedule(sk Skill, now time.Time) (*scheduled, error) {
+	spec := strings.TrimSpace(sk.Trigger.Schedule)
+	if spec == "" {
+		return nil, fmt.Errorf("empty schedule")
+	}
+	if d, err := parseInterval(spec); err == nil {
+		return &scheduled{skill: sk, interval: d, nextDue: now.Add(d)}, nil
+	}
+	cron, err := parseCron(spec)
+	if err != nil {
+		return nil, err
+	}
+	return &scheduled{skill: sk, cron: cron, nextDue: cron.next(now)}, nil
+}
+
+// parseInterval accepts a Go duration ("30m", "1h", "45s"). It rejects
+// non-positive and sub-minute cadences so a typo can't busy-fire.
+func parseInterval(spec string) (time.Duration, error) {
+	d, err := time.ParseDuration(spec)
+	if err != nil {
+		return 0, err
+	}
+	if d < time.Minute {
+		return 0, fmt.Errorf("interval %s below the one-minute floor", spec)
+	}
+	return d, nil
+}

--- a/internal/skill/scheduler_test.go
+++ b/internal/skill/scheduler_test.go
@@ -1,0 +1,73 @@
+package skill
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInterval(t *testing.T) {
+	d, err := parseInterval("30m")
+	require.NoError(t, err)
+	assert.Equal(t, 30*time.Minute, d)
+
+	_, err = parseInterval("30s")
+	require.Error(t, err, "sub-minute cadence is rejected")
+	_, err = parseInterval("garbage")
+	require.Error(t, err)
+}
+
+func TestSchedulerReplaceSkillsParses(t *testing.T) {
+	s := NewScheduler(NewEngine(Options{}), nil)
+	s.ReplaceSkills([]Skill{
+		{Name: "interval", Trigger: Trigger{Kind: KindSchedule, Schedule: "1h"}, Action: Action{Type: TypeStatic, Template: "tick"}},
+		{Name: "cron", Trigger: Trigger{Kind: KindSchedule, Schedule: "*/5 * * * *"}, Action: Action{Type: TypeStatic, Template: "cron"}},
+		{Name: "bad", Trigger: Trigger{Kind: KindSchedule, Schedule: "nonsense"}, Action: Action{Type: TypeStatic}},
+		{Name: "notsched", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeStatic}},
+	})
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	require.Len(t, s.items, 2, "only valid schedule skills are kept")
+}
+
+func TestSchedulerTickFires(t *testing.T) {
+	act := &fakeActor{}
+	eng := NewEngine(Options{Actor: act})
+	s := NewScheduler(eng, nil)
+	base := time.Unix(0, 0).UTC()
+	s.now = func() time.Time { return base }
+	s.ReplaceSkills([]Skill{{
+		Name:    "announce",
+		Trigger: Trigger{Kind: KindSchedule, Schedule: "30m", Channels: []string{"#room"}},
+		Action:  Action{Type: TypeStatic, Template: "scheduled hello"},
+	}})
+
+	// Before the first interval — nothing fires.
+	s.tick(context.Background(), base.Add(time.Minute))
+	assert.Empty(t, act.snapshot())
+
+	// Past the interval — it fires to the scoped channel.
+	s.tick(context.Background(), base.Add(31*time.Minute))
+	assert.Equal(t, []string{"say #room scheduled hello"}, act.snapshot())
+
+	// Immediately again — not yet re-due.
+	s.tick(context.Background(), base.Add(32*time.Minute))
+	assert.Len(t, act.snapshot(), 1)
+}
+
+func TestSchedulerRunStopsOnCancel(t *testing.T) {
+	s := NewScheduler(NewEngine(Options{}), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -137,20 +137,23 @@ type Effect struct {
 	Thresholds *Thresholds `json:"thresholds,omitempty"`
 }
 
-// Trigger is what makes a skill fire.
+// Trigger is what makes a skill fire. The JSON tags are used when a Trigger is
+// nested directly in another document (e.g. a flow); the flat skill wire maps
+// these fields by hand in Skill's (Un)MarshalJSON and does not marshal a
+// Trigger directly.
 type Trigger struct {
 	// Kind selects the trigger family. Empty decodes as KindCommand.
-	Kind TriggerKind
+	Kind TriggerKind `json:"kind,omitempty"`
 	// Event is the lifecycle event for KindEvent.
-	Event string
+	Event string `json:"event,omitempty"`
 	// Match is the regex for KindMatch (and the cheap prefilter for an
 	// llm_classify action).
-	Match string
+	Match string `json:"match,omitempty"`
 	// Schedule is the interval ("30m"/"1h"/"45s") or 5-field cron for
 	// KindSchedule.
-	Schedule string
+	Schedule string `json:"schedule,omitempty"`
 	// Channels scopes the trigger to specific channels. Empty = all.
-	Channels []string
+	Channels []string `json:"channels,omitempty"`
 }
 
 // Action is what a skill does when it fires.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,0 +1,311 @@
+// Package skill generalizes data-driven command definitions into a
+// trigger+action engine. A skill pairs a trigger (what makes it fire) with
+// an action (what it does):
+//
+//   - command  trigger: a prefixed word a user types (the historical "command").
+//   - event    trigger: a connector lifecycle event (join/leave/kick/…).
+//   - match    trigger: a regular expression tested against every message.
+//   - schedule trigger: a fixed interval or cron cadence.
+//
+// Actions render a template as a literal reply, run it as an LLM prompt,
+// classify a message with an LLM and map the verdict onto a moderation
+// effect, or run a moderation effect directly (kick/ban/mute/…).
+//
+// The wire shape is FLAT and backward-compatible: a legacy command
+// definition ({name,type,template,instructions,access,allowlist}) decodes to
+// a command/reply skill identical to the historical one, and any skill whose
+// new fields are all default marshals byte-identically to the legacy shape.
+// All new fields are optional. Internally a Skill is a nested
+// Skill{Trigger, Action} value; (Un)MarshalJSON map between the flat wire and
+// the nested form.
+//
+// The package is transport-agnostic and declarative only: there is no
+// sandboxed or arbitrary code execution. Definitions arrive as JSON (from an
+// env var or a polled feed), are decoded into Skill values, and split into
+// command handlers (for the agent's CommandRegistry) and engine skills (for
+// the event/match/schedule Engine).
+package skill
+
+import (
+	"encoding/json"
+
+	"github.com/turborg/turborg/internal/commands"
+)
+
+// Type is the action kind. Static renders the template as a literal reply;
+// LLM runs it as a prompt; LLMClassify asks an LLM for a structured verdict
+// and maps it onto a moderation effect; Effect runs a moderation effect.
+type Type string
+
+const (
+	// TypeStatic renders the template (with placeholders substituted) as the
+	// literal reply — a deterministic, zero-cost canned response.
+	TypeStatic Type = "static"
+	// TypeLLM runs the rendered template as a prompt against the configured
+	// LLM provider and replies with the model's answer.
+	TypeLLM Type = "llm"
+	// TypeLLMClassify asks the LLM for a structured {severity,action,reason}
+	// verdict on the triggering message and maps the severity onto a
+	// moderation effect via the action's effect thresholds.
+	TypeLLMClassify Type = "llm_classify"
+	// TypeEffect runs a moderation effect (kick/ban/mute/…) directly when the
+	// trigger fires. With effect thresholds set it becomes a flood gate keyed
+	// off a per-sender sliding-window message count.
+	TypeEffect Type = "effect"
+	// TypeWebhook POSTs the trigger context as JSON to an external URL when the
+	// skill fires. It is the integration seam to outbound flow engines: turborg
+	// is the trigger source + action sink, the external graph does the rest.
+	TypeWebhook Type = "webhook"
+)
+
+// Access is the per-skill trust policy deciding who may trigger a command
+// skill. It is meaningful for command triggers; event/match/schedule skills
+// are operator-installed and not user-invoked, so access does not gate them.
+type Access = commands.Access
+
+const (
+	// AccessEveryone lets any sender trigger the skill.
+	AccessEveryone = commands.AccessEveryone
+	// AccessOwner restricts the skill to the verified owner.
+	AccessOwner = commands.AccessOwner
+	// AccessAllowlist allows the owner plus an explicit nick/account list.
+	AccessAllowlist = commands.AccessAllowlist
+)
+
+// TriggerKind selects what makes a skill fire.
+type TriggerKind string
+
+const (
+	// KindCommand fires on a prefixed command word (the historical default).
+	KindCommand TriggerKind = "command"
+	// KindEvent fires on a connector lifecycle event named by Trigger.Event.
+	KindEvent TriggerKind = "event"
+	// KindMatch fires when Trigger.Match (a regex) matches a message.
+	KindMatch TriggerKind = "match"
+	// KindSchedule fires on the cadence named by Trigger.Schedule.
+	KindSchedule TriggerKind = "schedule"
+)
+
+// Event names valid for an event-trigger skill. They mirror the agent's
+// EventBus user-event types but are kept as a closed set here so a malformed
+// definition fails validation rather than silently never firing.
+const (
+	EventUserJoin       = "USER_JOIN"
+	EventUserLeave      = "USER_LEAVE"
+	EventUserKicked     = "USER_KICKED"
+	EventUserNickChange = "USER_NICK_CHANGE"
+	EventTopicChanged   = "TOPIC_CHANGED"
+	EventModeChanged    = "MODE_CHANGED"
+)
+
+// EffectAction is a moderation action an Effect can perform.
+type EffectAction string
+
+const (
+	EffectKick   EffectAction = "kick"
+	EffectBan    EffectAction = "ban"
+	EffectMute   EffectAction = "mute"
+	EffectOp     EffectAction = "op"
+	EffectVoice  EffectAction = "voice"
+	EffectMode   EffectAction = "mode"
+	EffectNotice EffectAction = "notice"
+	EffectTopic  EffectAction = "topic"
+)
+
+// Thresholds maps a 0..3 severity onto an escalating action. Each field is
+// the lowest severity (or, for a flood gate, the lowest count) at which that
+// action triggers; the highest matched tier wins. A zero field disables that
+// tier. warn maps to a notice.
+type Thresholds struct {
+	Warn int `json:"warn,omitempty"`
+	Mute int `json:"mute,omitempty"`
+	Kick int `json:"kick,omitempty"`
+	Ban  int `json:"ban,omitempty"`
+}
+
+// Effect parameterizes a moderation action.
+type Effect struct {
+	// Action is the moderation action to perform. For llm_classify (and a
+	// flood gate) the action is derived from Thresholds instead and this is
+	// the optional default fallback.
+	Action EffectAction `json:"action,omitempty"`
+	// Modes is the raw mode string for Action=="mode" (e.g. "+m").
+	Modes string `json:"modes,omitempty"`
+	// Reason annotates a kick/ban.
+	Reason string `json:"reason,omitempty"`
+	// Thresholds maps a verdict severity / flood count onto an action.
+	Thresholds *Thresholds `json:"thresholds,omitempty"`
+}
+
+// Trigger is what makes a skill fire.
+type Trigger struct {
+	// Kind selects the trigger family. Empty decodes as KindCommand.
+	Kind TriggerKind
+	// Event is the lifecycle event for KindEvent.
+	Event string
+	// Match is the regex for KindMatch (and the cheap prefilter for an
+	// llm_classify action).
+	Match string
+	// Schedule is the interval ("30m"/"1h"/"45s") or 5-field cron for
+	// KindSchedule.
+	Schedule string
+	// Channels scopes the trigger to specific channels. Empty = all.
+	Channels []string
+}
+
+// Action is what a skill does when it fires.
+type Action struct {
+	// Type selects the action kind.
+	Type Type
+	// Template is the reply/prompt template, with placeholders.
+	Template string
+	// Instructions is the LLM system prompt for llm / llm_classify actions.
+	Instructions string
+	// Model optionally overrides the LLM model for this skill.
+	Model string
+	// Effect parameterizes a moderation action (effect / llm_classify).
+	Effect *Effect
+	// Webhook is the outbound URL a webhook action POSTs the trigger context
+	// to. Empty for non-webhook actions.
+	Webhook string
+}
+
+// Skill is one declarative trigger+action unit. It is the nested in-memory
+// form; the wire form is flat (see MarshalJSON / UnmarshalJSON).
+type Skill struct {
+	Name      string
+	Access    Access
+	Allowlist []string
+	Trigger   Trigger
+	Action    Action
+}
+
+// wire is the flat JSON shape shared by the legacy command definition and the
+// generalized skill. Field order matches the legacy commands.Definition so a
+// command/reply skill marshals byte-identically to the historical wire; the
+// generalized fields follow and are all omitempty.
+type wire struct {
+	Name         string   `json:"name"`
+	Type         Type     `json:"type"`
+	Template     string   `json:"template"`
+	Instructions string   `json:"instructions,omitempty"`
+	Model        string   `json:"model,omitempty"`
+	Access       Access   `json:"access"`
+	Allowlist    []string `json:"allowlist,omitempty"`
+
+	TriggerKind TriggerKind `json:"trigger_kind,omitempty"`
+	Event       string      `json:"event,omitempty"`
+	Match       string      `json:"match,omitempty"`
+	Schedule    string      `json:"schedule,omitempty"`
+	Channels    []string    `json:"channels,omitempty"`
+	Effect      *Effect     `json:"effect,omitempty"`
+	Webhook     string      `json:"webhook,omitempty"`
+}
+
+// UnmarshalJSON decodes the flat wire (including the legacy command shape)
+// into the nested Skill. An absent trigger_kind defaults to KindCommand, so
+// historical command definitions decode to command/reply skills unchanged.
+func (s *Skill) UnmarshalJSON(b []byte) error {
+	var w wire
+	if err := json.Unmarshal(b, &w); err != nil {
+		return err
+	}
+	kind := w.TriggerKind
+	if kind == "" {
+		kind = KindCommand
+	}
+	*s = Skill{
+		Name:      w.Name,
+		Access:    w.Access,
+		Allowlist: w.Allowlist,
+		Trigger: Trigger{
+			Kind:     kind,
+			Event:    w.Event,
+			Match:    w.Match,
+			Schedule: w.Schedule,
+			Channels: w.Channels,
+		},
+		Action: Action{
+			Type:         w.Type,
+			Template:     w.Template,
+			Instructions: w.Instructions,
+			Model:        w.Model,
+			Effect:       w.Effect,
+			Webhook:      w.Webhook,
+		},
+	}
+	return nil
+}
+
+// MarshalJSON emits the flat wire and omits defaults: a command-kind skill
+// leaves trigger_kind unset so the output matches the legacy command shape
+// byte-for-byte, and all generalized fields are omitempty.
+func (s Skill) MarshalJSON() ([]byte, error) {
+	w := wire{
+		Name:         s.Name,
+		Type:         s.Action.Type,
+		Template:     s.Action.Template,
+		Instructions: s.Action.Instructions,
+		Model:        s.Action.Model,
+		Access:       s.Access,
+		Allowlist:    s.Allowlist,
+		Event:        s.Trigger.Event,
+		Match:        s.Trigger.Match,
+		Schedule:     s.Trigger.Schedule,
+		Channels:     s.Trigger.Channels,
+		Effect:       s.Action.Effect,
+		Webhook:      s.Action.Webhook,
+	}
+	// Omit the default command kind so legacy payloads round-trip identically.
+	if s.Trigger.Kind != "" && s.Trigger.Kind != KindCommand {
+		w.TriggerKind = s.Trigger.Kind
+	}
+	return json.Marshal(w)
+}
+
+// IsCommand reports whether the skill fires on a command word (the default).
+func (s Skill) IsCommand() bool {
+	return s.Trigger.Kind == "" || s.Trigger.Kind == KindCommand
+}
+
+// ToDefinition projects a command-kind skill onto the legacy command
+// definition consumed by the command builder. It is only meaningful for
+// command-kind skills (IsCommand); the generalized trigger/effect fields are
+// not part of a command definition and are dropped.
+func (s Skill) ToDefinition() commands.Definition {
+	return commands.Definition{
+		Name:         s.Name,
+		Type:         commands.Type(s.Action.Type),
+		Template:     s.Action.Template,
+		Instructions: s.Action.Instructions,
+		Model:        s.Action.Model,
+		Access:       s.Access,
+		Allowlist:    s.Allowlist,
+	}
+}
+
+// Command builds a command-kind skill from flat fields — an ergonomic
+// constructor for callers (and tests) that would otherwise nest by hand.
+func Command(name string, typ Type, template string, access Access, allowlist ...string) Skill {
+	return Skill{
+		Name:      name,
+		Access:    access,
+		Allowlist: allowlist,
+		Trigger:   Trigger{Kind: KindCommand},
+		Action:    Action{Type: typ, Template: template},
+	}
+}
+
+// Split partitions skills into command-kind definitions (for the command
+// registry) and the remaining event/match/schedule skills (for the Engine).
+// Order is preserved within each partition.
+func Split(skills []Skill) (cmds []commands.Definition, engine []Skill) {
+	for _, s := range skills {
+		if s.IsCommand() {
+			cmds = append(cmds, s.ToDefinition())
+			continue
+		}
+		engine = append(engine, s)
+	}
+	return cmds, engine
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -84,6 +84,11 @@ const (
 	KindMatch TriggerKind = "match"
 	// KindSchedule fires on the cadence named by Trigger.Schedule.
 	KindSchedule TriggerKind = "schedule"
+	// KindWebhook fires when an external system POSTs to the skill's inbound
+	// webhook URL. The decoded request body seeds the render/data bag. It is the
+	// inbound counterpart to the outbound TypeWebhook action: here turborg is the
+	// action sink an external event drives, rather than the trigger source.
+	KindWebhook TriggerKind = "webhook"
 )
 
 // Event names valid for an event-trigger skill. They mirror the agent's

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -135,6 +135,11 @@ type Effect struct {
 	Reason string `json:"reason,omitempty"`
 	// Thresholds maps a verdict severity / flood count onto an action.
 	Thresholds *Thresholds `json:"thresholds,omitempty"`
+	// DurationSeconds, when > 0 and Action is a reversible mode
+	// (mute/ban/mode/op/voice), auto-lifts the applied mode after that many
+	// seconds. The pending lift is persisted via the Store so it survives a
+	// restart. Non-reversible actions (kick/notice/topic) ignore it.
+	DurationSeconds int `json:"duration_seconds,omitempty"`
 }
 
 // Trigger is what makes a skill fire. The JSON tags are used when a Trigger is

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,0 +1,114 @@
+package skill
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/commands"
+)
+
+// TestLegacyCommandRoundTrip proves a legacy command definition decodes to a
+// command/reply skill identical to today and marshals back byte-identically —
+// the backward-compatibility guarantee.
+func TestLegacyCommandRoundTrip(t *testing.T) {
+	legacy := `{"name":"rules","type":"static","template":"be nice","access":"everyone"}`
+
+	var s Skill
+	require.NoError(t, json.Unmarshal([]byte(legacy), &s))
+
+	assert.Equal(t, "rules", s.Name)
+	assert.True(t, s.IsCommand(), "absent trigger_kind defaults to command")
+	assert.Equal(t, KindCommand, s.Trigger.Kind)
+	assert.Equal(t, TypeStatic, s.Action.Type)
+	assert.Equal(t, "be nice", s.Action.Template)
+	assert.Equal(t, AccessEveryone, s.Access)
+
+	// The decoded skill projects onto the legacy command definition unchanged.
+	def := s.ToDefinition()
+	assert.Equal(t, commands.Definition{
+		Name: "rules", Type: commands.TypeStatic, Template: "be nice", Access: commands.AccessEveryone,
+	}, def)
+
+	// Re-marshal must match the legacy bytes exactly (trigger_kind omitted).
+	out, err := json.Marshal(s)
+	require.NoError(t, err)
+	assert.JSONEq(t, legacy, string(out))
+	assert.NotContains(t, string(out), "trigger_kind", "default command kind must be omitted")
+}
+
+// TestLegacyArrayMatchesCommandsDefinition pins that an array of legacy command
+// objects marshals identically whether modeled as a Skill or the historical
+// commands.Definition.
+func TestLegacyArrayMatchesCommandsDefinition(t *testing.T) {
+	def := commands.Definition{Name: "ask", Type: commands.TypeLLM, Template: "{args}", Instructions: "be terse", Access: commands.AccessOwner, Allowlist: []string{"a"}}
+	defBytes, err := json.Marshal(def)
+	require.NoError(t, err)
+
+	var s Skill
+	require.NoError(t, json.Unmarshal(defBytes, &s))
+	skillBytes, err := json.Marshal(s)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(defBytes), string(skillBytes))
+}
+
+func TestUnmarshalFullWire(t *testing.T) {
+	raw := `{
+	  "name":"flood",
+	  "type":"effect",
+	  "trigger_kind":"match",
+	  "match":".*",
+	  "channels":["#ops"],
+	  "effect":{"action":"kick","reason":"slow down","thresholds":{"warn":3,"kick":5}}
+	}`
+	var s Skill
+	require.NoError(t, json.Unmarshal([]byte(raw), &s))
+
+	assert.Equal(t, KindMatch, s.Trigger.Kind)
+	assert.Equal(t, ".*", s.Trigger.Match)
+	assert.Equal(t, []string{"#ops"}, s.Trigger.Channels)
+	assert.False(t, s.IsCommand())
+	require.NotNil(t, s.Action.Effect)
+	assert.Equal(t, EffectKick, s.Action.Effect.Action)
+	require.NotNil(t, s.Action.Effect.Thresholds)
+	assert.Equal(t, 5, s.Action.Effect.Thresholds.Kick)
+}
+
+func TestMarshalEmitsTriggerKindWhenNonDefault(t *testing.T) {
+	s := Skill{
+		Name:    "greet",
+		Trigger: Trigger{Kind: KindEvent, Event: EventUserJoin},
+		Action:  Action{Type: TypeStatic, Template: "welcome {nick}"},
+	}
+	out, err := json.Marshal(s)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"trigger_kind":"event"`)
+	assert.Contains(t, string(out), `"event":"USER_JOIN"`)
+}
+
+func TestUnmarshalRejectsBadJSON(t *testing.T) {
+	var s Skill
+	require.Error(t, s.UnmarshalJSON([]byte(`{bad`)))
+}
+
+func TestCommandConstructor(t *testing.T) {
+	s := Command("team", TypeStatic, "ok", AccessAllowlist, "alice", "bob")
+	assert.True(t, s.IsCommand())
+	assert.Equal(t, []string{"alice", "bob"}, s.Allowlist)
+	assert.Equal(t, "ok", s.Action.Template)
+}
+
+func TestSplitPartitionsByKind(t *testing.T) {
+	skills := []Skill{
+		Command("rules", TypeStatic, "be nice", AccessEveryone),
+		{Name: "greet", Trigger: Trigger{Kind: KindEvent, Event: EventUserJoin}, Action: Action{Type: TypeStatic, Template: "hi"}},
+		{Name: "flood", Trigger: Trigger{Kind: KindMatch, Match: ".*"}, Action: Action{Type: TypeEffect}},
+	}
+	cmds, engine := Split(skills)
+	require.Len(t, cmds, 1)
+	assert.Equal(t, "rules", cmds[0].Name)
+	require.Len(t, engine, 2)
+	assert.Equal(t, "greet", engine[0].Name)
+}

--- a/internal/skill/store.go
+++ b/internal/skill/store.go
@@ -1,0 +1,99 @@
+package skill
+
+import (
+	"sync"
+	"time"
+)
+
+// Store is the small key/value + counter backend skills use for state that
+// must survive between fires: a value with an optional TTL (setvar/getvar) and
+// a per-key sliding-window counter (flood detection). Keys are namespaced by
+// skill name so two skills can't collide. Implementations must be safe for
+// concurrent use.
+type Store interface {
+	// Get returns the stored value for (skill,key) and whether it was present
+	// and unexpired.
+	Get(skill, key string) (string, bool)
+	// Set stores val for (skill,key). A positive ttl expires it after that
+	// duration; a non-positive ttl stores it without expiry.
+	Set(skill, key, val string, ttl time.Duration)
+	// Incr records one hit for (skill,key) in a sliding window and returns the
+	// number of hits within the window (including this one).
+	Incr(skill, key string, window time.Duration) (int, error)
+}
+
+// clock abstracts the time source so tests can drive TTLs and windows
+// deterministically.
+type clock func() time.Time
+
+type memValue struct {
+	val       string
+	expiresAt time.Time // zero = no expiry
+}
+
+// MemoryStore is the default in-process Store. Values support TTL expiry and
+// counters use a sliding window pruned on each Incr, mirroring the IRC
+// throttle's window bookkeeping.
+type MemoryStore struct {
+	now clock
+
+	mu     sync.Mutex
+	values map[string]memValue
+	counts map[string][]time.Time
+}
+
+// NewMemoryStore returns an empty in-process store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		now:    time.Now,
+		values: map[string]memValue{},
+		counts: map[string][]time.Time{},
+	}
+}
+
+func storeKey(skill, key string) string { return skill + "\x00" + key }
+
+func (m *MemoryStore) Get(skill, key string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.values[storeKey(skill, key)]
+	if !ok {
+		return "", false
+	}
+	if !v.expiresAt.IsZero() && !m.now().Before(v.expiresAt) {
+		delete(m.values, storeKey(skill, key))
+		return "", false
+	}
+	return v.val, true
+}
+
+func (m *MemoryStore) Set(skill, key, val string, ttl time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var exp time.Time
+	if ttl > 0 {
+		exp = m.now().Add(ttl)
+	}
+	m.values[storeKey(skill, key)] = memValue{val: val, expiresAt: exp}
+}
+
+func (m *MemoryStore) Incr(skill, key string, window time.Duration) (int, error) {
+	if window <= 0 {
+		window = time.Minute
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := storeKey(skill, key)
+	now := m.now()
+	cutoff := now.Add(-window)
+	bucket := m.counts[k]
+	pruned := bucket[:0]
+	for _, t := range bucket {
+		if !t.Before(cutoff) {
+			pruned = append(pruned, t)
+		}
+	}
+	pruned = append(pruned, now)
+	m.counts[k] = pruned
+	return len(pruned), nil
+}

--- a/internal/skill/store.go
+++ b/internal/skill/store.go
@@ -17,6 +17,9 @@ type Store interface {
 	// Set stores val for (skill,key). A positive ttl expires it after that
 	// duration; a non-positive ttl stores it without expiry.
 	Set(skill, key, val string, ttl time.Duration)
+	// Delete removes any stored value for (skill,key). A no-op when the key is
+	// absent.
+	Delete(skill, key string)
 	// Incr records one hit for (skill,key) in a sliding window and returns the
 	// number of hits within the window (including this one).
 	Incr(skill, key string, window time.Duration) (int, error)
@@ -75,6 +78,12 @@ func (m *MemoryStore) Set(skill, key, val string, ttl time.Duration) {
 		exp = m.now().Add(ttl)
 	}
 	m.values[storeKey(skill, key)] = memValue{val: val, expiresAt: exp}
+}
+
+func (m *MemoryStore) Delete(skill, key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.values, storeKey(skill, key))
 }
 
 func (m *MemoryStore) Incr(skill, key string, window time.Duration) (int, error) {

--- a/internal/skill/store_test.go
+++ b/internal/skill/store_test.go
@@ -1,0 +1,64 @@
+package skill
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreSetGetNamespaced(t *testing.T) {
+	s := NewMemoryStore()
+	s.Set("a", "k", "v1", 0)
+	s.Set("b", "k", "v2", 0)
+
+	got, ok := s.Get("a", "k")
+	require.True(t, ok)
+	assert.Equal(t, "v1", got)
+	got, ok = s.Get("b", "k")
+	require.True(t, ok)
+	assert.Equal(t, "v2", got, "keys are namespaced by skill")
+
+	_, ok = s.Get("a", "missing")
+	assert.False(t, ok)
+}
+
+func TestStoreTTLExpiry(t *testing.T) {
+	s := NewMemoryStore()
+	now := time.Unix(1000, 0)
+	s.now = func() time.Time { return now }
+
+	s.Set("a", "k", "v", time.Minute)
+	got, ok := s.Get("a", "k")
+	require.True(t, ok)
+	assert.Equal(t, "v", got)
+
+	now = now.Add(2 * time.Minute)
+	_, ok = s.Get("a", "k")
+	assert.False(t, ok, "value past its TTL is gone")
+}
+
+func TestStoreIncrSlidingWindow(t *testing.T) {
+	s := NewMemoryStore()
+	now := time.Unix(0, 0)
+	s.now = func() time.Time { return now }
+
+	for i := 1; i <= 3; i++ {
+		n, err := s.Incr("flood", "alice", 10*time.Second)
+		require.NoError(t, err)
+		assert.Equal(t, i, n)
+	}
+	// Advance past the window — the count resets.
+	now = now.Add(11 * time.Second)
+	n, err := s.Incr("flood", "alice", 10*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "events older than the window are pruned")
+}
+
+func TestStoreIncrDefaultsWindow(t *testing.T) {
+	s := NewMemoryStore()
+	n, err := s.Incr("flood", "k", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+}

--- a/internal/skill/store_test.go
+++ b/internal/skill/store_test.go
@@ -62,3 +62,17 @@ func TestStoreIncrDefaultsWindow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 }
+
+func TestStoreDelete(t *testing.T) {
+	s := NewMemoryStore()
+	s.Set("ns", "k", "v", 0)
+	if _, ok := s.Get("ns", "k"); !ok {
+		t.Fatal("expected value present before delete")
+	}
+	s.Delete("ns", "k")
+	if _, ok := s.Get("ns", "k"); ok {
+		t.Fatal("expected value gone after delete")
+	}
+	// Deleting an absent key is a no-op (must not panic).
+	s.Delete("ns", "missing")
+}

--- a/internal/skill/webhook_test.go
+++ b/internal/skill/webhook_test.go
@@ -1,0 +1,73 @@
+package skill
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func webhookSkill(name string, channels ...string) Skill {
+	return Skill{
+		Name:    name,
+		Trigger: Trigger{Kind: KindWebhook, Channels: channels},
+		Action:  Action{Type: TypeStatic, Template: "{text} from {user}"},
+	}
+}
+
+func TestEngineFireWebhookDispatch(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{webhookSkill("deploy")})
+
+	ok := e.FireWebhook("deploy", map[string]string{"channel": "#ops", "text": "ship", "user": "ci"})
+	assert.True(t, ok)
+	assert.Equal(t, []string{"say #ops ship from ci"}, act.snapshot())
+}
+
+func TestEngineFireWebhookCaseInsensitive(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{webhookSkill("Deploy")})
+
+	assert.True(t, e.FireWebhook("DEPLOY", map[string]string{"channel": "#c", "text": "x", "user": "u"}))
+	assert.Equal(t, []string{"say #c x from u"}, act.snapshot())
+}
+
+func TestEngineFireWebhookUnknownName(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{webhookSkill("deploy")})
+
+	assert.False(t, e.FireWebhook("ghost", map[string]string{"channel": "#c", "text": "x"}))
+	assert.Empty(t, act.snapshot())
+}
+
+func TestEngineFireWebhookTriggerChannelWins(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{webhookSkill("deploy", "#locked")})
+
+	assert.True(t, e.FireWebhook("deploy", map[string]string{"channel": "#attacker", "text": "x", "user": "u"}))
+	assert.Equal(t, []string{"say #locked x from u"}, act.snapshot())
+}
+
+func TestEngineFireWebhookEmptyNameDropped(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{webhookSkill("")}) // empty name is dropped at index time
+
+	assert.False(t, e.FireWebhook("", map[string]string{"channel": "#c", "text": "x"}))
+	assert.Empty(t, act.snapshot())
+}
+
+func TestEngineFireWebhookNotIndexedForOtherKinds(t *testing.T) {
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.ReplaceSkills([]Skill{{
+		Name:    "deploy",
+		Trigger: Trigger{Kind: KindMatch, Match: "hi"},
+		Action:  Action{Type: TypeStatic, Template: "x"},
+	}})
+	assert.False(t, e.FireWebhook("deploy", map[string]string{"text": "x"}))
+	assert.Empty(t, act.snapshot())
+}

--- a/internal/web/gateway.go
+++ b/internal/web/gateway.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +34,15 @@ const (
 	gatewayReadHeaderTimeout = 10 * time.Second
 	gatewayWriteTimeout      = 30 * time.Second
 	gatewayIdleTimeout       = 60 * time.Second
+)
+
+const (
+	// hookMaxBodyBytes bounds an inbound webhook body so a large or streaming
+	// POST can't exhaust memory. 64 KiB is generous for a JSON event envelope.
+	hookMaxBodyBytes = 64 << 10
+	// hookReadTimeout bounds how long the handler waits on the request body so a
+	// slow sender can't pin the connection.
+	hookReadTimeout = 5 * time.Second
 )
 
 // activityHeartbeatInterval is how often an engaged web session
@@ -112,6 +123,14 @@ type Options struct {
 	// TBSummarizeMaxMessages caps how many messages /tb summarize can
 	// consume per invocation. 0 = feature disabled.
 	TBSummarizeMaxMessages int
+
+	// WebhookFire dispatches an authenticated inbound webhook (POST /hook/{name})
+	// to the trigger machinery. name is the per-flow path segment; bag is the
+	// flat string data bag decoded from the request body. It returns true when a
+	// matching webhook trigger fired. Nil disables the /hook ingress route (every
+	// request answers 404), so a deployment without trigger wiring exposes no
+	// ingress surface.
+	WebhookFire func(name string, bag map[string]string) bool
 }
 
 // Gateway is an HTTP server exposing /ws (WebSocket), /health, /metrics,
@@ -243,6 +262,7 @@ func (g *Gateway) Handler() http.Handler {
 	mux.HandleFunc("/ws", g.handleWS)
 	mux.HandleFunc("/health", g.handleHealth)
 	mux.HandleFunc("/metrics", g.handleMetrics)
+	mux.HandleFunc("POST /hook/{name}", g.handleHook)
 	if staticSub, err := fs.Sub(staticFS, "static"); err == nil {
 		mux.Handle("/", http.FileServer(http.FS(staticSub)))
 	}
@@ -473,6 +493,128 @@ func (g *Gateway) sendInitialConnectorState(ctx context.Context, c *client) {
 		"severity":      irc.SeverityForUpstreamState(state),
 		"server_reason": machine.ServerReason(),
 	})
+}
+
+// handleHook is the inbound-webhook ingress: an external system POSTs a JSON
+// body to POST /hook/{name} to fire the flow/skill whose webhook trigger carries
+// that name. It authenticates every request against the same verifier the WS
+// surface uses (Authorization: Bearer <token> or ?token=), rejecting an
+// unauthenticated caller with 401 and no body detail before any body is read or
+// any trigger is consulted. A missing/unknown name — or a deployment with no
+// trigger wiring — answers 404 with no detail so a caller can neither enumerate
+// installed triggers nor probe other tenants. The body is size-capped and read
+// under a short deadline.
+func (g *Gateway) handleHook(w http.ResponseWriter, r *http.Request) {
+	ip := clientIP(r)
+	token := extractToken(r)
+
+	// Brute-force gate — identical to the WS path so both surfaces share one
+	// lockout bucket per IP.
+	if g.opts.RateLimiter != nil && ip != "" && g.opts.RateLimiter.IsLocked(ip) {
+		http.Error(w, "Too many attempts", http.StatusTooManyRequests)
+		return
+	}
+	if !g.opts.Verifier.Verify(token) {
+		if g.opts.RateLimiter != nil && ip != "" {
+			g.opts.RateLimiter.RecordFailure(ip)
+		}
+		g.metMu.Lock()
+		g.metrics.authFailures++
+		g.metMu.Unlock()
+		g.log.Info("web hook auth fail", "ip", ip)
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+	if g.opts.RateLimiter != nil && ip != "" {
+		g.opts.RateLimiter.RecordSuccess(ip)
+	}
+
+	// No wiring or no name → 404 with no detail. Same opaque answer as an
+	// unknown trigger, so an authenticated caller can't distinguish "no ingress
+	// configured" from "name not found".
+	if g.opts.WebhookFire == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	name := r.PathValue("name")
+	if name == "" {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	// Bound the body and read it under a short deadline. LimitReader takes one
+	// byte past the cap so an over-cap body is detectable rather than silently
+	// truncated into a valid-looking payload.
+	if rc := http.NewResponseController(w); rc != nil {
+		_ = rc.SetReadDeadline(time.Now().Add(hookReadTimeout))
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, hookMaxBodyBytes+1))
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if len(body) > hookMaxBodyBytes {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	if !g.opts.WebhookFire(name, webhookBag(body)) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	// Additive audit signal — one WEBHOOK_RECEIVED per fired trigger. Carries
+	// only the trigger name (no body), so the audit trail can't leak payloads.
+	g.mu.Lock()
+	bus := g.bus
+	g.mu.Unlock()
+	if bus != nil {
+		bus.Publish(context.Background(), &agent.Event{
+			Type:   agent.EventWebhookReceived,
+			Time:   time.Now(),
+			Fields: map[string]any{"name": name},
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+// webhookBag flattens a decoded webhook JSON body into the string data bag the
+// trigger machinery consumes: each top-level scalar (string/number/bool/null)
+// becomes a string var, the raw JSON is preserved under "body", and {user} is
+// seeded from the first present user/from/sender field. A body that isn't a JSON
+// object still yields a bag with the raw "body" so a flow can parse it itself.
+func webhookBag(raw []byte) map[string]string {
+	bag := map[string]string{"body": string(raw)}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return bag
+	}
+	for k, v := range obj {
+		switch val := v.(type) {
+		case string:
+			bag[k] = val
+		case float64:
+			bag[k] = strconv.FormatFloat(val, 'f', -1, 64)
+		case bool:
+			bag[k] = strconv.FormatBool(val)
+		case nil:
+			bag[k] = ""
+		default:
+			// Nested object/array: not a scalar var, but still reachable via
+			// the raw "body" for a flow that wants to parse it.
+		}
+	}
+	for _, k := range []string{"user", "from", "sender"} {
+		if v := bag[k]; v != "" {
+			bag["user"] = v
+			break
+		}
+	}
+	return bag
 }
 
 func (g *Gateway) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/hook_test.go
+++ b/internal/web/hook_test.go
@@ -1,0 +1,212 @@
+package web_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/web"
+)
+
+// captureFire records the last (name, bag) FireWebhook was called with and
+// returns a configurable result.
+type captureFire struct {
+	mu     sync.Mutex
+	calls  int
+	name   string
+	bag    map[string]string
+	result bool
+}
+
+func (c *captureFire) fn(name string, bag map[string]string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	c.name = name
+	c.bag = bag
+	return c.result
+}
+
+func (c *captureFire) snapshot() (int, string, map[string]string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls, c.name, c.bag
+}
+
+// newHookGateway builds a gateway whose /hook route dispatches to fire, without
+// binding a listener — tests drive Handler() directly with httptest.
+func newHookGateway(t *testing.T, password string, fire func(string, map[string]string) bool) (*web.Gateway, *agent.Agent) {
+	t.Helper()
+	v, err := web.NewStaticPasswordVerifier(password)
+	require.NoError(t, err)
+	g, err := web.New(newFakeBridge("bot"), &fakeSender{}, web.Options{
+		Verifier:    v,
+		WebhookFire: fire,
+	})
+	require.NoError(t, err)
+	a := agent.New(nil)
+	g.Subscribe(a.Events)
+	return g, a
+}
+
+func postHook(g *web.Gateway, target string, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHookRejectsMissingToken(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	rec := postHook(g, "/hook/deploy", `{"text":"hi"}`)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	calls, _, _ := cap.snapshot()
+	assert.Zero(t, calls, "dispatch must not run for an unauthenticated request")
+}
+
+func TestHookRejectsBadToken(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	rec := postHook(g, "/hook/deploy?token=wrong", `{"text":"hi"}`)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "deploy", "401 body must not leak the flow name")
+	calls, _, _ := cap.snapshot()
+	assert.Zero(t, calls)
+}
+
+func TestHookAcceptsBearerToken(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	req := httptest.NewRequest(http.MethodPost, "/hook/deploy", strings.NewReader(`{"text":"hi"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	calls, name, _ := cap.snapshot()
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "deploy", name)
+}
+
+func TestHookUnknownNameReturns404(t *testing.T) {
+	cap := &captureFire{result: false} // no matching trigger
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	rec := postHook(g, "/hook/ghost?token=secret", `{"text":"hi"}`)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "ghost", "404 body must not echo the requested name")
+	calls, name, _ := cap.snapshot()
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "ghost", name)
+}
+
+func TestHookDisabledWhenNoDispatcher(t *testing.T) {
+	g, _ := newHookGateway(t, "secret", nil) // WebhookFire nil = ingress disabled
+
+	rec := postHook(g, "/hook/deploy?token=secret", `{"text":"hi"}`)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHookFiresWithBodyInBag(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, a := newHookGateway(t, "secret", cap.fn)
+
+	// Audit event should fire exactly once on a successful dispatch.
+	var audit int
+	var auditMu sync.Mutex
+	a.Events.Subscribe(agent.EventWebhookReceived, func(_ context.Context, ev *agent.Event) {
+		auditMu.Lock()
+		defer auditMu.Unlock()
+		audit++
+		assert.Equal(t, "deploy", ev.Fields["name"])
+	})
+
+	body := `{"text":"ship it","from":"ci","channel":"#ops","count":3,"ok":true}`
+	rec := postHook(g, "/hook/deploy?token=secret", body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	calls, name, bag := cap.snapshot()
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, "deploy", name)
+	// Top-level scalars become string bag vars.
+	assert.Equal(t, "ship it", bag["text"])
+	assert.Equal(t, "ci", bag["from"])
+	assert.Equal(t, "#ops", bag["channel"])
+	assert.Equal(t, "3", bag["count"])
+	assert.Equal(t, "true", bag["ok"])
+	// Raw JSON preserved under "body".
+	assert.Equal(t, body, bag["body"])
+	// {user} seeded from "from" when no explicit "user".
+	assert.Equal(t, "ci", bag["user"])
+
+	// Give the async bus publish a beat to land.
+	require.Eventually(t, func() bool {
+		auditMu.Lock()
+		defer auditMu.Unlock()
+		return audit == 1
+	}, time.Second, 5*time.Millisecond)
+}
+
+func TestHookUserFieldWins(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	rec := postHook(g, "/hook/x?token=secret", `{"user":"alice","from":"bob"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, _, bag := cap.snapshot()
+	assert.Equal(t, "alice", bag["user"], "explicit user field takes precedence over from")
+}
+
+func TestHookNonObjectBodyStillDispatches(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	rec := postHook(g, "/hook/x?token=secret", `"just a string"`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, _, bag := cap.snapshot()
+	assert.Equal(t, `"just a string"`, bag["body"])
+}
+
+func TestHookRejectsOversizedBody(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	// 64 KiB + slack of JSON padding — well over the cap.
+	big := `{"text":"` + strings.Repeat("a", 70<<10) + `"}`
+	rec := postHook(g, "/hook/deploy?token=secret", big)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	calls, _, _ := cap.snapshot()
+	assert.Zero(t, calls, "an over-cap body must never reach dispatch")
+}
+
+func TestHookGetMethodNotRouted(t *testing.T) {
+	cap := &captureFire{result: true}
+	g, _ := newHookGateway(t, "secret", cap.fn)
+
+	// GET is not the hook method; it falls through to the static file server,
+	// which has no such file — never a 200 dispatch.
+	req := httptest.NewRequest(http.MethodGet, "/hook/deploy?token=secret", nil)
+	rec := httptest.NewRecorder()
+	g.Handler().ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusOK, rec.Code)
+	calls, _, _ := cap.snapshot()
+	assert.Zero(t, calls)
+}


### PR DESCRIPTION
## What

Two layers of modular, declarative automation for the agent — no sandboxed or arbitrary code execution anywhere.

### 1. Skills — trigger + action (generalizes the command-only model)

A skill pairs a **trigger** (`command` / `event` / `match` / `schedule`) with an **action** (`static` reply / `llm` / `llm_classify` moderation / `effect` kick·ban·mute·mode·notice·op·voice·topic / `webhook`). The wire stays **flat and backward-compatible**: a legacy command definition decodes to a command/reply skill identical to today and re-marshals byte-identically (round-trip test pins it). Internally a `Skill` is a nested `Skill{Trigger, Action}` with custom `(Un)MarshalJSON`.

- `internal/skill`: model, KV + sliding-window `Store` (`{getvar}/{setvar}`, flood counters), event/match `Engine` (atomic `ReplaceSkills`, EventBus-subscribed), interval/cron `Scheduler` (supervised, goleak-clean), `EventModeration` audit event (additive — no existing EventType value changed).
- `agent.Actor` connector-agnostic action surface; `irc.Actor` over `SendRaw`.

### 2. Flows — declarative node-graph engine (the composable layer above skills)

An operator wires **activity nodes** into a directed graph the agent walks when the flow's trigger fires, threading a JSON **data bag** between nodes — branching, transforms, LLM calls, network moderation, and outbound webhooks, all without code.

- `internal/flow`: `Flow/Node/Edge` model (JSON, builder-friendly), a pluggable **node catalog** (`set`, `if`, `switch`, `stop`, `say`, `notice`, `effect`, `llm`, `webhook`, `setvar`, `getvar`) with introspectable schemas via `Types()`, and a **bounded graph executor** (step ceiling — cyclic/malformed graphs can't run away). A flow `Engine` subscribes to the EventBus and runs event/match-triggered flows.
- `TURBORG_FLOWS` is wired through `runtime.Build` + `WireCommon` (`Wiring.Flows`) so flows load and hot-reload (`ApplyFlows`) alongside skills, sharing the same Actor / provider / owner / platform context.

The `Types()` catalog + the `Flow` JSON are the contract a **visual flow builder** renders and edits.

## Wiring

`WireCommon` constructs the skill engine + scheduler + flow engine and returns them as `Wiring`; `ApplySkills`/`ApplyFlows` split one incoming set across the command registry, skill engine, scheduler, and flow engine atomically (no reconnect). Both single-instance and pooled tenants supervise the scheduler. `COMMANDS_URL` / tenant-feed transport unchanged.

## Gates

`make fmt && vet && lint && test && cover-gate` all green. Total coverage **94.6%**; new packages `internal/skill` 95.6%, `internal/flow` 98.1%. New test packages use `goleak.VerifyTestMain` and run under `-race`.