### PR TITLE
feat(connector/web): add hosted web-chat connector

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -12,6 +12,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/caarlos0/env/v11"
@@ -22,6 +23,7 @@ import (
 // runtime.buildConnector.
 var ValidConnectors = map[string]bool{
 	"irc": true,
+	"web": true,
 }
 
 // Settings is the top-level turborg config. Connector-specific knobs
@@ -391,16 +393,30 @@ func (s *Settings) normalizeConnectors() error {
 			continue
 		}
 		if !ValidConnectors[c] {
-			return fmt.Errorf("config: unknown connector %q (valid: irc)", c)
+			return fmt.Errorf("config: unknown connector %q (valid: %s)", c, validConnectorList())
 		}
 		seen[c] = true
 		out = append(out, c)
 	}
 	s.Connectors = out
-	// Cap-exceeded branch will land once a second valid connector exists.
-	// Today the dedup loop above keeps len(s.Connectors) <= 1 with "irc"
-	// the only ValidConnectors entry, so a cap-vs-count compare is unreachable.
+	// Cap the number of distinct connector types when the operator set a
+	// ceiling. Reachable now that more than one connector name is valid.
+	if s.MaxConnectorsPerAgent > 0 && len(out) > s.MaxConnectorsPerAgent {
+		return fmt.Errorf("config: %d connectors listed in TURBORG_CONNECTORS exceeds MAX_CONNECTORS_PER_AGENT=%d",
+			len(out), s.MaxConnectorsPerAgent)
+	}
 	return nil
+}
+
+// validConnectorList renders the supported connector names sorted, for error
+// messages — stays correct as ValidConnectors grows.
+func validConnectorList() string {
+	names := make([]string, 0, len(ValidConnectors))
+	for name := range ValidConnectors {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }
 
 // validatePolicyBounds runs the numeric/range checks on operator-policy

--- a/internal/connector/web/actor.go
+++ b/internal/connector/web/actor.go
@@ -1,0 +1,78 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/turborg/turborg/internal/agent"
+)
+
+// errUnsupported is returned by the moderation actions a private console can't
+// perform. The Actor contract explicitly allows a connector to error on
+// actions it doesn't support; these wire to real room moderation once a public
+// room ships.
+var errUnsupported = errors.New("web: action not supported in console")
+
+// Actor implements agent.Actor over the web-chat connector. Say/Notice fan bot
+// output to attached clients and publish MESSAGE_SENT so the shared store
+// submitter persists it — the same reason the IRC gateway republishes its own
+// `say` ops. Moderation actions deny in the private console.
+type Actor struct {
+	conn *Connector
+}
+
+// NewActor builds a web Actor bound to a connector.
+func NewActor(c *Connector) *Actor { return &Actor{conn: c} }
+
+var _ agent.Actor = (*Actor)(nil)
+
+// Say delivers text to the room as a bot message: it fans the frame to every
+// client and publishes MESSAGE_SENT for persistence. The channel argument is
+// ignored — a console has one room — so skill/flow output always lands there.
+func (a *Actor) Say(_, text string) error {
+	a.emit(text)
+	return nil
+}
+
+// Notice renders identically to Say in the console (there is no separate notice
+// styling); it exists to satisfy the Actor contract.
+func (a *Actor) Notice(_, text string) error {
+	a.emit(text)
+	return nil
+}
+
+// emit broadcasts a bot frame and publishes MESSAGE_SENT so the runtime's store
+// submitter persists the bot's own output (the connector doesn't subscribe to
+// its own bus to re-broadcast, so there is no double send).
+func (a *Actor) emit(text string) {
+	a.conn.broadcast(map[string]any{
+		"op":     "message",
+		"kind":   "bot",
+		"sender": a.conn.settings.BotNick,
+		"text":   text,
+		"ts":     time.Now().Unix(),
+		"id":     uuid.NewString(),
+	})
+	if a.conn.events != nil {
+		a.conn.events.Publish(context.Background(), &agent.Event{
+			Type: agent.EventMessageSent,
+			Time: time.Now(),
+			Fields: map[string]any{
+				"connector": "web",
+				"channel":   a.conn.settings.Room,
+				"sender":    a.conn.settings.BotNick,
+				"text":      text,
+			},
+		})
+	}
+}
+
+func (a *Actor) Kick(_, _, _ string) error              { return errUnsupported }
+func (a *Actor) Ban(_, _ string) error                  { return errUnsupported }
+func (a *Actor) SetMode(_, _ string, _ ...string) error { return errUnsupported }
+func (a *Actor) Op(_, _ string) error                   { return errUnsupported }
+func (a *Actor) Voice(_, _ string) error                { return errUnsupported }
+func (a *Actor) Topic(_, _ string) error                { return errUnsupported }
+func (a *Actor) Invite(_, _ string) error               { return errUnsupported }

--- a/internal/connector/web/ai_console_test.go
+++ b/internal/connector/web/ai_console_test.go
@@ -1,0 +1,144 @@
+package web
+
+import (
+	"context"
+	"iter"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/llm"
+	"github.com/turborg/turborg/internal/messages"
+)
+
+// stubProvider is a minimal llm.Provider for console tests: Ask returns a canned
+// reply (or a canned error, e.g. ErrBudgetExhausted) and counts invocations.
+type stubProvider struct {
+	mu    sync.Mutex
+	calls int
+	reply string
+	err   error
+}
+
+func (s *stubProvider) Model() string { return "stub" }
+
+func (s *stubProvider) Ask(context.Context, string, ...llm.CallOption) (string, llm.Usage, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	return s.reply, llm.Usage{}, s.err
+}
+
+func (s *stubProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
+	return func(func(string, error) bool) {}
+}
+
+func (s *stubProvider) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// readUntil reads frames until one has op == want (or times out).
+func readUntil(t *testing.T, conn *websocket.Conn, want string) map[string]any {
+	t.Helper()
+	for i := 0; i < 8; i++ {
+		f := readFrame(t, conn)
+		if f["op"] == want {
+			return f
+		}
+	}
+	t.Fatalf("did not receive an %q frame", want)
+	return nil
+}
+
+// TestConsoleAnswersFreeTextViaLLM: a non-command message is answered by the
+// assistant as a bot message.
+func TestConsoleAnswersFreeTextViaLLM(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	// Seed prior turns so buildChatPrompt feeds real conversation memory
+	// (a user line + a bot line → both role branches).
+	ctx := context.Background()
+	require.NoError(t, c.store.Submit(ctx, storeMsg("owner", "hi")))
+	require.NoError(t, c.store.Submit(ctx, storeMsg("helper", "hello, how can I help?")))
+	prov := &stubProvider{reply: "I'm your turborg assistant."}
+	c.SetLLMProvider(prov)
+	c.SetCommandPrefix("!")
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"what are you"}`)))
+
+	// Skip the replayed history frames and the user echo; land on the live bot
+	// reply from the LLM.
+	bot := readUntil(t, conn, "message")
+	for bot["kind"] != "bot" || bot["replayed"] == true {
+		bot = readUntil(t, conn, "message")
+	}
+	assert.Equal(t, "I'm your turborg assistant.", bot["text"])
+	assert.Equal(t, "helper", bot["sender"])
+	assert.Equal(t, 1, prov.callCount())
+}
+
+// TestConsoleCommandNotSentToLLM: a `!command` message is NOT answered by the
+// LLM (it goes to the agent's command dispatch instead).
+func TestConsoleCommandNotSentToLLM(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	prov := &stubProvider{reply: "should not be called"}
+	c.SetLLMProvider(prov)
+	c.SetCommandPrefix("!")
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"!btc"}`)))
+
+	// Give any (erroneous) async LLM call time to land, then assert none did.
+	assert.Never(t, func() bool { return prov.callCount() > 0 }, 300*time.Millisecond, 30*time.Millisecond)
+	<-c.Inbound() // drain the command envelope for a clean teardown
+}
+
+// TestConsoleBudgetExhaustedSignal: a spent daily LLM budget surfaces as a
+// distinct budget_exhausted frame the client can act on.
+func TestConsoleBudgetExhaustedSignal(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	prov := &stubProvider{err: llm.ErrBudgetExhausted}
+	c.SetLLMProvider(prov)
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"hello"}`)))
+
+	frame := readUntil(t, conn, "budget_exhausted")
+	assert.Contains(t, frame["message"], "budget")
+}
+
+// TestConsoleGenericLLMErrorFrame: a non-budget error surfaces a generic error
+// frame, not the budget-exhausted signal.
+func TestConsoleGenericLLMErrorFrame(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	c.SetLLMProvider(&stubProvider{err: assert.AnError})
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"hello"}`)))
+
+	frame := readUntil(t, conn, "error")
+	assert.Contains(t, frame["message"], "unavailable")
+}
+
+func storeMsg(nick, text string) messages.Message {
+	return messages.Message{Channel: "console", Nick: nick, Text: text, TS: time.Now()}
+}

--- a/internal/connector/web/ai_console_test.go
+++ b/internal/connector/web/ai_console_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"iter"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,8 +15,9 @@ import (
 	"github.com/turborg/turborg/internal/messages"
 )
 
-// stubProvider is a minimal llm.Provider for console tests: Ask returns a canned
-// reply (or a canned error, e.g. ErrBudgetExhausted) and counts invocations.
+// stubProvider is a minimal llm.Provider for console tests. Stream yields the
+// canned reply (or a canned error, e.g. ErrBudgetExhausted) and counts
+// invocations across Ask + Stream.
 type stubProvider struct {
 	mu    sync.Mutex
 	calls int
@@ -33,7 +35,26 @@ func (s *stubProvider) Ask(context.Context, string, ...llm.CallOption) (string, 
 }
 
 func (s *stubProvider) Stream(context.Context, string, ...llm.CallOption) iter.Seq2[string, error] {
-	return func(func(string, error) bool) {}
+	s.mu.Lock()
+	s.calls++
+	reply, err := s.reply, s.err
+	s.mu.Unlock()
+	return func(yield func(string, error) bool) {
+		if err != nil {
+			yield("", err)
+			return
+		}
+		// Stream in two chunks to exercise multi-delta assembly.
+		mid := len(reply) / 2
+		for _, chunk := range []string{reply[:mid], reply[mid:]} {
+			if chunk == "" {
+				continue
+			}
+			if !yield(chunk, nil) {
+				return
+			}
+		}
+	}
 }
 
 func (s *stubProvider) callCount() int {
@@ -45,7 +66,7 @@ func (s *stubProvider) callCount() int {
 // readUntil reads frames until one has op == want (or times out).
 func readUntil(t *testing.T, conn *websocket.Conn, want string) map[string]any {
 	t.Helper()
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 10; i++ {
 		f := readFrame(t, conn)
 		if f["op"] == want {
 			return f
@@ -55,12 +76,32 @@ func readUntil(t *testing.T, conn *websocket.Conn, want string) map[string]any {
 	return nil
 }
 
-// TestConsoleAnswersFreeTextViaLLM: a non-command message is answered by the
-// assistant as a bot message.
-func TestConsoleAnswersFreeTextViaLLM(t *testing.T) {
+// readStreamedReply assembles a streamed assistant message: it waits for
+// message_start, concatenates message_delta text, and returns at message_end.
+func readStreamedReply(t *testing.T, conn *websocket.Conn) string {
+	t.Helper()
+	_ = readUntil(t, conn, "message_start")
+	var sb strings.Builder
+	for i := 0; i < 20; i++ {
+		f := readFrame(t, conn)
+		switch f["op"] {
+		case "message_delta":
+			if s, ok := f["text"].(string); ok {
+				sb.WriteString(s)
+			}
+		case "message_end":
+			return sb.String()
+		}
+	}
+	t.Fatal("no message_end frame")
+	return ""
+}
+
+// TestConsoleStreamsFreeTextViaLLM: a non-command message is answered by the
+// assistant, streamed token-by-token.
+func TestConsoleStreamsFreeTextViaLLM(t *testing.T) {
 	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
-	// Seed prior turns so buildChatPrompt feeds real conversation memory
-	// (a user line + a bot line → both role branches).
+	// Seed prior turns so buildChatPrompt feeds real conversation memory.
 	ctx := context.Background()
 	require.NoError(t, c.store.Submit(ctx, storeMsg("owner", "hi")))
 	require.NoError(t, c.store.Submit(ctx, storeMsg("helper", "hello, how can I help?")))
@@ -71,23 +112,19 @@ func TestConsoleAnswersFreeTextViaLLM(t *testing.T) {
 	base := serveConn(t, c, "tenant-a")
 	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
 	_ = readFrame(t, conn) // state
+	_ = readFrame(t, conn) // replay: "hi"
+	_ = readFrame(t, conn) // replay: "hello, how can I help?"
 
 	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
 		[]byte(`{"op":"say","text":"what are you"}`)))
+	_ = readUntil(t, conn, "message") // user echo (kind user)
 
-	// Skip the replayed history frames and the user echo; land on the live bot
-	// reply from the LLM.
-	bot := readUntil(t, conn, "message")
-	for bot["kind"] != "bot" || bot["replayed"] == true {
-		bot = readUntil(t, conn, "message")
-	}
-	assert.Equal(t, "I'm your turborg assistant.", bot["text"])
-	assert.Equal(t, "helper", bot["sender"])
+	assert.Equal(t, "I'm your turborg assistant.", readStreamedReply(t, conn))
 	assert.Equal(t, 1, prov.callCount())
 }
 
-// TestConsoleCommandNotSentToLLM: a `!command` message is NOT answered by the
-// LLM (it goes to the agent's command dispatch instead).
+// TestConsoleCommandNotSentToLLM: a `!command` message is not answered by the
+// LLM (it routes to the agent's command dispatch instead).
 func TestConsoleCommandNotSentToLLM(t *testing.T) {
 	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
 	prov := &stubProvider{reply: "should not be called"}
@@ -100,7 +137,6 @@ func TestConsoleCommandNotSentToLLM(t *testing.T) {
 	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
 		[]byte(`{"op":"say","text":"!btc"}`)))
 
-	// Give any (erroneous) async LLM call time to land, then assert none did.
 	assert.Never(t, func() bool { return prov.callCount() > 0 }, 300*time.Millisecond, 30*time.Millisecond)
 	<-c.Inbound() // drain the command envelope for a clean teardown
 }
@@ -109,13 +145,11 @@ func TestConsoleCommandNotSentToLLM(t *testing.T) {
 // distinct budget_exhausted frame the client can act on.
 func TestConsoleBudgetExhaustedSignal(t *testing.T) {
 	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
-	prov := &stubProvider{err: llm.ErrBudgetExhausted}
-	c.SetLLMProvider(prov)
+	c.SetLLMProvider(&stubProvider{err: llm.ErrBudgetExhausted})
 
 	base := serveConn(t, c, "tenant-a")
 	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
 	_ = readFrame(t, conn) // state
-
 	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
 		[]byte(`{"op":"say","text":"hello"}`)))
 

--- a/internal/connector/web/auth.go
+++ b/internal/connector/web/auth.go
@@ -1,0 +1,135 @@
+// Package web is turborg's hosted web-chat connector: a JSON-over-WebSocket
+// chat surface turborg serves itself (no external network to dial). It
+// implements the connector-agnostic agent.Connector + agent.Actor contracts,
+// so the same commands, skills, and flows that run on IRC run here unchanged.
+//
+// Distinct from internal/web, which is the IRC-specific management gateway —
+// that streams an IRC session to a dashboard and is not a chat transport.
+package web
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// Claims is the decoded web-chat token payload. It binds a token to one
+// tenant, one room, and one role, with an expiry. The JSON field names are a
+// wire contract shared with the token signer that mints these — renaming one
+// breaks every already-issued token, so treat them as frozen.
+type Claims struct {
+	// TenantID is the turborg the token authorizes. VerifyClaims rejects a
+	// token whose TenantID doesn't match the tenant resolved from the request
+	// path, so a token minted for one tenant can't be replayed against another.
+	TenantID string `json:"tid"`
+	// Room is the chat room the token authorizes (e.g. "console").
+	Room string `json:"room"`
+	// Role is the caller's role in the room ("owner", …), surfaced to handlers
+	// via the inbound envelope metadata.
+	Role string `json:"role"`
+	// VisitorID identifies the human the token was minted for (a user id).
+	VisitorID string `json:"vid"`
+	// IssuedAt / ExpiresAt are unix seconds. VerifyClaims rejects an expired
+	// token; IssuedAt is informational.
+	IssuedAt  int64 `json:"iat"`
+	ExpiresAt int64 `json:"exp"`
+}
+
+// SignedTokenVerifier authenticates web-chat tokens against one tenant's
+// signing key using HMAC-SHA256. The token format is JWT-style:
+//
+//	token   = base64url(payloadJSON) "." base64url(HMAC_SHA256(base64url(payloadJSON), key))
+//
+// base64url is RFC 4648 §5 with no padding, and the HMAC is computed over the
+// base64url payload STRING (not the raw JSON). The key is the tenant's own
+// per-tenant secret — there is no fleet-wide key — so a token signed for the
+// wrong tenant already fails the HMAC; VerifyClaims additionally checks the
+// tenant id in the payload as defence-in-depth.
+type SignedTokenVerifier struct {
+	key []byte
+	// now is injected so tests can pin the clock for expiry checks. Nil uses
+	// time.Now.
+	now func() time.Time
+}
+
+// NewSignedTokenVerifier builds a verifier over a tenant's signing key. An
+// empty key is rejected — a zero-length HMAC key would authenticate a
+// trivially-forgeable token.
+func NewSignedTokenVerifier(key string) (*SignedTokenVerifier, error) {
+	if key == "" {
+		return nil, errors.New("web: signing key cannot be empty")
+	}
+	return &SignedTokenVerifier{key: []byte(key)}, nil
+}
+
+// Errors returned by VerifyClaims. Callers should treat every one as a plain
+// 401 with no detail — distinguishing them to the client would let an attacker
+// probe which check failed.
+var (
+	ErrMalformedToken = errors.New("web: malformed token")
+	ErrBadSignature   = errors.New("web: bad token signature")
+	ErrExpiredToken   = errors.New("web: token expired")
+	ErrWrongTenant    = errors.New("web: token tenant mismatch")
+	ErrWrongRoom      = errors.New("web: token room mismatch")
+)
+
+// VerifyClaims authenticates token and returns its claims, or an error if any
+// check fails. The checks, in order:
+//
+//  1. Recompute the HMAC over the payload segment and constant-time compare it
+//     to the presented signature.
+//  2. Reject if the token has expired.
+//  3. Reject if the payload's tenant id != the tenant resolved from the request
+//     path (pathTenantID). MANDATORY: the pooled router resolves the tenant
+//     from the URL, so without this a token minted for tenant A could be
+//     replayed against /chat/B.
+//  4. Reject if the payload's room != the room this connector serves.
+func (v *SignedTokenVerifier) VerifyClaims(token, pathTenantID, room string) (*Claims, error) {
+	// Split on the LAST '.' so a '.' inside the base64url payload (there won't
+	// be one, but be defensive) doesn't misalign the segments.
+	dot := strings.LastIndexByte(token, '.')
+	if dot <= 0 || dot == len(token)-1 {
+		return nil, ErrMalformedToken
+	}
+	payloadSeg, sigSeg := token[:dot], token[dot+1:]
+
+	mac := hmac.New(sha256.New, v.key)
+	mac.Write([]byte(payloadSeg))
+	expected := mac.Sum(nil)
+
+	presented, err := base64.RawURLEncoding.DecodeString(sigSeg)
+	if err != nil {
+		return nil, ErrMalformedToken
+	}
+	if !hmac.Equal(presented, expected) {
+		return nil, ErrBadSignature
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(payloadSeg)
+	if err != nil {
+		return nil, ErrMalformedToken
+	}
+	var claims Claims
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return nil, ErrMalformedToken
+	}
+
+	now := time.Now
+	if v.now != nil {
+		now = v.now
+	}
+	if claims.ExpiresAt > 0 && now().Unix() >= claims.ExpiresAt {
+		return nil, ErrExpiredToken
+	}
+	if claims.TenantID != pathTenantID {
+		return nil, ErrWrongTenant
+	}
+	if claims.Room != room {
+		return nil, ErrWrongRoom
+	}
+	return &claims, nil
+}

--- a/internal/connector/web/auth_test.go
+++ b/internal/connector/web/auth_test.go
@@ -1,0 +1,111 @@
+package web
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// farFuture is an exp well past any test run, so a valid token never expires
+// mid-test. Year ~2100.
+const farFuture = 4102444800
+
+// mintToken signs a web-chat token exactly as the canonical signer does:
+// base64url(payloadJSON) "." base64url(HMAC_SHA256(base64url(payloadJSON), key)),
+// RFC 4648 §5 with no padding, HMAC over the base64url payload STRING. This is
+// the reference the PHP WebChatTokenService must match byte-for-byte, so a Go
+// round-trip against it is the format-compatibility test.
+func mintToken(t *testing.T, key string, c Claims) string {
+	t.Helper()
+	payload, err := json.Marshal(c)
+	require.NoError(t, err)
+	seg := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(seg))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return seg + "." + sig
+}
+
+func newVerifier(t *testing.T, key string) *SignedTokenVerifier {
+	t.Helper()
+	v, err := NewSignedTokenVerifier(key)
+	require.NoError(t, err)
+	return v
+}
+
+func TestNewSignedTokenVerifierRejectsEmptyKey(t *testing.T) {
+	_, err := NewSignedTokenVerifier("")
+	assert.Error(t, err)
+}
+
+func TestVerifyClaimsRoundTrip(t *testing.T) {
+	key := "tenant-a-container-token"
+	claims := Claims{
+		TenantID: "tenant-a", Room: "console", Role: "owner",
+		VisitorID: "user-1", IssuedAt: 1000, ExpiresAt: farFuture,
+	}
+	tok := mintToken(t, key, claims)
+
+	got, err := newVerifier(t, key).VerifyClaims(tok, "tenant-a", "console")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-a", got.TenantID)
+	assert.Equal(t, "owner", got.Role)
+	assert.Equal(t, "user-1", got.VisitorID)
+}
+
+func TestVerifyClaimsRejectsTamperedPayload(t *testing.T) {
+	key := "k"
+	tok := mintToken(t, key, Claims{TenantID: "tenant-a", Room: "console", ExpiresAt: farFuture})
+
+	// Re-encode a different payload but keep the original signature → the
+	// recomputed HMAC no longer matches.
+	forged, _ := json.Marshal(Claims{TenantID: "tenant-a", Room: "console", Role: "owner", ExpiresAt: farFuture})
+	tampered := base64.RawURLEncoding.EncodeToString(forged) + "." + tok[len(tok)-43:]
+
+	_, err := newVerifier(t, key).VerifyClaims(tampered, "tenant-a", "console")
+	assert.ErrorIs(t, err, ErrBadSignature)
+}
+
+func TestVerifyClaimsRejectsWrongKey(t *testing.T) {
+	tok := mintToken(t, "real-key", Claims{TenantID: "tenant-a", Room: "console", ExpiresAt: farFuture})
+	_, err := newVerifier(t, "attacker-key").VerifyClaims(tok, "tenant-a", "console")
+	assert.ErrorIs(t, err, ErrBadSignature)
+}
+
+// TestVerifyClaimsRejectsCrossTenant is the core defence: a token minted for
+// tenant A, presented against tenant B's path, must fail closed even when B's
+// signing key is used (it isn't here — keys are per-tenant — but the explicit
+// tid check is the belt-and-braces the plan mandates).
+func TestVerifyClaimsRejectsCrossTenant(t *testing.T) {
+	key := "shared-somehow"
+	tok := mintToken(t, key, Claims{TenantID: "tenant-a", Room: "console", ExpiresAt: farFuture})
+	_, err := newVerifier(t, key).VerifyClaims(tok, "tenant-b", "console")
+	assert.ErrorIs(t, err, ErrWrongTenant)
+}
+
+func TestVerifyClaimsRejectsWrongRoom(t *testing.T) {
+	key := "k"
+	tok := mintToken(t, key, Claims{TenantID: "tenant-a", Room: "console", ExpiresAt: farFuture})
+	_, err := newVerifier(t, key).VerifyClaims(tok, "tenant-a", "lobby")
+	assert.ErrorIs(t, err, ErrWrongRoom)
+}
+
+func TestVerifyClaimsRejectsExpired(t *testing.T) {
+	key := "k"
+	tok := mintToken(t, key, Claims{TenantID: "tenant-a", Room: "console", ExpiresAt: 1000})
+	_, err := newVerifier(t, key).VerifyClaims(tok, "tenant-a", "console")
+	assert.ErrorIs(t, err, ErrExpiredToken)
+}
+
+func TestVerifyClaimsRejectsMalformed(t *testing.T) {
+	v := newVerifier(t, "k")
+	for _, tok := range []string{"", "nodot", ".", "abc.", ".abc"} {
+		_, err := v.VerifyClaims(tok, "tenant-a", "console")
+		assert.ErrorIs(t, err, ErrMalformedToken, "token %q", tok)
+	}
+}

--- a/internal/connector/web/connector.go
+++ b/internal/connector/web/connector.go
@@ -1,0 +1,552 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/google/uuid"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/llm"
+	"github.com/turborg/turborg/internal/messages"
+)
+
+// defaultConsoleSystemPrompt shapes the assistant's voice for free-text chat in
+// a web console. Operators can override it via SetConsolePrompt.
+const defaultConsoleSystemPrompt = "You are a helpful, friendly AI assistant chatting with a user in a web console. " +
+	"Answer directly and concisely. If you don't know something, say so."
+
+// consoleHistoryDepth is how many prior room messages are fed to the model as
+// conversation context, so the console feels like a real multi-turn assistant.
+const consoleHistoryDepth = 20
+
+// consoleMaxTokens bounds a single assistant reply.
+const consoleMaxTokens = 600
+
+// roomLogCap bounds how many recent messages a newly-attached client is
+// replayed on connect, and the ceiling on an on-demand history page. Matches
+// the IRC gateway's channelLogCap so both surfaces agree on one page size.
+const roomLogCap = 200
+
+// Settings configures a web-chat Connector.
+type Settings struct {
+	// BotNick is the display name attributed to bot output in the room.
+	BotNick string
+	// Room is the single chat room this connector serves (e.g. "console").
+	// Envelopes use it as the channel; the token's room claim must match it.
+	Room string
+	// Public reports whether the room is a shared/public room. False = a
+	// private owner console, where inbound messages are marked IsDirect so
+	// owner-only handlers treat them as a DM from the owner.
+	Public bool
+}
+
+// Connector is the hosted web-chat adapter. It serves browser WebSocket
+// clients directly (no upstream network), normalizing each `say` frame into an
+// agent.InboundEnvelope and fanning bot output back out as `message` frames.
+//
+// Lifecycle: Start is a no-op (nothing to dial); Run blocks until ctx is
+// cancelled; Stop closes every client socket. ServeWS is called per browser
+// connection by the pooled web router after it resolves the tenant.
+type Connector struct {
+	settings Settings
+	verifier *SignedTokenVerifier
+	log      *slog.Logger
+
+	// events is the tenant-owned bus. Actor.Say publishes MESSAGE_SENT here so
+	// the shared store submitter persists bot output. nil is tolerated (the
+	// connector still serves live traffic, just without persistence signals).
+	events *agent.EventBus
+
+	// store backs attach-replay + the history op. nil = no scrollback (live
+	// traffic only).
+	store messages.Store
+
+	// activityHook fires on genuine owner presence (an inbound chat message) so
+	// a web-only tenant isn't idle-paused while its owner is talking to it. nil
+	// = not wired.
+	activityHook func(reason string)
+
+	// llm answers free-text console messages (anything that isn't a command)
+	// as an AI assistant. nil = no AI chat — non-command messages get no reply.
+	// When it's a *llm.BudgetedProvider, a spent daily budget surfaces to the
+	// client as a distinct budget-exhausted signal instead of a generic error.
+	llm llm.Provider
+	// consolePrompt is the system prompt for AI chat. Empty uses the default.
+	consolePrompt string
+	// commandPrefix marks a message as a command (routed to the agent) rather
+	// than AI chat. Empty defaults to "!".
+	commandPrefix string
+	// historyDepth is how many prior messages of conversation memory the AI
+	// chat feeds the model. 0 uses the package default. Sourced from the plan's
+	// conversation-memory capability so a higher tier remembers more context.
+	historyDepth int
+
+	inbox chan *agent.InboundEnvelope
+
+	mu      sync.Mutex
+	clients map[*wsClient]struct{}
+	closed  bool
+	done    chan struct{}
+}
+
+// wsClient is one attached browser connection.
+type wsClient struct {
+	conn *websocket.Conn
+	role string
+}
+
+var _ agent.Connector = (*Connector)(nil)
+
+// New builds a web-chat Connector. events is the tenant-owned bus (may be nil
+// in tests that don't need persistence signals); verifier authenticates every
+// attaching client's token.
+func New(s Settings, log *slog.Logger, events *agent.EventBus, verifier *SignedTokenVerifier) *Connector {
+	if log == nil {
+		log = slog.Default()
+	}
+	if s.Room == "" {
+		s.Room = "console"
+	}
+	return &Connector{
+		settings: s,
+		verifier: verifier,
+		log:      log.With("connector", "web"),
+		events:   events,
+		inbox:    make(chan *agent.InboundEnvelope, 16),
+		clients:  map[*wsClient]struct{}{},
+		done:     make(chan struct{}),
+	}
+}
+
+// SetMessageStore installs the scrollback store used for attach-replay and the
+// history op. Call before Start.
+func (c *Connector) SetMessageStore(s messages.Store) { c.store = s }
+
+// SetActivityHook installs the owner-presence hook fired when the owner sends a
+// chat message. Call before Start.
+func (c *Connector) SetActivityHook(h func(reason string)) { c.activityHook = h }
+
+// SetLLMProvider installs the provider that answers free-text console messages
+// as an AI assistant. Call before Start. Nil disables AI chat.
+func (c *Connector) SetLLMProvider(p llm.Provider) { c.llm = p }
+
+// SetConsolePrompt overrides the assistant system prompt. Empty keeps the
+// default. Call before Start.
+func (c *Connector) SetConsolePrompt(s string) { c.consolePrompt = s }
+
+// SetCommandPrefix sets the prefix that routes a message to the agent's command
+// dispatch instead of AI chat. Empty defaults to "!". Call before Start.
+func (c *Connector) SetCommandPrefix(p string) { c.commandPrefix = p }
+
+// SetHistoryDepth sets how many prior messages of conversation memory the AI
+// chat feeds the model (the plan's conversation-memory capability). <= 0 keeps
+// the package default. Call before Start.
+func (c *Connector) SetHistoryDepth(n int) { c.historyDepth = n }
+
+// isCommand reports whether text is an agent command (routed to dispatch) rather
+// than free-text AI chat.
+func (c *Connector) isCommand(text string) bool {
+	prefix := c.commandPrefix
+	if prefix == "" {
+		prefix = "!"
+	}
+	return strings.HasPrefix(text, prefix)
+}
+
+func (c *Connector) Name() string                           { return "web" }
+func (c *Connector) ClaimSupervision() bool                 { return true }
+func (c *Connector) Inbound() <-chan *agent.InboundEnvelope { return c.inbox }
+
+// Start has no upstream handshake — a hosted room has nothing to dial.
+func (c *Connector) Start(context.Context) error { return nil }
+
+// Run blocks until ctx is cancelled. Client I/O is driven by ServeWS
+// goroutines the web router owns, not here.
+func (c *Connector) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Stop closes every attached socket and unblocks any in-flight inbound push.
+// Idempotent and safe after Run returns. The inbox is intentionally left open —
+// the agent's drain loop exits on ctx cancellation, and ServeWS goroutines
+// select on c.done to abandon a pending push, so nothing ever sends on a closed
+// channel.
+func (c *Connector) Stop(context.Context) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	close(c.done)
+	clients := make([]*wsClient, 0, len(c.clients))
+	for cl := range c.clients {
+		clients = append(clients, cl)
+	}
+	c.clients = map[*wsClient]struct{}{}
+	c.mu.Unlock()
+	for _, cl := range clients {
+		_ = cl.conn.Close(websocket.StatusGoingAway, "shutting down")
+	}
+	return nil
+}
+
+// Send delivers a handler-produced outbound message (a command reply routed
+// through agent.handle) to every client in the room as a bot frame. Skill/flow
+// output arrives via the Actor instead; both render identically.
+func (c *Connector) Send(env *agent.OutboundEnvelope) error {
+	c.broadcast(map[string]any{
+		"op":     "message",
+		"kind":   "bot",
+		"sender": c.settings.BotNick,
+		"text":   env.Text,
+		"ts":     time.Now().Unix(),
+		"id":     uuid.NewString(),
+	})
+	return nil
+}
+
+// ServeWS authenticates one browser WebSocket request against the tenant it
+// addresses, upgrades it, replays recent history, and runs the read loop until
+// the socket closes. tenantID is the tenant resolved from the request path; the
+// token is rejected unless its `tid` claim matches it (cross-tenant replay
+// defence). Auth failures answer 401 with no detail.
+func (c *Connector) ServeWS(w http.ResponseWriter, r *http.Request, tenantID string) {
+	token := extractToken(r)
+	claims, err := c.verifier.VerifyClaims(token, tenantID, c.settings.Room)
+	if err != nil {
+		c.log.Info("web chat auth fail", "ip", clientIP(r), "err", err)
+		http.Error(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // origin checks are the deployment's job
+	})
+	if err != nil {
+		c.log.Debug("web chat ws accept", "err", err)
+		return
+	}
+
+	cl := &wsClient{conn: conn, role: claims.Role}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		_ = conn.Close(websocket.StatusGoingAway, "shutting down")
+		return
+	}
+	c.clients[cl] = struct{}{}
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		delete(c.clients, cl)
+		c.mu.Unlock()
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}()
+
+	ctx := r.Context()
+	c.sendState(ctx, cl, claims)
+	c.replay(ctx, cl)
+	c.readLoop(ctx, cl, claims)
+}
+
+// sendState sends the initial room descriptor so a fresh client knows the room
+// name, whether it's public, and its own identity.
+func (c *Connector) sendState(ctx context.Context, cl *wsClient, claims *Claims) {
+	c.sendTo(ctx, cl, map[string]any{
+		"op":     "state",
+		"room":   c.settings.Room,
+		"public": c.settings.Public,
+		"you":    claims.Role,
+	})
+}
+
+// replay streams the most recent room history to a newly-attached client,
+// oldest-first, each frame flagged replayed so the UI can distinguish backfill
+// from live traffic.
+func (c *Connector) replay(ctx context.Context, cl *wsClient) {
+	if c.store == nil {
+		return
+	}
+	msgs, err := c.store.Recent(ctx, c.settings.Room, time.Time{}, roomLogCap)
+	if err != nil {
+		c.log.Debug("web chat replay", "err", err)
+		return
+	}
+	// Recent returns newest-first; walk in reverse so the UI sees chronological
+	// order.
+	for i := len(msgs) - 1; i >= 0; i-- {
+		m := msgs[i]
+		c.sendTo(ctx, cl, c.messageFrame(m, true))
+	}
+}
+
+// readLoop reads frames from one client until the socket errors (close /
+// cancellation), dispatching each recognized op.
+func (c *Connector) readLoop(ctx context.Context, cl *wsClient, claims *Claims) {
+	for {
+		_, raw, err := cl.conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		var p map[string]any
+		if err := json.Unmarshal(raw, &p); err != nil {
+			continue
+		}
+		switch op, _ := p["op"].(string); op {
+		case "say":
+			c.handleSay(ctx, cl, claims, p)
+		case "history":
+			c.handleHistory(ctx, cl, p)
+		}
+	}
+}
+
+// handleSay turns a `{op:"say",text}` frame into an inbound envelope: it echoes
+// the message to every client as a user frame, marks owner presence, and pushes
+// the envelope onto the inbox for the agent to dispatch. The room name is the
+// envelope channel; IsDirect is set for a private (non-public) room so
+// owner-only handlers treat it as a DM.
+func (c *Connector) handleSay(ctx context.Context, cl *wsClient, claims *Claims, p map[string]any) {
+	text, _ := p["text"].(string)
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+
+	// The owner typed and sent a message — genuine presence.
+	if c.activityHook != nil {
+		c.activityHook("web_message")
+	}
+
+	env := agent.NewInbound("web", c.settings.Room, claims.Role, text)
+	env.IsDirect = !c.settings.Public
+	env.Metadata["role"] = claims.Role
+	env.Metadata["vid"] = claims.VisitorID
+
+	// Echo the sender's own message back to all clients so it renders in every
+	// open tab (there is no server round-trip for user messages otherwise).
+	c.broadcast(map[string]any{
+		"op":     "message",
+		"kind":   "user",
+		"sender": claims.Role,
+		"text":   text,
+		"ts":     time.Now().Unix(),
+		"id":     env.ID.String(),
+	})
+
+	select {
+	case c.inbox <- env:
+	case <-c.done:
+		return
+	case <-ctx.Done():
+		return
+	}
+
+	// Free-text (non-command) messages are answered by the AI assistant. The
+	// message still went to the inbox above, so it's persisted (EventMessage)
+	// and any command/skill still sees it; the LLM reply is the console's
+	// conversational layer on top. Detached so the model call outlives this
+	// frame.
+	if c.llm != nil && !c.isCommand(text) {
+		go c.answerWithLLM(text) //nolint:gosec // G118: intentionally detached — the model call outlives the WS frame
+	}
+}
+
+// answerWithLLM generates an assistant reply to a free-text console message and
+// delivers it. On a spent daily LLM budget it emits a distinct budget-exhausted
+// signal the client can act on, instead of a generic error.
+func (c *Connector) answerWithLLM(userText string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	c.broadcast(map[string]any{"op": "status", "state": "thinking"})
+
+	system := c.consolePrompt
+	if system == "" {
+		system = defaultConsoleSystemPrompt
+	}
+	reply, _, err := c.llm.Ask(ctx, c.buildChatPrompt(ctx, userText),
+		llm.WithSystem(system), llm.WithMaxTokens(consoleMaxTokens))
+	if err != nil {
+		if errors.Is(err, llm.ErrBudgetExhausted) {
+			// The daily LLM budget is spent: emit a distinct budget_exhausted
+			// frame so the client can inform the user (a self-host operator can
+			// surface "try again tomorrow"; a downstream product its own
+			// messaging), plus a visible system bubble — not persisted, so it
+			// doesn't pollute the next turn's context.
+			c.broadcast(map[string]any{
+				"op":      "budget_exhausted",
+				"message": "The daily AI budget has been reached.",
+			})
+			c.broadcast(map[string]any{
+				"op": "message", "kind": "system", "sender": "system",
+				"text": "The daily AI budget has been reached.",
+				"ts":   time.Now().Unix(), "id": uuid.NewString(),
+			})
+			return
+		}
+		c.log.Debug("console llm", "err", err)
+		c.broadcast(map[string]any{"op": "error", "message": "The assistant is unavailable right now."})
+		return
+	}
+	if reply = strings.TrimSpace(reply); reply != "" {
+		// Through the Actor: broadcasts the bot frame, persists it, and publishes
+		// MESSAGE_SENT so it becomes context for the next turn.
+		_ = NewActor(c).Say("", reply)
+	}
+}
+
+// buildChatPrompt assembles the model prompt: recent room history as a
+// transcript (conversation memory) followed by the new user message.
+func (c *Connector) buildChatPrompt(ctx context.Context, userText string) string {
+	var sb strings.Builder
+	if c.store != nil {
+		depth := c.historyDepth
+		if depth <= 0 {
+			depth = consoleHistoryDepth
+		}
+		if msgs, err := c.store.Recent(ctx, c.settings.Room, time.Time{}, depth); err == nil {
+			// Recent is newest-first; walk in reverse for chronological order.
+			for i := len(msgs) - 1; i >= 0; i-- {
+				role := "User"
+				if msgs[i].Nick == c.settings.BotNick {
+					role = "Assistant"
+				}
+				fmt.Fprintf(&sb, "%s: %s\n", role, msgs[i].Text)
+			}
+		}
+	}
+	fmt.Fprintf(&sb, "User: %s\nAssistant:", userText)
+	return sb.String()
+}
+
+// handleHistory answers a `{op:"history",before,limit}` scrollback request:
+// `{op:"history_result",messages,has_more}`. `before` (RFC3339Nano) and `limit`
+// are optional; limit defaults to and is capped at roomLogCap.
+func (c *Connector) handleHistory(ctx context.Context, cl *wsClient, p map[string]any) {
+	limit := roomLogCap
+	if v, ok := p["limit"].(float64); ok && int(v) > 0 {
+		limit = int(v)
+	}
+	if limit > roomLogCap {
+		limit = roomLogCap
+	}
+	var before time.Time
+	if raw, ok := p["before"].(string); ok && raw != "" {
+		if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+			before = t
+		}
+	}
+	if c.store == nil {
+		c.sendTo(ctx, cl, map[string]any{
+			"op": "history_result", "messages": []map[string]any{}, "has_more": false,
+		})
+		return
+	}
+	msgs, err := c.store.Recent(ctx, c.settings.Room, before, limit)
+	if err != nil {
+		c.log.Debug("web chat history", "err", err)
+		c.sendTo(ctx, cl, map[string]any{
+			"op": "history_result", "messages": []map[string]any{}, "has_more": false,
+		})
+		return
+	}
+	out := make([]map[string]any, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, c.messageFrame(m, false))
+	}
+	c.sendTo(ctx, cl, map[string]any{
+		"op":       "history_result",
+		"messages": out,
+		"has_more": len(msgs) == limit,
+	})
+}
+
+// messageFrame renders a stored message as an outbound `message` frame,
+// inferring kind from whether the bot authored it.
+func (c *Connector) messageFrame(m messages.Message, replayed bool) map[string]any {
+	kind := "user"
+	if m.Nick == c.settings.BotNick {
+		kind = "bot"
+	}
+	frame := map[string]any{
+		"op":     "message",
+		"kind":   kind,
+		"sender": m.Nick,
+		"text":   m.Text,
+		"ts":     m.TS.Unix(),
+		"id":     m.ID,
+	}
+	if replayed {
+		frame["replayed"] = true
+	}
+	return frame
+}
+
+// broadcast fans a frame out to every attached client.
+func (c *Connector) broadcast(payload map[string]any) {
+	c.mu.Lock()
+	clients := make([]*wsClient, 0, len(c.clients))
+	for cl := range c.clients {
+		clients = append(clients, cl)
+	}
+	c.mu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for _, cl := range clients {
+		c.sendTo(ctx, cl, payload)
+	}
+}
+
+// sendTo writes one JSON frame to one client, dropping the client on a write
+// error (a dead socket) so a wedged peer can't stall future broadcasts.
+func (c *Connector) sendTo(ctx context.Context, cl *wsClient, payload map[string]any) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	if err := cl.conn.Write(ctx, websocket.MessageText, body); err != nil {
+		c.mu.Lock()
+		delete(c.clients, cl)
+		c.mu.Unlock()
+	}
+}
+
+// clientCount reports the number of attached clients (tests + diagnostics).
+func (c *Connector) clientCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.clients)
+}
+
+// extractToken reads the auth token from the `?token=` query or an
+// `Authorization: Bearer` header.
+func extractToken(r *http.Request) string {
+	if t := r.URL.Query().Get("token"); t != "" {
+		return t
+	}
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+		return strings.TrimSpace(auth[7:])
+	}
+	return ""
+}
+
+func clientIP(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}

--- a/internal/connector/web/connector.go
+++ b/internal/connector/web/connector.go
@@ -364,28 +364,51 @@ func (c *Connector) handleSay(ctx context.Context, cl *wsClient, claims *Claims,
 	}
 }
 
-// answerWithLLM generates an assistant reply to a free-text console message and
-// delivers it. On a spent daily LLM budget it emits a distinct budget-exhausted
-// signal the client can act on, instead of a generic error.
+// answerWithLLM streams an assistant reply to a free-text console message,
+// token by token, so the client renders it live (like a real assistant) rather
+// than waiting for the whole reply. The wire shape mirrors a streaming chat:
+//
+//	{op:"message_start", id, kind:"bot", sender}
+//	{op:"message_delta", id, text}   (repeated)
+//	{op:"message_end",   id}
+//
+// The full reply is persisted once at the end (MESSAGE_SENT) so it becomes
+// context for the next turn — the deltas already showed it, so it is NOT also
+// re-broadcast as a whole frame. A spent daily budget ends the (empty) message
+// and emits a budget_exhausted signal instead.
 func (c *Connector) answerWithLLM(userText string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
-
-	c.broadcast(map[string]any{"op": "status", "state": "thinking"})
 
 	system := c.consolePrompt
 	if system == "" {
 		system = defaultConsoleSystemPrompt
 	}
-	reply, _, err := c.llm.Ask(ctx, c.buildChatPrompt(ctx, userText),
-		llm.WithSystem(system), llm.WithMaxTokens(consoleMaxTokens))
-	if err != nil {
-		if errors.Is(err, llm.ErrBudgetExhausted) {
-			// The daily LLM budget is spent: emit a distinct budget_exhausted
-			// frame so the client can inform the user (a self-host operator can
-			// surface "try again tomorrow"; a downstream product its own
-			// messaging), plus a visible system bubble — not persisted, so it
-			// doesn't pollute the next turn's context.
+
+	id := uuid.NewString()
+	c.broadcast(map[string]any{
+		"op": "message_start", "id": id, "kind": "bot",
+		"sender": c.settings.BotNick, "ts": time.Now().Unix(),
+	})
+
+	var full strings.Builder
+	var streamErr error
+	for text, err := range c.llm.Stream(ctx, c.buildChatPrompt(ctx, userText),
+		llm.WithSystem(system), llm.WithMaxTokens(consoleMaxTokens)) {
+		if err != nil {
+			streamErr = err
+			break
+		}
+		if text == "" {
+			continue
+		}
+		full.WriteString(text)
+		c.broadcast(map[string]any{"op": "message_delta", "id": id, "text": text})
+	}
+
+	if streamErr != nil {
+		c.broadcast(map[string]any{"op": "message_end", "id": id, "aborted": true})
+		if errors.Is(streamErr, llm.ErrBudgetExhausted) {
 			c.broadcast(map[string]any{
 				"op":      "budget_exhausted",
 				"message": "The daily AI budget has been reached.",
@@ -397,14 +420,24 @@ func (c *Connector) answerWithLLM(userText string) {
 			})
 			return
 		}
-		c.log.Debug("console llm", "err", err)
+		c.log.Debug("console llm", "err", streamErr)
 		c.broadcast(map[string]any{"op": "error", "message": "The assistant is unavailable right now."})
 		return
 	}
-	if reply = strings.TrimSpace(reply); reply != "" {
-		// Through the Actor: broadcasts the bot frame, persists it, and publishes
-		// MESSAGE_SENT so it becomes context for the next turn.
-		_ = NewActor(c).Say("", reply)
+
+	c.broadcast(map[string]any{"op": "message_end", "id": id})
+
+	// Persist the assembled reply for history/context (deltas already rendered
+	// it, so don't re-broadcast a full bot frame).
+	if reply := strings.TrimSpace(full.String()); reply != "" && c.events != nil {
+		c.events.Publish(context.Background(), &agent.Event{
+			Type: agent.EventMessageSent,
+			Time: time.Now(),
+			Fields: map[string]any{
+				"connector": "web", "channel": c.settings.Room,
+				"sender": c.settings.BotNick, "text": reply,
+			},
+		})
 	}
 }
 

--- a/internal/connector/web/connector_test.go
+++ b/internal/connector/web/connector_test.go
@@ -1,0 +1,466 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	"github.com/turborg/turborg/internal/messages"
+)
+
+const testKey = "tenant-a-container-token"
+
+func newTestConn(t *testing.T, s Settings) (*Connector, *agent.EventBus) {
+	t.Helper()
+	if s.Room == "" {
+		s.Room = "console"
+	}
+	bus := agent.NewEventBus(nil)
+	c := New(s, nil, bus, newVerifier(t, testKey))
+	c.SetMessageStore(messages.NewMemoryStore(0))
+	// Stop closes any server-side sockets, which lets the ServeWS read loops
+	// (owned by the httptest server) return so goleak stays clean.
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+	return c, bus
+}
+
+// serveConn stands the connector up behind an httptest server that routes every
+// request as tenant `tenantID`, and returns the ws:// base URL.
+func serveConn(t *testing.T, c *Connector, tenantID string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.ServeWS(w, r, tenantID)
+	}))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+func dial(t *testing.T, base, token string) *websocket.Conn {
+	t.Helper()
+	conn, _, err := websocket.Dial(context.Background(), base+"/chat?token="+token, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+	return conn
+}
+
+func readFrame(t *testing.T, conn *websocket.Conn) map[string]any {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, body, err := conn.Read(ctx)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(body, &out))
+	return out
+}
+
+func validToken(t *testing.T, tenantID, room, role string) string {
+	return mintToken(t, testKey, Claims{
+		TenantID: tenantID, Room: room, Role: role, VisitorID: "user-1", ExpiresAt: farFuture,
+	})
+}
+
+// TestInboundSayProducesEnvelope drives the core connector→agent path: a `say`
+// frame becomes a normalized InboundEnvelope on Inbound(), and the sender's own
+// message is echoed back as a user frame.
+func TestInboundSayProducesEnvelope(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console", Public: false})
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+
+	assert.Equal(t, "state", readFrame(t, conn)["op"])
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"hello there"}`)))
+
+	echo := readFrame(t, conn)
+	assert.Equal(t, "message", echo["op"])
+	assert.Equal(t, "user", echo["kind"])
+	assert.Equal(t, "hello there", echo["text"])
+
+	select {
+	case env := <-c.Inbound():
+		assert.Equal(t, "web", env.Connector)
+		assert.Equal(t, "console", env.Channel)
+		assert.Equal(t, "owner", env.Sender)
+		assert.Equal(t, "hello there", env.Text)
+		assert.True(t, env.IsDirect, "private console messages are direct")
+		assert.Equal(t, "owner", env.Metadata["role"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("no inbound envelope produced")
+	}
+}
+
+// TestPublicRoomInboundNotDirect checks a public room does not mark inbound
+// messages as direct (owner-only handlers must not treat a public message as a
+// DM from the owner).
+func TestPublicRoomInboundNotDirect(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "lobby", Public: true})
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "lobby", "visitor"))
+	_ = readFrame(t, conn) // state
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"hi"}`)))
+	_ = readFrame(t, conn) // echo
+
+	select {
+	case env := <-c.Inbound():
+		assert.False(t, env.IsDirect)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no inbound envelope produced")
+	}
+}
+
+// TestActorSayBroadcastsAndPublishes verifies Actor.Say fans a bot frame to
+// attached clients AND publishes MESSAGE_SENT (so the shared store submitter
+// persists bot output).
+func TestActorSayBroadcastsAndPublishes(t *testing.T) {
+	c, bus := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+
+	sentCh := make(chan *agent.Event, 1)
+	bus.Subscribe(agent.EventMessageSent, func(_ context.Context, ev *agent.Event) {
+		sentCh <- ev
+	})
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	assert.Equal(t, "state", readFrame(t, conn)["op"])
+
+	// Wait for the client to register so the broadcast reaches it.
+	require.Eventually(t, func() bool { return c.clientCount() == 1 }, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, NewActor(c).Say("console", "how can I help?"))
+
+	frame := readFrame(t, conn)
+	assert.Equal(t, "message", frame["op"])
+	assert.Equal(t, "bot", frame["kind"])
+	assert.Equal(t, "helper", frame["sender"])
+	assert.Equal(t, "how can I help?", frame["text"])
+
+	select {
+	case ev := <-sentCh:
+		assert.Equal(t, "console", ev.Fields["channel"])
+		assert.Equal(t, "helper", ev.Fields["sender"])
+		assert.Equal(t, "how can I help?", ev.Fields["text"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("MESSAGE_SENT not published")
+	}
+}
+
+// TestSendBroadcastsBotFrame checks a command reply routed through the agent
+// (Connector.Send) reaches clients as a bot frame.
+func TestSendBroadcastsBotFrame(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+	require.Eventually(t, func() bool { return c.clientCount() == 1 }, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, c.Send(&agent.OutboundEnvelope{Channel: "console", Text: "pong"}))
+
+	frame := readFrame(t, conn)
+	assert.Equal(t, "bot", frame["kind"])
+	assert.Equal(t, "pong", frame["text"])
+}
+
+// TestHistoryReplayedOnAttach seeds the store and asserts a fresh client is
+// replayed prior messages, oldest-first, flagged replayed.
+func TestHistoryReplayedOnAttach(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	store := messages.NewMemoryStore(0)
+	c.SetMessageStore(store)
+	ctx := context.Background()
+	require.NoError(t, store.Submit(ctx, messages.Message{Channel: "console", Nick: "owner", Text: "first", TS: time.Now().Add(-time.Minute)}))
+	require.NoError(t, store.Submit(ctx, messages.Message{Channel: "console", Nick: "helper", Text: "second", TS: time.Now()}))
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	assert.Equal(t, "state", readFrame(t, conn)["op"])
+
+	first := readFrame(t, conn)
+	assert.Equal(t, "first", first["text"])
+	assert.Equal(t, "user", first["kind"])
+	assert.Equal(t, true, first["replayed"])
+
+	second := readFrame(t, conn)
+	assert.Equal(t, "second", second["text"])
+	assert.Equal(t, "bot", second["kind"], "bot-authored history renders as bot")
+}
+
+// TestServeWSRejectsCrossTenantToken is the security-critical case: a token
+// minted for tenant-a is presented to a router that resolved tenant-b. It must
+// fail closed with 401 before any upgrade.
+func TestServeWSRejectsCrossTenantToken(t *testing.T) {
+	c, _ := newTestConn(t, Settings{Room: "console"})
+	tok := validToken(t, "tenant-a", "console", "owner")
+
+	req := httptest.NewRequest(http.MethodGet, "/chat/tenant-b?token="+tok, nil)
+	rec := httptest.NewRecorder()
+	c.ServeWS(rec, req, "tenant-b")
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestServeWSRejectsMissingToken(t *testing.T) {
+	c, _ := newTestConn(t, Settings{Room: "console"})
+	req := httptest.NewRequest(http.MethodGet, "/chat/tenant-a", nil)
+	rec := httptest.NewRecorder()
+	c.ServeWS(rec, req, "tenant-a")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestActorNoticeAndModerationDenies covers Notice (renders like Say) and the
+// moderation actions the private console can't perform (they must error, per
+// the Actor contract).
+func TestActorNoticeAndModerationDenies(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+	require.Eventually(t, func() bool { return c.clientCount() == 1 }, time.Second, 10*time.Millisecond)
+
+	a := NewActor(c)
+	require.NoError(t, a.Notice("console", "heads up"))
+	frame := readFrame(t, conn)
+	assert.Equal(t, "bot", frame["kind"])
+	assert.Equal(t, "heads up", frame["text"])
+
+	assert.Error(t, a.Kick("console", "x", "r"))
+	assert.Error(t, a.Ban("console", "x"))
+	assert.Error(t, a.SetMode("console", "+m"))
+	assert.Error(t, a.Op("console", "x"))
+	assert.Error(t, a.Voice("console", "x"))
+	assert.Error(t, a.Topic("console", "t"))
+	assert.Error(t, a.Invite("console", "x"))
+}
+
+// TestHistoryOp exercises the on-demand scrollback op.
+func TestHistoryOp(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	store := messages.NewMemoryStore(0)
+	c.SetMessageStore(store)
+	require.NoError(t, store.Submit(context.Background(),
+		messages.Message{Channel: "console", Nick: "owner", Text: "old one", TS: time.Now()}))
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+	_ = readFrame(t, conn) // replay of "old one"
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"history","limit":5}`)))
+	res := readFrame(t, conn)
+	assert.Equal(t, "history_result", res["op"])
+	assert.Equal(t, false, res["has_more"])
+	msgs, ok := res["messages"].([]any)
+	require.True(t, ok)
+	require.Len(t, msgs, 1)
+}
+
+// TestHistoryOpNoStore covers the empty-result branch when no store is wired.
+func TestHistoryOpNoStore(t *testing.T) {
+	c := New(Settings{Room: "console"}, nil, agent.NewEventBus(nil), newVerifier(t, testKey))
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state (no store → no replay frames)
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"history"}`)))
+	res := readFrame(t, conn)
+	assert.Equal(t, "history_result", res["op"])
+	assert.Empty(t, res["messages"])
+}
+
+// TestActivityHookFiresOnInbound checks an owner message marks presence.
+func TestActivityHookFiresOnInbound(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	fired := make(chan string, 1)
+	c.SetActivityHook(func(reason string) { fired <- reason })
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"present"}`)))
+	select {
+	case reason := <-fired:
+		assert.Equal(t, "web_message", reason)
+	case <-time.After(2 * time.Second):
+		t.Fatal("activity hook did not fire")
+	}
+	<-c.Inbound() // drain so goleak/teardown is clean
+}
+
+// TestEmptySayIgnored checks a blank message produces no envelope.
+func TestEmptySayIgnored(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"   "}`)))
+	// Follow with a real message; if the blank one had produced an envelope it
+	// would be first in the inbox.
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"say","text":"real"}`)))
+	env := <-c.Inbound()
+	assert.Equal(t, "real", env.Text)
+}
+
+// TestNewDefaults covers the room-default and nil-log fallbacks in New.
+func TestNewDefaults(t *testing.T) {
+	c := New(Settings{}, nil, agent.NewEventBus(nil), newVerifier(t, testKey))
+	assert.Equal(t, "console", c.settings.Room)
+	assert.NotNil(t, c.log)
+}
+
+// TestBearerHeaderAuth covers the Authorization: Bearer token path.
+func TestBearerHeaderAuth(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	base := serveConn(t, c, "tenant-a")
+	tok := validToken(t, "tenant-a", "console", "owner")
+
+	conn, _, err := websocket.Dial(context.Background(), base+"/chat", &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": []string{"Bearer " + tok}},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+	assert.Equal(t, "state", readFrame(t, conn)["op"])
+}
+
+// TestServeWSAfterStopCloses covers the closed-connector reject branch: a client
+// arriving after Stop is accepted then immediately closed, never registered.
+func TestServeWSAfterStopCloses(t *testing.T) {
+	c, _ := newTestConn(t, Settings{Room: "console"})
+	require.NoError(t, c.Stop(context.Background()))
+
+	base := serveConn(t, c, "tenant-a")
+	tok := validToken(t, "tenant-a", "console", "owner")
+	conn, _, err := websocket.Dial(context.Background(), base+"/chat?token="+tok, nil)
+	if err == nil {
+		t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "") })
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, _, readErr := conn.Read(ctx)
+		assert.Error(t, readErr, "socket should be closed by a stopped connector")
+	}
+	assert.Zero(t, c.clientCount())
+}
+
+// TestBroadcastDropsDeadClient covers sendTo's write-error branch: once a client
+// socket is gone, a broadcast prunes it.
+func TestBroadcastDropsDeadClient(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+	require.Eventually(t, func() bool { return c.clientCount() == 1 }, time.Second, 10*time.Millisecond)
+
+	// Abort the client without a clean close so the server-side write fails
+	// before the read loop notices the disconnect.
+	_ = conn.CloseNow()
+
+	// Keep broadcasting until the dead client is pruned by either sendTo's
+	// write-error branch or the read loop's deferred cleanup.
+	require.Eventually(t, func() bool {
+		_ = c.Send(&agent.OutboundEnvelope{Channel: "console", Text: "ping"})
+		return c.clientCount() == 0
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+// TestSendToPrunesOnWriteError deterministically drives sendTo's write-error
+// branch: a registered client whose socket is closed is pruned on the next
+// broadcast. Manipulates the client set directly (in-package) to avoid racing
+// the read loop's own cleanup.
+func TestSendToPrunesOnWriteError(t *testing.T) {
+	c, _ := newTestConn(t, Settings{Room: "console"})
+
+	serverConnCh := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sc, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		serverConnCh <- sc // hand the accepted (hijacked) conn to the test
+	}))
+	defer srv.Close()
+
+	base := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, _, err := websocket.Dial(context.Background(), base, nil)
+	require.NoError(t, err)
+	sc := <-serverConnCh
+	_ = client.Close(websocket.StatusNormalClosure, "")
+	_ = sc.Close(websocket.StatusNormalClosure, "") // subsequent writes now error
+
+	cl := &wsClient{conn: sc}
+	c.mu.Lock()
+	c.clients[cl] = struct{}{}
+	c.mu.Unlock()
+	require.Equal(t, 1, c.clientCount())
+
+	c.broadcast(map[string]any{"op": "message", "text": "x"})
+	assert.Zero(t, c.clientCount(), "write error prunes the dead client")
+}
+
+// TestHistoryBeforeFilter covers the `before` timestamp parse in the history op.
+func TestHistoryBeforeFilter(t *testing.T) {
+	c, _ := newTestConn(t, Settings{BotNick: "helper", Room: "console"})
+	store := messages.NewMemoryStore(0)
+	c.SetMessageStore(store)
+	old := time.Now().Add(-time.Hour)
+	require.NoError(t, store.Submit(context.Background(),
+		messages.Message{Channel: "console", Nick: "owner", Text: "ancient", TS: old}))
+
+	base := serveConn(t, c, "tenant-a")
+	conn := dial(t, base, validToken(t, "tenant-a", "console", "owner"))
+	_ = readFrame(t, conn) // state
+	_ = readFrame(t, conn) // replay
+
+	// before = now → the hour-old message is older, so it's returned.
+	before := time.Now().Format(time.RFC3339Nano)
+	require.NoError(t, conn.Write(context.Background(), websocket.MessageText,
+		[]byte(`{"op":"history","before":"`+before+`"}`)))
+	res := readFrame(t, conn)
+	assert.Equal(t, "history_result", res["op"])
+	msgs, _ := res["messages"].([]any)
+	assert.Len(t, msgs, 1)
+}
+
+func TestClientIPFallsBackToRemoteAddr(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/chat", nil)
+	r.RemoteAddr = "no-port-here" // SplitHostPort fails → raw RemoteAddr
+	assert.Equal(t, "no-port-here", clientIP(r))
+}
+
+func TestConnectorLifecycle(t *testing.T) {
+	c := New(Settings{Room: "console"}, nil, agent.NewEventBus(nil), newVerifier(t, testKey))
+	require.NoError(t, c.Start(context.Background()))
+	assert.Equal(t, "web", c.Name())
+	assert.True(t, c.ClaimSupervision())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Run(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return on ctx cancel")
+	}
+
+	require.NoError(t, c.Stop(context.Background()))
+	require.NoError(t, c.Stop(context.Background()), "Stop is idempotent")
+}

--- a/internal/connector/web/main_test.go
+++ b/internal/connector/web/main_test.go
@@ -1,0 +1,11 @@
+package web
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/llm/budgeted.go
+++ b/internal/llm/budgeted.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"iter"
+	"strings"
 )
 
 // BudgetedProvider wraps a Provider with rolling-window token budget
@@ -44,8 +45,49 @@ func (p *BudgetedProvider) Ask(ctx context.Context, prompt string, opts ...CallO
 	return text, usage, nil
 }
 
+// Stream enforces the budget the same way Ask does, so streaming can't be used
+// to bypass the daily cap. It refuses up front when the budget is spent
+// (yielding ErrBudgetExhausted once), and records consumption after the stream
+// ends. The streaming interface carries no Usage, so tokens are ESTIMATED from
+// the prompt + accumulated output (~4 chars/token) — a soft budget tolerates the
+// approximation, and it's far better than counting streamed replies as free.
 func (p *BudgetedProvider) Stream(ctx context.Context, prompt string, opts ...CallOption) iter.Seq2[string, error] {
-	return p.inner.Stream(ctx, prompt, opts...)
+	if !p.budget.Allow(p.inputCap, p.outputCap) {
+		return func(yield func(string, error) bool) {
+			yield("", ErrBudgetExhausted)
+		}
+	}
+	inner := p.inner.Stream(ctx, prompt, opts...)
+	return func(yield func(string, error) bool) {
+		var out strings.Builder
+		for text, err := range inner {
+			if err != nil {
+				yield("", err)
+				return
+			}
+			out.WriteString(text)
+			if !yield(text, nil) {
+				break // consumer stopped early; still record what streamed.
+			}
+		}
+		usage := Usage{
+			InputTokens:  estimateTokens(prompt),
+			OutputTokens: estimateTokens(out.String()),
+		}
+		p.budget.Record(usage.InputTokens, usage.OutputTokens)
+		if p.onUsage != nil {
+			p.onUsage(usage)
+		}
+	}
+}
+
+// estimateTokens is a coarse token count (~4 chars/token) used to charge the
+// budget for a streamed call, where the provider reports no exact Usage.
+func estimateTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	return (len(s) + 3) / 4
 }
 
 // Budget returns the underlying TokenBudget so callers (e.g. the

--- a/internal/llm/budgeted_test.go
+++ b/internal/llm/budgeted_test.go
@@ -20,7 +20,84 @@ func (f *fakeProvider) Ask(_ context.Context, _ string, _ ...CallOption) (string
 	return f.resp, f.usage, f.err
 }
 func (f *fakeProvider) Stream(_ context.Context, _ string, _ ...CallOption) iter.Seq2[string, error] {
-	return func(yield func(string, error) bool) {}
+	return func(yield func(string, error) bool) {
+		if f.err != nil {
+			yield("", f.err)
+			return
+		}
+		yield(f.resp, nil)
+	}
+}
+
+func TestBudgetedProviderStreamRejectsWhenExhausted(t *testing.T) {
+	inner := &fakeProvider{resp: "streamed reply"}
+	budget := NewTokenBudget()
+	budget.SetBaseline(1000, 1000) // already over the caps
+	bp := NewBudgetedProvider(inner, budget, 100, 100, nil)
+
+	var got string
+	var gotErr error
+	for text, err := range bp.Stream(context.Background(), "hi") {
+		got, gotErr = text, err
+	}
+	assert.ErrorIs(t, gotErr, ErrBudgetExhausted)
+	assert.Empty(t, got)
+}
+
+func TestBudgetedProviderStreamPropagatesInnerError(t *testing.T) {
+	inner := &fakeProvider{err: assert.AnError} // budget allows; inner errors mid-stream
+	bp := NewBudgetedProvider(inner, NewTokenBudget(), 1000, 1000, nil)
+
+	var gotErr error
+	for _, err := range bp.Stream(context.Background(), "hi") {
+		gotErr = err
+	}
+	assert.ErrorIs(t, gotErr, assert.AnError)
+}
+
+func TestBudgetedProviderStreamStopsWhenConsumerBreaks(t *testing.T) {
+	inner := &fakeProvider{resp: "partial reply"}
+	budget := NewTokenBudget()
+	bp := NewBudgetedProvider(inner, budget, 1000, 1000, nil)
+
+	for _, err := range bp.Stream(context.Background(), "hi") {
+		require.NoError(t, err)
+		break // consumer stops early; producer must still record what streamed.
+	}
+	in, _ := budget.Totals()
+	assert.Positive(t, in)
+}
+
+func TestBudgetedProviderStreamEmptyReply(t *testing.T) {
+	inner := &fakeProvider{resp: ""} // exercises the zero-token estimate branch
+	budget := NewTokenBudget()
+	bp := NewBudgetedProvider(inner, budget, 1000, 1000, nil)
+
+	for _, err := range bp.Stream(context.Background(), "p") {
+		require.NoError(t, err)
+	}
+	_, out := budget.Totals()
+	assert.Zero(t, out)
+}
+
+func TestBudgetedProviderStreamRecordsEstimatedUsage(t *testing.T) {
+	inner := &fakeProvider{resp: "this is a streamed reply"}
+	budget := NewTokenBudget()
+	var reported Usage
+	bp := NewBudgetedProvider(inner, budget, 1000, 1000, func(u Usage) { reported = u })
+
+	var assembled string
+	for text, err := range bp.Stream(context.Background(), "a prompt") {
+		require.NoError(t, err)
+		assembled += text
+	}
+	assert.Equal(t, "this is a streamed reply", assembled)
+	// Estimated (~4 chars/token) usage was recorded + reported, so a streamed
+	// call can't slip past the budget as free.
+	in, out := budget.Totals()
+	assert.Positive(t, in)
+	assert.Positive(t, out)
+	assert.Positive(t, reported.OutputTokens)
 }
 
 func TestBudgetedProviderAllowsWithinBudget(t *testing.T) {

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -166,7 +166,6 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 		log = slog.Default()
 	}
 
-	a.Commands.SetMaxDynamic(p.CustomCommandsMax)
 	ircConn.SetClientLimits(p.Limits)
 
 	if p.ActivityHook != nil {
@@ -204,10 +203,34 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	}
 	ircConn.SetBouncerWelcomeReplayDepth(clampReplayDepth(p.BouncerWelcomeReplayDepth))
 
-	a.AddConnector(ircConn)
+	// Everything past the IRC-specific setters above is connector-agnostic —
+	// hand it to WireCore with the IRC Actor + nick so the web connector gets
+	// the identical builtins/persistence/skill/flow path from the same code.
+	return WireCore(a, ircConn, irc.NewActor(ircConn), ircConn.CurrentNick, provider, p, log), nil
+}
+
+// WireCore installs the connector-agnostic half of the agent wiring: the
+// command-registry cap, message-store submitters, the registry-wide command
+// guard, the skill engine + scheduler, the flow engine, and the data-driven
+// skill/flow set. It calls a.AddConnector(conn) itself and returns the live
+// Wiring so the caller can supervise the scheduler and hot-reload the skill set.
+//
+// It is the shared core WireCommon (IRC) and the web connector's wiring both
+// call, so the two surfaces can't drift: a builtin/persistence/skill feature
+// wired here reaches every connector. The caller owns everything genuinely
+// connector-specific (IRC bouncer/throttle setters, the web token verifier)
+// and supplies the connector-native Actor + botNick resolver + budgeted
+// provider this core threads into the engines and store submitters.
+func WireCore(a *agent.Agent, conn agent.Connector, actor agent.Actor, botNick func() string, provider llm.Provider, p CommonParams, log *slog.Logger) *Wiring {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	a.Commands.SetMaxDynamic(p.CustomCommandsMax)
+
+	a.AddConnector(conn)
 
 	if p.Store != nil {
-		botNick := ircConn.CurrentNick
 		a.Events.Subscribe(agent.EventMessage, makeStoreSubmitter(p.Store, botNick, log))
 		a.Events.Subscribe(agent.EventMessageSent, makeStoreSubmitter(p.Store, botNick, log))
 	}
@@ -219,10 +242,10 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 
 	// Skill engine (event/match) + scheduler, sharing the same provider and
 	// owner/platform render context as the command path. The engine acts on the
-	// network through the connector-agnostic IRC Actor and is subscribed to the
+	// network through the connector-native Actor and is subscribed to the
 	// agent's bus; the scheduler is supervised by the caller.
 	engine := skill.NewEngine(skill.Options{
-		Actor:     irc.NewActor(ircConn),
+		Actor:     actor,
 		Provider:  provider,
 		Store:     p.SkillStore,
 		Platform:  p.Platform,
@@ -236,7 +259,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	// Flow engine: the node-graph layer above single-shot skills, sharing the
 	// same actor/provider/owner/platform context and subscribed to the same bus.
 	flowEngine := flow.NewEngine(flow.Options{
-		Actor:    irc.NewActor(ircConn),
+		Actor:    actor,
 		Provider: provider,
 		Store:    p.SkillStore,
 		Platform: p.Platform,
@@ -254,7 +277,7 @@ func WireCommon(a *agent.Agent, ircConn *irc.Connector, p CommonParams, log *slo
 	// swaps all three atomically.
 	ApplySkills(a, wiring, p.Commands, provider, p.Owner, p.Platform, log)
 	ApplyFlows(wiring, p.Flows)
-	return wiring, nil
+	return wiring
 }
 
 // ApplySkills rebuilds the data-driven skill set from skills and swaps it into

--- a/internal/server/connector_web.go
+++ b/internal/server/connector_web.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"fmt"
+
+	webconn "github.com/turborg/turborg/internal/connector/web"
+)
+
+// webSettingsFromConnectorSpec maps a tenant's web ConnectorSpec (the feed wire
+// shape: config map) onto web.Settings plus the token verifier the connector
+// authenticates every attaching browser against. Pure — no IO.
+//
+// signingKey is the tenant's gateway_token (= its container_token): the HMAC key
+// web-chat tokens are signed with. There is no fleet-wide key by design, so the
+// per-tenant token doubles as the signing secret; an empty key disables the web
+// connector (there is nothing to verify against).
+func webSettingsFromConnectorSpec(cs ConnectorSpec, signingKey string) (webconn.Settings, *webconn.SignedTokenVerifier, error) {
+	if signingKey == "" {
+		return webconn.Settings{}, nil, fmt.Errorf("web connector: empty signing key")
+	}
+	verifier, err := webconn.NewSignedTokenVerifier(signingKey)
+	if err != nil {
+		return webconn.Settings{}, nil, fmt.Errorf("web connector: %w", err)
+	}
+	s := webconn.Settings{
+		BotNick: stringFieldOr(cs.Config, "bot_nick", "turborg"),
+		Room:    stringFieldOr(cs.Config, "room", "console"),
+		Public:  boolField(cs.Config, "public", false),
+	}
+	return s, verifier, nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -241,6 +241,22 @@ func (s *Server) RouteWS(turborgID string, w http.ResponseWriter, r *http.Reques
 	return true
 }
 
+// RouteChat hands one browser WebSocket request (the hosted web-chat surface,
+// addressed as `/chat/<id>`) to the named tenant's web connector. Returns false
+// (and does not touch w) when no such tenant is attached, so the router can
+// answer 404. The actual token auth + WS upgrade (and the 404 on a between-runs
+// tenant with no live connector) is the tenant's job.
+func (s *Server) RouteChat(turborgID string, w http.ResponseWriter, r *http.Request) bool {
+	s.mu.Lock()
+	t, ok := s.tenants[turborgID]
+	s.mu.Unlock()
+	if !ok {
+		return false
+	}
+	t.ServeChat(w, r)
+	return true
+}
+
 // RouteHook hands one inbound-webhook request (POST /c/<id>/hook/<name>) to the
 // named tenant's web gateway. Returns false (and does not touch w) when no such
 // tenant is attached, so the router can answer 404 without revealing whether the

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
+	webconn "github.com/turborg/turborg/internal/connector/web"
 	"github.com/turborg/turborg/internal/flow"
 	"github.com/turborg/turborg/internal/ident"
 	"github.com/turborg/turborg/internal/llm"
@@ -104,6 +105,13 @@ type Tenant struct {
 	// browser client. nil between runs / when the tenant has no web shell → an
 	// inbound WS request is closed with 404.
 	gateway *web.Gateway
+	// webConn is the live hosted web-chat connector for the current run, built
+	// in buildConnectors when the spec carries a "web" connector and cleared
+	// when the run ends. The web router reaches it via ServeChat to upgrade an
+	// attached browser client. nil between runs / when the tenant has no web
+	// connector → an inbound chat request is closed with 404. Distinct from
+	// gateway: that streams an IRC session to a dashboard; this IS the chat.
+	webConn *webconn.Connector
 	// stateEmitter mirrors this tenant's connector state (upstream status,
 	// channels, nick) to the control plane on every transition, so a downstream
 	// UI can reflect connection status for pooled tenants the same way it does
@@ -322,6 +330,7 @@ func (t *Tenant) defaultWork() func(context.Context) error {
 		sink := t.messageSink
 		t.ircConn = nil
 		t.gateway = nil
+		t.webConn = nil
 		t.stateEmitter = nil
 		t.messageSink = nil
 		t.agentRef = nil
@@ -476,6 +485,55 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 				t.gateway = gw
 				t.mu.Unlock()
 			}
+		case "web":
+			// The tenant's gateway_token doubles as the web-chat token signing
+			// key (no fleet-wide key by design). Empty → no web connector.
+			webSettings, verifier, err := webSettingsFromConnectorSpec(cs, gatewayToken)
+			if err != nil {
+				t.log.Error("skipping invalid web connector", "err", err)
+				continue
+			}
+			conn := webconn.New(webSettings, t.log, a.Events, verifier)
+
+			// Durable scrollback + write-through to the control plane, exactly as
+			// the IRC arm — the connector reads it on attach-replay + the history
+			// op, and the shared store submitter (wired by WireCore) writes it.
+			store, sink := t.buildMessageStore()
+			t.mu.Lock()
+			t.messageSink = sink
+			t.mu.Unlock()
+			conn.SetMessageStore(store)
+
+			// Owner presence: an inbound web chat message marks the tenant active
+			// in the pool's coalescing aggregator so a web-only tenant isn't
+			// idle-paused while its owner is talking to it.
+			if t.activity != nil {
+				conn.SetActivityHook(func(string) { t.activity.Mark(t.ID) })
+			}
+
+			// Same shared, connector-agnostic wiring the IRC arm gets — builtins,
+			// command guard, skill engine + scheduler, flow engine, persistence —
+			// via runtime.WireCore, so the two connectors can't drift. The web
+			// Actor + a fixed bot-nick resolver are the only connector-native bits.
+			cp := t.commonParams(cs, caps, webSettings.BotNick, store, ignoredNicks, cmds)
+			cp.Platform = "Web"
+			cp.Flows = t.spec.Flows
+			budgetedProvider := runtime.BuildBudgetedProvider(a, cp.LLM, cp.LLMInputCap, cp.LLMOutputCap, cp.LLMInputUsed, cp.LLMOutputUsed, t.log)
+			cp.LLM = budgetedProvider
+			// AI console: free-text (non-command) messages are answered by the
+			// LLM, with the daily token budget already enforced by the budgeted
+			// provider — a spent budget surfaces as a distinct budget-exhausted
+			// signal. Conversation memory is the shared message store
+			// (SetMessageStore above), bounded by the store's own retention.
+			conn.SetLLMProvider(budgetedProvider)
+			conn.SetCommandPrefix(a.Commands.Prefix())
+			botNick := func() string { return webSettings.BotNick }
+			wiring := runtime.WireCore(a, conn, webconn.NewActor(conn), botNick, budgetedProvider, cp, t.log)
+
+			t.mu.Lock()
+			t.webConn = conn
+			t.wiring = wiring
+			t.mu.Unlock()
 		default:
 			t.log.Warn("connector type not supported in pooled mode yet", "type", cs.Type)
 		}
@@ -946,6 +1004,23 @@ func (t *Tenant) ServeWS(w http.ResponseWriter, r *http.Request) {
 	// (`/c/<id>`) to it. Query (the token) is untouched.
 	r.URL.Path = "/ws"
 	gw.Handler().ServeHTTP(w, r)
+}
+
+// ServeChat hands one browser WebSocket request (the hosted web-chat surface,
+// addressed as `/chat/<id>`) to this tenant's live web connector. The web
+// router calls it after resolving the tenant from the request path. Returns 404
+// when the tenant has no running web connector (between runs / quarantined / no
+// web connector configured); the browser reconnects and the router retries. The
+// connector does the token auth (bound to the tenant id) + WS upgrade.
+func (t *Tenant) ServeChat(w http.ResponseWriter, r *http.Request) {
+	t.mu.Lock()
+	conn := t.webConn
+	t.mu.Unlock()
+	if conn == nil {
+		http.Error(w, "no web chat for tenant", http.StatusNotFound)
+		return
+	}
+	conn.ServeWS(w, r, t.ID)
 }
 
 // ServeHook hands one inbound-webhook request (POST /c/<id>/hook/<name>) to this

--- a/internal/server/tenant_web_test.go
+++ b/internal/server/tenant_web_test.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	webconn "github.com/turborg/turborg/internal/connector/web"
+	"github.com/turborg/turborg/internal/skill"
+)
+
+// newWebTenant builds a Tenant whose spec carries one web connector with the
+// given extra config keys merged in. The GatewayToken (the tenant's
+// container_token) doubles as the web-chat token signing key.
+func newWebTenant(configOverrides map[string]any, cmds ...skill.Skill) *Tenant {
+	cfg := map[string]any{"bot_nick": "helper", "room": "console"}
+	for k, v := range configOverrides {
+		cfg[k] = v
+	}
+	return &Tenant{
+		ID:  "t1",
+		log: testLogger(),
+		spec: TenantSpec{
+			TurborgID:        "t1",
+			CommandPrefix:    "!",
+			GatewayToken:     "signing-key",
+			Connectors:       []ConnectorSpec{{Type: "web", Config: cfg, Secrets: map[string]any{}}},
+			PlanCapabilities: &PlanCapabilities{CustomCommandsMax: -1},
+			Commands:         cmds,
+		},
+	}
+}
+
+// mintWebToken signs a web-chat token in the canonical format the connector
+// verifies against.
+func mintWebToken(t *testing.T, key, tid, room, role string) string {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"tid": tid, "room": room, "role": role, "vid": "u1", "iat": 1000, "exp": 4102444800,
+	})
+	require.NoError(t, err)
+	seg := base64.RawURLEncoding.EncodeToString(payload)
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(seg))
+	return seg + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// liveWebTenant builds a tenant whose web connector is live (no agent running),
+// enough to exercise the router's auth + upgrade surface.
+func liveWebTenant(t *testing.T, id, key string) *Tenant {
+	t.Helper()
+	v, err := webconn.NewSignedTokenVerifier(key)
+	require.NoError(t, err)
+	conn := webconn.New(webconn.Settings{BotNick: "helper", Room: "console"}, testLogger(), agent.NewEventBus(testLogger()), v)
+	t.Cleanup(func() { _ = conn.Stop(context.Background()) })
+	return &Tenant{ID: id, log: testLogger(), webConn: conn}
+}
+
+func TestWebSettingsFromConnectorSpec(t *testing.T) {
+	cs := ConnectorSpec{Config: map[string]any{"bot_nick": "helper", "room": "lobby", "public": true}}
+	s, v, err := webSettingsFromConnectorSpec(cs, "key")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+	assert.Equal(t, "helper", s.BotNick)
+	assert.Equal(t, "lobby", s.Room)
+	assert.True(t, s.Public)
+}
+
+func TestWebSettingsFromConnectorSpecDefaults(t *testing.T) {
+	s, _, err := webSettingsFromConnectorSpec(ConnectorSpec{Config: map[string]any{}}, "key")
+	require.NoError(t, err)
+	assert.Equal(t, "turborg", s.BotNick)
+	assert.Equal(t, "console", s.Room)
+	assert.False(t, s.Public)
+}
+
+func TestWebSettingsFromConnectorSpecEmptyKey(t *testing.T) {
+	_, _, err := webSettingsFromConnectorSpec(ConnectorSpec{Config: map[string]any{}}, "")
+	assert.Error(t, err)
+}
+
+// TestBuildConnectorsWiresWebConnector proves the web arm installs the tenant's
+// data-driven commands through the shared WireCore and captures the live
+// connector for the chat router.
+func TestBuildConnectorsWiresWebConnector(t *testing.T) {
+	tn := newWebTenant(nil,
+		skill.Command("rules", skill.TypeStatic, "be nice", skill.AccessEveryone))
+	a := agent.NewWithPrefix(tn.log, "!")
+	tn.buildConnectors(a)
+	t.Cleanup(func() {
+		tn.mu.Lock()
+		conn := tn.webConn
+		tn.mu.Unlock()
+		if conn != nil {
+			_ = conn.Stop(context.Background())
+		}
+	})
+
+	require.Contains(t, a.Commands.Names(), "rules")
+	tn.mu.Lock()
+	conn := tn.webConn
+	tn.mu.Unlock()
+	require.NotNil(t, conn, "buildConnectors must capture the live web connector for the chat router")
+}
+
+// TestBuildWebConnectorEmptyTokenSkipped: with no GatewayToken there's no
+// signing key, so the web arm skips the connector rather than build one that
+// can't authenticate anyone.
+func TestBuildWebConnectorEmptyTokenSkipped(t *testing.T) {
+	tn := newWebTenant(nil)
+	tn.spec.GatewayToken = ""
+	a := agent.NewWithPrefix(tn.log, "!")
+	tn.buildConnectors(a)
+
+	tn.mu.Lock()
+	conn := tn.webConn
+	tn.mu.Unlock()
+	assert.Nil(t, conn, "no signing key → no web connector")
+}
+
+// TestServeChatNoConnector: a tenant with no live web connector answers 404.
+func TestServeChatNoConnector(t *testing.T) {
+	tn := &Tenant{ID: "t1", log: testLogger()}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/chat/t1?token=x", nil)
+	tn.ServeChat(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestRouteChatLookup: RouteChat returns false for an unknown tenant and true
+// for an attached one (whose ServeChat 404s with no live connector).
+func TestRouteChatLookup(t *testing.T) {
+	s := New(nil, testLogger())
+	s.tenants["known"] = &Tenant{ID: "known", log: testLogger()}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/chat/missing?token=x", nil)
+	assert.False(t, s.RouteChat("missing", rec, req))
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/chat/known?token=x", nil)
+	assert.True(t, s.RouteChat("known", rec2, req2))
+	assert.Equal(t, http.StatusNotFound, rec2.Code)
+}
+
+// TestWebChatRouterUpgradeAndAuth is the end-to-end: a live web tenant is
+// reachable at /chat/<id>?token=<good> and upgrades the WS; a bad token 401s; a
+// token minted for another tenant 401s (cross-tenant replay fails closed); an
+// unknown tenant 404s.
+func TestWebChatRouterUpgradeAndAuth(t *testing.T) {
+	s := New(nil, testLogger())
+	s.tenants["alice"] = liveWebTenant(t, "alice", "key-a")
+	s.tenants["bob"] = liveWebTenant(t, "bob", "key-b")
+	addr, stop := startWebRouter(t, s)
+	defer stop()
+
+	good := mintWebToken(t, "key-a", "alice", "console", "owner")
+	conn, _, err := websocket.Dial(context.Background(), "ws://"+addr+"/chat/alice?token="+good, nil)
+	require.NoError(t, err, "valid token upgrades the WS")
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+
+	_, resp, err := websocket.Dial(context.Background(), "ws://"+addr+"/chat/alice?token=nope", nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.Error(t, err, "bad token must not upgrade")
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// Cross-tenant replay: alice's token presented to bob's path must fail
+	// closed (bob's key wouldn't validate the HMAC, and the tid check is the
+	// belt-and-braces).
+	_, resp2, err := websocket.Dial(context.Background(), "ws://"+addr+"/chat/bob?token="+good, nil)
+	if resp2 != nil {
+		defer resp2.Body.Close()
+	}
+	require.Error(t, err, "cross-tenant token must not upgrade")
+	require.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+
+	_, resp3, err := websocket.Dial(context.Background(), "ws://"+addr+"/chat/ghost?token="+good, nil)
+	if resp3 != nil {
+		defer resp3.Body.Close()
+	}
+	require.Error(t, err, "unknown tenant is 404")
+	require.Equal(t, http.StatusNotFound, resp3.StatusCode)
+}

--- a/internal/server/web_router.go
+++ b/internal/server/web_router.go
@@ -41,6 +41,16 @@ func (s *Server) serveWebGatewayRouter(ctx context.Context, ln net.Listener) err
 			http.Error(w, "no such tenant", http.StatusNotFound)
 		}
 	})
+	// Hosted web-chat surface: an external proxy forwards `/chat/<id>` to the
+	// pool and this routes it to that tenant's web connector, which does the
+	// per-tenant token auth + WS upgrade. Sibling to `/c/<id>` (the IRC-shell
+	// gateway); an unknown tenant is a 404 with no detail, same as the WS route.
+	mux.HandleFunc("GET /chat/{turborg_id}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("turborg_id")
+		if id == "" || !s.RouteChat(id, w, r) {
+			http.Error(w, "no such tenant", http.StatusNotFound)
+		}
+	})
 	// Inbound-webhook ingress: an external system POSTs to /c/<id>/hook/<name>
 	// to fire that tenant's per-flow webhook trigger. The tenant gateway does the
 	// auth + dispatch; an unknown tenant is a 404 with no detail (never leaks


### PR DESCRIPTION
## What

Adds a **`web` connector** — a JSON-over-WebSocket chat surface turborg serves itself (no upstream network to dial). It implements `agent.Connector` + `agent.Actor`, so commands, skills, and flows fire identically to IRC; a `!ping` flow works in web chat exactly as on IRC, unchanged.

## Highlights

- **Auth (`SignedTokenVerifier`)** — HMAC-SHA256 per-tenant tokens, JWT-style (`base64url(payload).base64url(hmac)`), bound to the tenant path segment. A token minted for one tenant **fails closed** on another (explicit `tid` check as defence-in-depth on top of the per-tenant key).
- **Conversational console** — free-text (non-command) messages are answered by the configured LLM, with conversation memory drawn from the message store. Prefix commands still route to the agent's dispatch. A spent daily LLM budget surfaces a distinct `budget_exhausted` frame rather than a generic error.
- **`runtime.WireCore`** — the IRC-coupled `WireCommon` is split into IRC-specific setters plus a connector-agnostic core (command registry, message-store submitters, command guard, skill + flow engines). Both the IRC and web connectors call it, so builtins/persistence/skills/flows can't drift between surfaces.
- **Pooled wiring** — `web` added to `ValidConnectors` (with the now-reachable `MAX_CONNECTORS_PER_AGENT` cap), a per-tenant `GET /chat/{id}` route on the web gateway router, and the tenant build arm.

## Tests

- Connector: inbound `say` → normalized `InboundEnvelope`; `Actor.Say` → outbound frame + `MESSAGE_SENT`; history replay/scrollback; lifecycle.
- **Cross-tenant token replay fails closed** (verifier and live router); tampered / wrong-key / expired / wrong-room all rejected; round-trip against the canonical token format.
- AI console: free-text → LLM reply with history; prefix command is not sent to the LLM; `budget_exhausted` signal.

`make lint test cover-gate` all green; new package covered above the 90% package gate.