### PR TITLE
test(connector/irc): deflake pong-ack and intra-detached transition tests

### DIFF
--- a/internal/connector/irc/bouncer_state_test.go
+++ b/internal/connector/irc/bouncer_state_test.go
@@ -273,6 +273,12 @@ func TestBouncerSkipsIntraDetachedTransitions(t *testing.T) {
 	machine.Transition(irc.UpstreamStateRegistered)
 
 	conn, r := authBouncerClient(t, addr)
+	// sendWelcome runs async on the bouncer's handleClient goroutine, and
+	// surfaceStateToClient fires right after it. Drain the welcome flow
+	// while upstream is still Registered so surface reads that state (and
+	// sends nothing) instead of racing the transitions below and injecting
+	// its own "Currently connecting" NOTICE * that the scan would pick up.
+	drainBuffered(t, conn, r)
 	machine.Transition(irc.UpstreamStateDisconnectedTransient,
 		irc.WithServerReason("EOF"))
 	_ = readUntilContains(r, conn, "Currently disconnected", time.Second)

--- a/internal/connector/irc/connector_pong_timeout_test.go
+++ b/internal/connector/irc/connector_pong_timeout_test.go
@@ -70,8 +70,16 @@ func TestPongTimeoutTransitionsTransient(t *testing.T) {
 }
 
 // TestPongAckResetsLedger: server echoes PONGs back so every PING is
-// matched within the timeout window. Run for 3x PongTimeout and assert
-// the connector stays Registered (no transient transition emitted).
+// matched within the timeout window. Assert the connector stays
+// Registered (no transient transition emitted).
+//
+// PongTimeout is held well above the worst-case localhost PONG
+// round-trip under a loaded -race runner (goroutine wakeups + GC pauses
+// can add tens of ms), so a healthy session never trips a false
+// transient. The soak window is kept longer than PongTimeout so the
+// test stays non-vacuous: had acks been broken, the first unacked PING
+// would trip the watchdog (~ClientPingInterval + PongTimeout) well
+// inside the window.
 func TestPongAckResetsLedger(t *testing.T) {
 	fs := fakeirc.New(t, fakeirc.WithPongResponses(true))
 	defer fs.Close()
@@ -82,7 +90,7 @@ func TestPongAckResetsLedger(t *testing.T) {
 		Nick:               "turborg",
 		Channels:           []string{"#test"},
 		ClientPingInterval: 50 * time.Millisecond,
-		PongTimeout:        30 * time.Millisecond,
+		PongTimeout:        200 * time.Millisecond,
 		ReadIdleTimeout:    10 * time.Second,
 	}, nil, nil)
 
@@ -110,9 +118,10 @@ func TestPongAckResetsLedger(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- a.Run(ctx) }()
 
-	// Hold the session for several ping cycles. Acks should keep the
-	// ledger drained continuously — no transient transition.
-	time.Sleep(300 * time.Millisecond)
+	// Hold the session for several ping cycles, longer than PongTimeout so
+	// a broken-ack regression would surface a transient inside the window.
+	// Acks should keep the ledger drained continuously — no transition.
+	time.Sleep(700 * time.Millisecond)
 
 	mu.Lock()
 	gotRegistered := registeredOnce


### PR DESCRIPTION
## Summary

Two IRC tests intermittently failed in CI under load — both are timing/scheduling flakes, not product bugs. Removes the flakiness at its source.

### `TestBouncerSkipsIntraDetachedTransitions`
Raced `surfaceStateToClient`, which reads the upstream state on the per-client `handleClient` goroutine right after the welcome flow. When that read landed *after* the test advanced the machine to `connecting`, it injected a stray `Currently connecting` `NOTICE *` that the drain scan then flagged (`Should be false`).

Fix: `drainBuffered(t, conn, r)` before the first transition — the exact pattern the sibling broadcast tests already use — so `surfaceStateToClient` reads the still-`registered` state and stays silent.

### `TestPongAckResetsLedger`
Used a `PongTimeout` of 30ms, tighter than the worst-case localhost PONG round-trip under a loaded `-race` runner (goroutine wakeups + GC pauses can add tens of ms), so a healthy session occasionally tripped a false transient.

Fix: widen `PongTimeout` to 200ms and extend the soak window to 700ms. The window stays longer than `PongTimeout`, so the test remains non-vacuous — a broken-ack regression would still trip the watchdog inside the window.

## Type of change

- [x] `test` — tests only

## Test plan

- `go test -race -count=20 -run 'TestBouncerSkipsIntraDetachedTransitions|TestPongAckResetsLedger|TestPongTimeout' ./internal/connector/irc/` → pass
- `go test -race -count=3 ./internal/connector/irc/` → pass (full package, 3x)
- `gofmt`/`go vet`/`golangci-lint` clean