### PR TITLE
feat(flow): webhook node headers, retries, and response capture

### DIFF
--- a/internal/flow/engine.go
+++ b/internal/flow/engine.go
@@ -93,7 +93,7 @@ func NewEngine(o Options) *Engine {
 	}
 }
 
-func defaultPost(ctx context.Context, method, url string, payload []byte) error {
+func defaultPost(ctx context.Context, method, url string, headers map[string]string, payload []byte) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, webhookTimeout)
 	defer cancel()
 	if method == "" {
@@ -106,16 +106,26 @@ func defaultPost(ctx context.Context, method, url string, payload []byte) error 
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
+	// Capture a bounded slice of the response so a webhook can feed a later
+	// node; a non-2xx status is surfaced as an error for retry classification.
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxWebhookBody))
+	if resp.StatusCode >= 400 {
+		return respBody, &httpStatusError{status: resp.StatusCode}
+	}
+	return respBody, nil
 }
 
 // SetMaxFlows caps how many flows ReplaceFlows installs: 0 = none (default),
@@ -283,7 +293,7 @@ func (e *Engine) onUserEvent(ctx context.Context, ev *agent.Event) {
 func (e *Engine) run(ctx context.Context, f Flow, bag Bag) {
 	nc := &nodeContext{
 		actor: e.actor, provider: e.provider, store: e.store,
-		post: e.post, flowName: f.Name, bag: bag,
+		post: e.post, flowName: f.Name, bag: bag, log: e.log,
 	}
 	queue := f.entryNodes()
 	index := make(map[string]Node, len(f.Nodes))

--- a/internal/flow/engine_test.go
+++ b/internal/flow/engine_test.go
@@ -209,17 +209,22 @@ func TestDefaultPost(t *testing.T) {
 		w.WriteHeader(200)
 	}))
 	defer srv.Close()
-	require.NoError(t, defaultPost(context.Background(), "", srv.URL, []byte(`{}`)))
+	_, err := defaultPost(context.Background(), "", srv.URL, nil, []byte(`{}`))
+	require.NoError(t, err)
 	assert.Equal(t, http.MethodPost, gotMethod, "empty method defaults to POST")
 	assert.Equal(t, `{}`, string(gotBody))
 	// A GET carries no request body.
-	require.NoError(t, defaultPost(context.Background(), http.MethodGet, srv.URL, []byte(`{"ignored":true}`)))
+	_, err = defaultPost(context.Background(), http.MethodGet, srv.URL, nil, []byte(`{"ignored":true}`))
+	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
 	assert.Empty(t, gotBody, "GET sends no body")
-	require.NoError(t, defaultPost(context.Background(), http.MethodDelete, srv.URL, nil))
+	_, err = defaultPost(context.Background(), http.MethodDelete, srv.URL, nil, nil)
+	require.NoError(t, err)
 	assert.Equal(t, http.MethodDelete, gotMethod)
-	require.Error(t, defaultPost(context.Background(), http.MethodPost, "://bad", []byte(`{}`)))
-	require.Error(t, defaultPost(context.Background(), http.MethodPost, "http://127.0.0.1:0/x", []byte(`{}`)))
+	_, err = defaultPost(context.Background(), http.MethodPost, "://bad", nil, []byte(`{}`))
+	require.Error(t, err)
+	_, err = defaultPost(context.Background(), http.MethodPost, "http://127.0.0.1:0/x", nil, []byte(`{}`))
+	require.Error(t, err)
 }
 
 func TestValidateUnknownNodeError(t *testing.T) {
@@ -230,7 +235,10 @@ func TestValidateUnknownNodeError(t *testing.T) {
 
 func TestEngineWebhookFlowEndToEnd(t *testing.T) {
 	var got []byte
-	e, bus := newEngine(t, Options{Post: func(_ context.Context, _, _ string, b []byte) error { got = b; return nil }})
+	e, bus := newEngine(t, Options{Post: func(_ context.Context, _, _ string, _ map[string]string, b []byte) ([]byte, error) {
+		got = b
+		return nil, nil
+	}})
 	e.ReplaceFlows([]Flow{{
 		Name:    "to-flow",
 		Trigger: skill.Trigger{Kind: skill.KindEvent, Event: "USER_JOIN"},

--- a/internal/flow/nodes.go
+++ b/internal/flow/nodes.go
@@ -2,11 +2,15 @@ package flow
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"net/http"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/llm"
@@ -38,11 +42,13 @@ type nodeContext struct {
 	post     PostFunc
 	flowName string
 	bag      Bag
+	log      *slog.Logger
 }
 
-// PostFunc sends a JSON payload to a URL with the given HTTP method (the
-// webhook node's egress). Tests substitute a recorder.
-type PostFunc func(ctx context.Context, method, url string, payload []byte) error
+// PostFunc sends a payload to a URL with the given HTTP method and custom
+// request headers, returning the (bounded) response body. It is the webhook
+// node's egress seam; tests substitute a recorder.
+type PostFunc func(ctx context.Context, method, url string, headers map[string]string, payload []byte) ([]byte, error)
 
 // Handler runs one node. It mutates nc.bag and returns the output port to
 // follow next ("" for the default single output).
@@ -92,7 +98,7 @@ func init() {
 	Register(NodeType{Name: "notice", Ports: []string{""}, Config: map[string]any{"target": "string", "text": "string"}, Handler: nodeNotice})
 	Register(NodeType{Name: "effect", Ports: []string{""}, Config: map[string]any{"action": "kick|ban|mute|op|voice|mode|topic", "channel": "string", "target": "string", "modes": "string", "reason": "string"}, Handler: nodeEffect})
 	Register(NodeType{Name: "llm", Ports: []string{""}, Config: map[string]any{"prompt": "string", "system": "string", "model": "string", "into": "string"}, Handler: nodeLLM})
-	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string", "method": "GET|POST|PUT|PATCH|DELETE", "body": "string"}, Handler: nodeWebhook})
+	Register(NodeType{Name: "webhook", Ports: []string{""}, Config: map[string]any{"url": "string", "method": "GET|POST|PUT|PATCH|DELETE", "body": "string", "headers": "map[string]string", "into": "string", "retries": "int", "retry_backoff": "int"}, Handler: nodeWebhook})
 	Register(NodeType{Name: "setvar", Ports: []string{""}, Config: map[string]any{"key": "string", "value": "string"}, Handler: nodeSetvar})
 	Register(NodeType{Name: "getvar", Ports: []string{""}, Config: map[string]any{"key": "string", "into": "string"}, Handler: nodeGetvar})
 	Register(NodeType{Name: "incr", Ports: []string{""}, Config: map[string]any{"key": "string", "by": "string", "into": "string"}, Handler: nodeIncr})
@@ -232,23 +238,154 @@ func nodeLLM(ctx context.Context, n Node, nc *nodeContext) (string, error) {
 	return "", nil
 }
 
+// webhook retry/backoff bounds. Config is clamped into these ranges.
+const (
+	maxWebhookRetries = 5
+	defaultBackoffSec = 3
+	minBackoffSec     = 1
+	maxBackoffSec     = 30
+	maxWebhookBackoff = maxBackoffSec * time.Second
+)
+
 func nodeWebhook(ctx context.Context, n Node, nc *nodeContext) (string, error) {
 	url := cfg(n, "url", nc.bag)
 	if url == "" || nc.post == nil {
 		return "", nil
 	}
 	method := webhookMethod(cfg(n, "method", nc.bag))
+	headers := webhookHeaders(n, nc.bag)
 	// Optional custom body: a template rendered against the bag (e.g. your own
 	// JSON with {user}/{channel}/… placeholders). Empty falls back to posting
 	// the whole data bag as JSON.
+	var payload []byte
 	if body := strings.TrimSpace(cfg(n, "body", nc.bag)); body != "" {
-		return "", nc.post(ctx, method, url, []byte(body))
+		payload = []byte(body)
+	} else {
+		p, err := jsonMarshal(nc.bag)
+		if err != nil {
+			return "", err
+		}
+		payload = p
 	}
-	payload, err := jsonMarshal(nc.bag)
+	retries := clamp(cfgInt(n, "retries", 0), 0, maxWebhookRetries)
+	backoff := clamp(cfgInt(n, "retry_backoff", defaultBackoffSec), minBackoffSec, maxBackoffSec)
+
+	resp, err := postWithRetry(ctx, nc.post, method, url, headers, payload, retries, backoff)
 	if err != nil {
-		return "", err
+		// A webhook failure is logged, not fatal: the flow continues so a
+		// downstream node can degrade gracefully (an unset capture key renders
+		// empty).
+		webhookLog(nc).Warn("flow webhook failed", "flow", nc.flowName, "url", url, "retries", retries, "err", err)
+		return "", nil
 	}
-	return "", nc.post(ctx, method, url, payload)
+	// Optional response capture: bound the body and stash it under the given
+	// bag key so a later node can use it (e.g. a GET that fetches JSON).
+	if into := rawCfg(n, "into"); into != "" {
+		if len(resp) > maxWebhookBody {
+			resp = resp[:maxWebhookBody]
+		}
+		nc.bag[into] = string(resp)
+	}
+	return "", nil
+}
+
+// maxWebhookBody bounds a captured webhook response body (belt-and-braces on
+// top of the poster's own limit).
+const maxWebhookBody = 64 << 10 // 64 KiB
+
+// webhookHeaders renders each configured header value against the bag so a user
+// can interpolate a secret (e.g. {apitoken}) into an Authorization header.
+func webhookHeaders(n Node, bag Bag) map[string]string {
+	raw, ok := n.Config["headers"].(map[string]any)
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		s, _ := v.(string)
+		out[k] = renderBag(s, bag)
+	}
+	return out
+}
+
+// cfgInt reads an int config value, tolerating JSON's float64 numbers and
+// string digits, falling back to def when absent or unparseable.
+func cfgInt(n Node, key string, def int) int {
+	switch v := n.Config[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case string:
+		if i, err := strconv.Atoi(strings.TrimSpace(v)); err == nil {
+			return i
+		}
+	}
+	return def
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// postWithRetry calls post, retrying transport errors and 5xx/429 responses up
+// to retries times with a linearly increasing backoff (base, 2·base, …) capped
+// at maxWebhookBackoff. 4xx responses (other than 429) are permanent and are
+// not retried. Backoff waits respect ctx cancellation.
+func postWithRetry(ctx context.Context, post PostFunc, method, url string, headers map[string]string, payload []byte, retries, backoffSec int) ([]byte, error) {
+	var (
+		resp []byte
+		err  error
+	)
+	for attempt := 0; ; attempt++ {
+		resp, err = post(ctx, method, url, headers, payload)
+		if err == nil {
+			return resp, nil
+		}
+		if attempt >= retries || !retryable(err) {
+			return resp, err
+		}
+		wait := time.Duration(backoffSec*(attempt+1)) * time.Second
+		if wait > maxWebhookBackoff {
+			wait = maxWebhookBackoff
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return resp, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// retryable reports whether a webhook error warrants a retry: any transport-
+// level error, or a 5xx / 429 HTTP status. Other 4xx statuses are permanent.
+func retryable(err error) bool {
+	var se *httpStatusError
+	if errors.As(err, &se) {
+		return se.status == http.StatusTooManyRequests || se.status >= 500
+	}
+	return true
+}
+
+// httpStatusError carries a non-2xx webhook response status so the retry loop
+// can distinguish retryable (5xx / 429) from permanent (other 4xx) failures.
+type httpStatusError struct{ status int }
+
+func (e *httpStatusError) Error() string { return "webhook: HTTP " + strconv.Itoa(e.status) }
+
+func webhookLog(nc *nodeContext) *slog.Logger {
+	if nc.log != nil {
+		return nc.log
+	}
+	return slog.Default()
 }
 
 // webhookMethod normalizes a configured HTTP method to upper case and

--- a/internal/flow/nodes_test.go
+++ b/internal/flow/nodes_test.go
@@ -144,9 +144,9 @@ func TestNodeWebhookAndVars(t *testing.T) {
 		bag:      Bag{"user": "alice", "channel": "#r"},
 		store:    skill.NewMemoryStore(),
 		flowName: "f1",
-		post: func(_ context.Context, method, url string, body []byte) error {
+		post: func(_ context.Context, method, url string, _ map[string]string, body []byte) ([]byte, error) {
 			gotMethod, gotURL, gotBody = method, url, body
-			return nil
+			return nil, nil
 		},
 	}
 	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{"url": "https://h/{channel}"}}, nc)

--- a/internal/flow/webhook_overhaul_test.go
+++ b/internal/flow/webhook_overhaul_test.go
@@ -1,0 +1,236 @@
+package flow
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWebhookHeadersRenderedFromBag verifies custom headers are applied and
+// that each value is rendered against the bag (so a user can inject a secret).
+func TestWebhookHeadersRenderedFromBag(t *testing.T) {
+	var gotAuth, gotStatic string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotStatic = r.Header.Get("X-Api-Key")
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	nc := &nodeContext{
+		bag:  Bag{"apitoken": "s3cr3t"},
+		post: defaultPost,
+	}
+	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{
+		"url":     srv.URL,
+		"headers": map[string]any{"Authorization": "Bearer {apitoken}", "X-Api-Key": "abc"},
+	}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer s3cr3t", gotAuth, "header value rendered from bag")
+	assert.Equal(t, "abc", gotStatic)
+}
+
+// TestWebhookResponseCapturedIntoBag verifies a GET's response body lands in
+// the configured bag key, bounded and usable by later nodes.
+func TestWebhookResponseCapturedIntoBag(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"price":42}`)
+	}))
+	defer srv.Close()
+
+	nc := &nodeContext{bag: Bag{}, post: defaultPost}
+	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{
+		"url": srv.URL, "method": "GET", "into": "resp",
+	}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, `{"price":42}`, nc.bag.str("resp"))
+}
+
+// TestWebhookResponseCapBound verifies capture is bounded to 64 KiB.
+func TestWebhookResponseCapBound(t *testing.T) {
+	huge := strings.Repeat("x", maxWebhookBody+4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, huge)
+	}))
+	defer srv.Close()
+
+	nc := &nodeContext{bag: Bag{}, post: defaultPost}
+	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{
+		"url": srv.URL, "method": "GET", "into": "resp",
+	}}, nc)
+	require.NoError(t, err)
+	assert.Len(t, nc.bag.str("resp"), maxWebhookBody, "captured body is capped at 64 KiB")
+}
+
+// TestWebhookRetriesThenSucceeds verifies a 500 is retried and the eventual
+// 200 response is captured. Uses a 1s backoff (the floor).
+func TestWebhookRetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	nc := &nodeContext{bag: Bag{}, post: defaultPost}
+	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{
+		"url": srv.URL, "method": "GET", "into": "resp",
+		"retries": 2, "retry_backoff": 1,
+	}}, nc)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "one retry after the 500")
+	assert.Equal(t, "ok", nc.bag.str("resp"))
+}
+
+// TestWebhookNoRetryOn4xx verifies a 400 is not retried and no capture happens.
+func TestWebhookNoRetryOn4xx(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	nc := &nodeContext{bag: Bag{}, post: defaultPost}
+	_, err := nodeWebhook(context.Background(), Node{Config: map[string]any{
+		"url": srv.URL, "method": "GET", "into": "resp",
+		"retries": 3, "retry_backoff": 1,
+	}}, nc)
+	require.NoError(t, err, "a failing webhook is logged, not fatal")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "4xx is permanent, no retry")
+	assert.Empty(t, nc.bag.str("resp"), "no capture on failure")
+}
+
+// TestWebhook429IsRetried verifies 429 (rate limit) is treated as retryable.
+func TestWebhook429IsRetried(t *testing.T) {
+	var n int32
+	post := func(context.Context, string, string, map[string]string, []byte) ([]byte, error) {
+		if atomic.AddInt32(&n, 1) == 1 {
+			return nil, &httpStatusError{status: http.StatusTooManyRequests}
+		}
+		return []byte("done"), nil
+	}
+	got, err := postWithRetry(context.Background(), post, "GET", "http://x", nil, nil, 3, 1)
+	require.NoError(t, err)
+	assert.Equal(t, "done", string(got))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&n))
+}
+
+// TestWebhookBackoffRespectsCtxCancel verifies a cancelled context aborts the
+// wait between retries promptly instead of sleeping the full backoff.
+func TestWebhookBackoffRespectsCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int32
+	post := func(context.Context, string, string, map[string]string, []byte) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, &httpStatusError{status: http.StatusServiceUnavailable}
+	}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	_, err := postWithRetry(ctx, post, "GET", "http://x", nil, nil, 5, 1)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), time.Second, "cancel short-circuits the 1s backoff")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "no attempt after cancel")
+}
+
+// TestWebhookRetryClampAndGiveUp verifies retries clamp to 5 and a persistently
+// failing webhook gives up without failing the flow.
+func TestWebhookRetryClampAndGiveUp(t *testing.T) {
+	var calls int32
+	post := func(context.Context, string, string, map[string]string, []byte) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, &httpStatusError{status: 500}
+	}
+	nc := &nodeContext{bag: Bag{}, post: post}
+	// retries=99 clamps to 5 → 6 total attempts; retry_backoff=0 clamps to 1s
+	// but we only care about the attempt count, so keep it fast by cancelling.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(30 * time.Millisecond); cancel() }()
+	_, err := nodeWebhook(ctx, Node{Config: map[string]any{
+		"url": "http://x", "method": "GET", "retries": 99, "retry_backoff": 0,
+	}}, nc)
+	require.NoError(t, err, "give-up is logged, not fatal")
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(1))
+}
+
+// TestWebhookCfgIntParsesStringAndFloat covers the JSON number / string forms
+// the flow config can carry for retries / retry_backoff.
+func TestWebhookCfgIntParsesStringAndFloat(t *testing.T) {
+	n := Node{Config: map[string]any{"a": float64(4), "b": "7", "c": 2, "d": "bad"}}
+	assert.Equal(t, 4, cfgInt(n, "a", 0))
+	assert.Equal(t, 7, cfgInt(n, "b", 0))
+	assert.Equal(t, 2, cfgInt(n, "c", 0))
+	assert.Equal(t, 3, cfgInt(n, "d", 3), "unparseable string falls back to default")
+	assert.Equal(t, 9, cfgInt(n, "missing", 9))
+	assert.Equal(t, 5, clamp(99, 0, 5))
+	assert.Equal(t, 0, clamp(-1, 0, 5))
+}
+
+// TestWebhookCatalogExposesNewKeys verifies the UI catalog introspects the new
+// config keys on the webhook node type.
+func TestWebhookCatalogExposesNewKeys(t *testing.T) {
+	for _, nt := range Types() {
+		if nt.Name != "webhook" {
+			continue
+		}
+		for _, key := range []string{"headers", "into", "retries", "retry_backoff"} {
+			_, ok := nt.Config[key]
+			assert.Truef(t, ok, "webhook config exposes %q", key)
+		}
+		return
+	}
+	t.Fatal("webhook node type not registered")
+}
+
+// TestWebhookEndToEndCaptureFeedsSay wires a GET-fetch webhook whose captured
+// body a downstream say node emits — the !cryptoprice shape.
+func TestWebhookEndToEndCaptureFeedsSay(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "42000")
+	}))
+	defer srv.Close()
+
+	act := &fakeActor{}
+	e, _ := newEngine(t, Options{Actor: act})
+	e.RunOnce(context.Background(), Flow{
+		Name: "price",
+		Nodes: []Node{
+			{ID: "w", Type: "webhook", Config: map[string]any{"url": srv.URL, "method": "GET", "into": "price"}},
+			{ID: "s", Type: "say", Config: map[string]any{"channel": "#c", "text": "BTC {price}"}},
+		},
+		Edges: []Edge{{From: "w", To: "s"}},
+	}, Bag{})
+	assert.Equal(t, []string{"say #c BTC 42000"}, act.snapshot())
+}
+
+// TestDefaultPostAppliesHeaders exercises defaultPost's header application and
+// non-2xx error classification directly.
+func TestDefaultPostAppliesHeaders(t *testing.T) {
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Token")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+	body, err := defaultPost(context.Background(), "GET", srv.URL, map[string]string{"X-Token": "t"}, nil)
+	require.Error(t, err)
+	var se *httpStatusError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, http.StatusServiceUnavailable, se.status)
+	assert.Equal(t, "t", gotKey)
+	assert.NotNil(t, body)
+}

--- a/internal/skill/coverage_test.go
+++ b/internal/skill/coverage_test.go
@@ -38,15 +38,37 @@ func TestDefaultPostSuccessAndError(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	require.NoError(t, defaultPost(context.Background(), "", srv.URL, []byte(`{}`)))
+	_, err := defaultPost(context.Background(), "", srv.URL, nil, []byte(`{}`))
+	require.NoError(t, err)
 	assert.Equal(t, http.MethodPost, gotMethod, "empty method defaults to POST")
 	// A GET carries no body.
-	require.NoError(t, defaultPost(context.Background(), http.MethodGet, srv.URL, []byte(`{"x":1}`)))
+	_, err = defaultPost(context.Background(), http.MethodGet, srv.URL, nil, []byte(`{"x":1}`))
+	require.NoError(t, err)
 	assert.Equal(t, http.MethodGet, gotMethod)
 	assert.Empty(t, gotBody, "GET sends no body")
 
-	require.Error(t, defaultPost(context.Background(), http.MethodPost, "http://127.0.0.1:0/nope", []byte(`{}`)))
-	require.Error(t, defaultPost(context.Background(), http.MethodPost, "://bad-url", []byte(`{}`)))
+	_, err = defaultPost(context.Background(), http.MethodPost, "http://127.0.0.1:0/nope", nil, []byte(`{}`))
+	require.Error(t, err)
+	_, err = defaultPost(context.Background(), http.MethodPost, "://bad-url", nil, []byte(`{}`))
+	require.Error(t, err)
+}
+
+// TestDefaultPostHeadersAndStatus covers header application and the non-2xx
+// status-error classification in defaultPost.
+func TestDefaultPostHeadersAndStatus(t *testing.T) {
+	var gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-Api-Key")
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer srv.Close()
+	body, err := defaultPost(context.Background(), http.MethodPost, srv.URL, map[string]string{"X-Api-Key": "k"}, []byte(`{}`))
+	require.Error(t, err)
+	var se *httpStatusError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, http.StatusTeapot, se.status)
+	assert.Equal(t, "k", gotKey, "custom header applied")
+	assert.NotNil(t, body)
 }
 
 func TestDoWebhookEmptyURLAndError(t *testing.T) {
@@ -61,9 +83,9 @@ func TestDoWebhookEmptyURLAndError(t *testing.T) {
 
 	// Post error path is logged, not fatal.
 	called := false
-	e2, bus2 := newEngine(t, Options{Post: func(context.Context, string, string, []byte) error {
+	e2, bus2 := newEngine(t, Options{Post: func(context.Context, string, string, map[string]string, []byte) ([]byte, error) {
 		called = true
-		return errors.New("down")
+		return nil, errors.New("down")
 	}})
 	e2.ReplaceSkills([]Skill{{
 		Name:    "w",

--- a/internal/skill/engine.go
+++ b/internal/skill/engine.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -21,10 +22,15 @@ import (
 // can't stall the engine.
 const webhookTimeout = 5 * time.Second
 
-// PostFunc sends a JSON payload to a URL with the given HTTP method. It is the
-// seam external flow engines (n8n and the like) plug into; the default uses
-// net/http and tests substitute a recorder.
-type PostFunc func(ctx context.Context, method, url string, payload []byte) error
+// PostFunc sends a payload to a URL with the given HTTP method and custom
+// request headers, returning the (bounded) response body. It is the seam
+// external flow engines (n8n and the like) plug into; the default uses
+// net/http and tests substitute a recorder. Skills ignore the returned body.
+type PostFunc func(ctx context.Context, method, url string, headers map[string]string, payload []byte) ([]byte, error)
+
+// maxWebhookBody bounds how much of a webhook response body is read, so a
+// hostile or misconfigured endpoint can't stream unbounded data into memory.
+const maxWebhookBody = 64 << 10 // 64 KiB
 
 // floodWindow is the sliding window over which an effect skill with severity
 // thresholds counts a sender's messages. Kept a package constant — operators
@@ -120,8 +126,10 @@ func NewEngine(o Options) *Engine {
 }
 
 // defaultPost sends payload as application/json with the given method (default
-// POST) and a bounded timeout. A GET carries no request body.
-func defaultPost(ctx context.Context, method, url string, payload []byte) error {
+// POST), custom headers, and a bounded timeout, returning the bounded response
+// body. A GET carries no request body. A non-2xx response is returned as an
+// error (with the body captured) so callers can classify it.
+func defaultPost(ctx context.Context, method, url string, headers map[string]string, payload []byte) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, webhookTimeout)
 	defer cancel()
 	if method == "" {
@@ -133,17 +141,31 @@ func defaultPost(ctx context.Context, method, url string, payload []byte) error 
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxWebhookBody))
+	if resp.StatusCode >= 400 {
+		return respBody, &httpStatusError{status: resp.StatusCode}
+	}
+	return respBody, nil
 }
+
+// httpStatusError carries a non-2xx webhook response status so a retry loop can
+// distinguish retryable (5xx / 429) from permanent (other 4xx) failures.
+type httpStatusError struct{ status int }
+
+func (e *httpStatusError) Error() string { return "webhook: HTTP " + strconv.Itoa(e.status) }
 
 // SetMaxSkills caps how many engine skills ReplaceSkills installs: 0 = none
 // (default), -1 = unrestricted, N = at most N. Mirrors the command registry's
@@ -355,7 +377,8 @@ func (e *Engine) doWebhook(ctx context.Context, s Skill, f renderFields) {
 	if err != nil {
 		return
 	}
-	if err := e.post(ctx, http.MethodPost, s.Action.Webhook, payload); err != nil {
+	// Skills have no data bag to capture into, so the response body is ignored.
+	if _, err := e.post(ctx, http.MethodPost, s.Action.Webhook, nil, payload); err != nil {
 		e.log.Warn("skill webhook failed", "skill", s.Name, "err", err)
 	}
 }

--- a/internal/skill/engine_test.go
+++ b/internal/skill/engine_test.go
@@ -198,11 +198,11 @@ func TestEngineWebhook(t *testing.T) {
 	var mu sync.Mutex
 	var gotMethod, gotURL string
 	var gotBody []byte
-	e, bus := newEngine(t, Options{Post: func(_ context.Context, method, url string, body []byte) error {
+	e, bus := newEngine(t, Options{Post: func(_ context.Context, method, url string, _ map[string]string, body []byte) ([]byte, error) {
 		mu.Lock()
 		gotMethod, gotURL, gotBody = method, url, body
 		mu.Unlock()
-		return nil
+		return nil, nil
 	}})
 	e.ReplaceSkills([]Skill{{
 		Name:    "to-flow",


### PR DESCRIPTION
Extends the outbound webhook node: custom (bag-rendered) headers so callers can send an API token, retries with backoff (0-5, retries 5xx/429 only, ctx-cancellable) and a response-capture 'into' key that reads the bounded response body into the flow data bag (making a GET fetch usable, e.g. a price lookup). The PostFunc seam now returns the response body; skills pass nil headers and ignore it. Backward-compatible: all new node config keys are optional.