### PR TITLE
fix(messages): persist each message once across surfaces

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -14,6 +14,7 @@ type Agent struct {
 	Commands   *CommandRegistry
 	Events     *EventBus
 	log        *slog.Logger
+	storeWired bool
 }
 
 func New(log *slog.Logger) *Agent {
@@ -42,6 +43,21 @@ func NewWithPrefix(log *slog.Logger, prefix string) *Agent {
 
 func (a *Agent) AddConnector(c Connector) {
 	a.connectors = append(a.connectors, c)
+}
+
+// MarkStoreWired reports whether the caller is the first to claim
+// message-store wiring on this agent, flipping the guard so later callers
+// get false. WireCore is invoked once per connector surface but they all
+// share this one agent + EventBus, so the durable-store submitter must be
+// subscribed exactly once — otherwise every message is persisted N times
+// (one row per surface), each with a distinct minted msg_id that defeats
+// the receiver's msg_id dedupe. Setup is single-threaded, so no lock.
+func (a *Agent) MarkStoreWired() bool {
+	if a.storeWired {
+		return false
+	}
+	a.storeWired = true
+	return true
 }
 
 // Log exposes the agent's logger for handlers + runtime composers that

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -241,3 +241,14 @@ type sendFails struct {
 func (s *sendFails) Send(_ *agent.OutboundEnvelope) error {
 	return errors.New("send broken")
 }
+
+// TestMarkStoreWiredOnce pins the once-per-agent guard: WireCore runs once per
+// connector surface but they share one agent + EventBus, so only the first
+// caller may wire the durable-store submitter — otherwise every message is
+// persisted once per surface.
+func TestMarkStoreWiredOnce(t *testing.T) {
+	a := agent.New(nil)
+	assert.True(t, a.MarkStoreWired(), "first call claims the wiring")
+	assert.False(t, a.MarkStoreWired(), "second call is a no-op")
+	assert.False(t, a.MarkStoreWired(), "and stays a no-op")
+}

--- a/internal/runtime/messages_test.go
+++ b/internal/runtime/messages_test.go
@@ -179,6 +179,42 @@ func TestMakeStoreSubmitterOutboundSkipsWhenBotNickEmpty(t *testing.T) {
 		"empty bot nick → row would 422; must skip rather than write a half-formed entry")
 }
 
+// TestMakeStoreSubmitterDedupesSendAndSelfEcho pins the duplicate-row fix: a
+// message you send arrives on MESSAGE_SENT and again as the IRC self-echo
+// MESSAGE. One submitter closure subscribed to both events must persist it
+// exactly once (previously it wrote both, each with a fresh minted msg_id, so
+// the receiver's msg_id dedupe couldn't collapse them).
+func TestMakeStoreSubmitterDedupesSendAndSelfEcho(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, func() string { return "bot" }, nil)
+	sub(context.Background(), &agent.Event{
+		Type:   agent.EventMessageSent,
+		Fields: map[string]any{"envelope": &agent.OutboundEnvelope{Channel: "#x", Text: "hello"}},
+	})
+	sub(context.Background(), &agent.Event{
+		Type:   agent.EventMessage,
+		Fields: map[string]any{"channel": "#x", "sender": "bot", "text": "hello"},
+	})
+	assert.Equal(t, 1, store.Len("#x"), "send + self-echo must collapse to one row")
+}
+
+// TestMakeStoreSubmitterKeepsDistinctMessages guards against the dedupe being
+// too greedy: different text, or the same text from a different nick, are
+// genuinely different messages and must all persist.
+func TestMakeStoreSubmitterKeepsDistinctMessages(t *testing.T) {
+	store := messages.NewMemoryStore(0)
+	sub := makeStoreSubmitter(store, nil, nil)
+	fields := []map[string]any{
+		{"channel": "#x", "sender": "alice", "text": "one"},
+		{"channel": "#x", "sender": "alice", "text": "two"},
+		{"channel": "#x", "sender": "bob", "text": "one"},
+	}
+	for _, f := range fields {
+		sub(context.Background(), &agent.Event{Type: agent.EventMessage, Fields: f})
+	}
+	assert.Equal(t, 3, store.Len("#x"), "distinct text/nick must not be deduped")
+}
+
 func TestBuildSkillStoreNilWhenUnconfigured(t *testing.T) {
 	s := &config.Settings{} // No STATE_URL configured.
 	assert.Nil(t, buildSkillStore(s, nil), "no state URL → nil (engines default to in-process)")

--- a/internal/runtime/messages_test.go
+++ b/internal/runtime/messages_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -213,6 +214,26 @@ func TestMakeStoreSubmitterKeepsDistinctMessages(t *testing.T) {
 		sub(context.Background(), &agent.Event{Type: agent.EventMessage, Fields: f})
 	}
 	assert.Equal(t, 3, store.Len("#x"), "distinct text/nick must not be deduped")
+}
+
+// TestStoreDedupeFirstSight exercises the dedupe helper directly: a first
+// sighting persists, an immediate repeat within the window is suppressed, the
+// same key after the window is a fresh sighting again, and once the map grows
+// past the GC threshold a later sighting evicts the stale keys.
+func TestStoreDedupeFirstSight(t *testing.T) {
+	d := &storeDedupe{seen: make(map[string]time.Time)}
+	base := time.Unix(1_700_000_000, 0)
+
+	assert.True(t, d.firstSight("a", base), "first sighting persists")
+	assert.False(t, d.firstSight("a", base.Add(time.Second)), "repeat within window is suppressed")
+	assert.True(t, d.firstSight("a", base.Add(2*storeDedupeWindow)), "same key past the window is fresh again")
+
+	for i := 0; i < 600; i++ {
+		d.firstSight(fmt.Sprintf("k%d", i), base)
+	}
+	assert.True(t, d.firstSight("trigger", base.Add(10*time.Second)),
+		"a new key after the window is a first sighting")
+	assert.Less(t, len(d.seen), 600, "stale keys evicted once the map grew past the GC threshold")
 }
 
 func TestBuildSkillStoreNilWhenUnconfigured(t *testing.T) {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/turborg/turborg/internal/activity"
@@ -479,7 +480,43 @@ func buildSkillStore(s *config.Settings, log *slog.Logger) skill.Store {
 // re-resolve the nick on every event — handy when the bot renames
 // mid-session (NICK changes); avoids stamping the original boot-time
 // nick onto every later reply.
+// storeDedupeWindow is how long an identical (channel, nick, text) is treated
+// as the same logical message. A send and its IRC self-echo arrive well under a
+// second apart; the window only needs to be comfortably longer than that round
+// trip. The trade-off is that a human who sends byte-identical text to the same
+// channel twice inside the window collapses to one row — rare, and far less bad
+// than the 2–4× duplication it prevents.
+const storeDedupeWindow = 3 * time.Second
+
+// storeDedupe collapses the same logical message arriving on more than one
+// event (MESSAGE_SENT + the self-echo MESSAGE) within a short window.
+type storeDedupe struct {
+	mu   sync.Mutex
+	seen map[string]time.Time
+}
+
+// firstSight records key at now and reports whether it had NOT been seen within
+// the window (i.e. this is the copy that should be persisted).
+func (d *storeDedupe) firstSight(key string, now time.Time) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if last, ok := d.seen[key]; ok && now.Sub(last) < storeDedupeWindow {
+		d.seen[key] = now // refresh so a burst stays collapsed
+		return false
+	}
+	d.seen[key] = now
+	if len(d.seen) > 512 { // opportunistic GC of stale keys
+		for k, t := range d.seen {
+			if now.Sub(t) >= storeDedupeWindow {
+				delete(d.seen, k)
+			}
+		}
+	}
+	return true
+}
+
 func makeStoreSubmitter(store messages.Store, botNick func() string, log *slog.Logger) func(ctx context.Context, ev *agent.Event) {
+	dedupe := &storeDedupe{seen: make(map[string]time.Time)}
 	return func(ctx context.Context, ev *agent.Event) {
 		channel, _ := ev.Fields["channel"].(string)
 		nick, _ := ev.Fields["sender"].(string)
@@ -520,11 +557,17 @@ func makeStoreSubmitter(store messages.Store, botNick func() string, log *slog.L
 		if channel == "" || nick == "" || text == "" {
 			return
 		}
+		now := time.Now()
+		// Same message can land on MESSAGE_SENT and again on the self-echo
+		// MESSAGE; persist only the first sighting within the window.
+		if !dedupe.firstSight(channel+"\x00"+nick+"\x00"+text, now) {
+			return
+		}
 		if err := store.Submit(ctx, messages.Message{
 			Channel: channel,
 			Nick:    nick,
 			Text:    text,
-			TS:      time.Now(),
+			TS:      now,
 		}); err != nil {
 			log.Debug("store submit", "err", err, "channel", channel)
 		}

--- a/internal/runtime/wire.go
+++ b/internal/runtime/wire.go
@@ -230,9 +230,15 @@ func WireCore(a *agent.Agent, conn agent.Connector, actor agent.Actor, botNick f
 
 	a.AddConnector(conn)
 
-	if p.Store != nil {
-		a.Events.Subscribe(agent.EventMessage, makeStoreSubmitter(p.Store, botNick, log))
-		a.Events.Subscribe(agent.EventMessageSent, makeStoreSubmitter(p.Store, botNick, log))
+	if p.Store != nil && a.MarkStoreWired() {
+		// ONE submitter closure (with its own short-window dedupe) subscribed
+		// to BOTH events. A message you send surfaces twice — once as
+		// MESSAGE_SENT and again as the IRC self-echo MESSAGE — so the two
+		// subscriptions must share a single dedupe, and the whole thing must
+		// be wired once per agent (MarkStoreWired), or the row multiplies.
+		submit := makeStoreSubmitter(p.Store, botNick, log)
+		a.Events.Subscribe(agent.EventMessage, submit)
+		a.Events.Subscribe(agent.EventMessageSent, submit)
 	}
 
 	// Registry-wide guard: the ignore list + per-sender throttle, applied to


### PR DESCRIPTION
## Problem
The durable-store submitter is subscribed to both `MESSAGE` and `MESSAGE_SENT` inside `WireCore`, which runs once per connector surface on the same shared agent + `EventBus`. A message you send surfaces twice — the sent event plus the IRC self-echo — and with multiple surfaces wired each copy is persisted again. Every copy mints a fresh `msg_id`, so a receiver deduping on `msg_id` cannot collapse them: one logical message lands as 2–4 rows.

## Fix
- Wire the store submitter **exactly once per agent** (`Agent.MarkStoreWired`), with a single closure subscribed to both events.
- Add a short-window `(channel, nick, text)` dedupe inside the submitter so a send and its self-echo collapse to one row.

## Tests
- `TestMakeStoreSubmitterDedupesSendAndSelfEcho`, `TestMakeStoreSubmitterKeepsDistinctMessages` (dedupe correctness, not too greedy).
- `TestMarkStoreWiredOnce` (once-per-agent guard).
- `go build ./...` + `go vet` clean.