### PR TITLE
feat(statepush): report connection state for all connectors

### DIFF
--- a/internal/agent/state.go
+++ b/internal/agent/state.go
@@ -1,0 +1,20 @@
+package agent
+
+import "time"
+
+// ConnectorState is a connector-agnostic snapshot of a connector's live
+// connection state, surfaced to the state-mirror emitter. State is one of:
+// "connecting", "connected", "suspended", "error", "disconnected".
+type ConnectorState struct {
+	State  string
+	Since  time.Time
+	Reason string
+}
+
+// StateReporter is the optional capability a connector implements to expose
+// its live connection state.
+type StateReporter interface{ ConnectorState() ConnectorState }
+
+// StateSubscriber optionally lets a connector push a notify() callback on
+// every state change so the emitter is event-driven rather than polled.
+type StateSubscriber interface{ OnStateChange(fn func()) }

--- a/internal/connector/discord/connector.go
+++ b/internal/connector/discord/connector.go
@@ -71,9 +71,48 @@ type Connector struct {
 	lifecycleMu sync.Mutex
 	suspended   bool
 	lifecycleCh chan struct{}
+
+	stateMu       sync.Mutex
+	state         string
+	stateSince    time.Time
+	stateReason   string
+	onStateChange func()
 }
 
 var _ agent.Connector = (*Connector)(nil)
+var _ agent.StateReporter = (*Connector)(nil)
+var _ agent.StateSubscriber = (*Connector)(nil)
+
+// ConnectorState returns a connector-agnostic snapshot of the live connection
+// state for the state-mirror emitter.
+func (c *Connector) ConnectorState() agent.ConnectorState {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return agent.ConnectorState{State: c.state, Since: c.stateSince, Reason: c.stateReason}
+}
+
+// OnStateChange registers a callback fired on every state transition so the
+// emitter can be event-driven rather than polled.
+func (c *Connector) OnStateChange(fn func()) {
+	c.stateMu.Lock()
+	c.onStateChange = fn
+	c.stateMu.Unlock()
+}
+
+// setState records a new connection state (and reason) and fires the change
+// hook synchronously when either moved.
+func (c *Connector) setState(state, reason string) {
+	c.stateMu.Lock()
+	changed := c.state != state || c.stateReason != reason
+	if changed {
+		c.state, c.stateReason, c.stateSince = state, reason, time.Now()
+	}
+	fn := c.onStateChange
+	c.stateMu.Unlock()
+	if changed && fn != nil {
+		fn()
+	}
+}
 
 // New builds a Discord Connector. events is the tenant-owned bus (may be nil in
 // tests that don't need persistence signals).
@@ -87,6 +126,10 @@ func New(s *Settings, log *slog.Logger, events *agent.EventBus) *Connector {
 			allow[ch] = struct{}{}
 		}
 	}
+	initialState := "connecting"
+	if s.Suspended {
+		initialState = "suspended"
+	}
 	return &Connector{
 		settings:    s,
 		log:         log.With("connector", "discord"),
@@ -97,6 +140,8 @@ func New(s *Settings, log *slog.Logger, events *agent.EventBus) *Connector {
 		refs:        map[uuid.UUID]replyRef{},
 		lifecycleCh: make(chan struct{}, 1),
 		suspended:   s.Suspended,
+		state:       initialState,
+		stateSince:  time.Now(),
 	}
 }
 
@@ -135,6 +180,7 @@ func (c *Connector) Suspend() {
 	c.lifecycleMu.Unlock()
 	c.disconnect()
 	c.signalLifecycle()
+	c.setState("suspended", "")
 }
 
 // Resume clears a user-requested disconnect and wakes Run to reconnect.
@@ -147,6 +193,7 @@ func (c *Connector) Resume() {
 	}
 	c.suspended = false
 	c.lifecycleMu.Unlock()
+	c.setState("connecting", "")
 	c.signalLifecycle()
 }
 
@@ -181,16 +228,23 @@ func (c *Connector) connect() error {
 	existing := c.session
 	c.mu.Unlock()
 	if existing != nil {
-		return existing.Open()
+		if err := existing.Open(); err != nil {
+			c.setState("error", err.Error())
+			return err
+		}
+		c.setState("connected", "")
+		return nil
 	}
 
 	dg, err := discordgo.New("Bot " + c.settings.Token)
 	if err != nil {
+		c.setState("error", err.Error())
 		return err
 	}
 	dg.Identify.Intents = discordgo.IntentGuildMessages | discordgo.IntentDirectMessages | discordgo.IntentMessageContent
 	dg.AddHandler(c.onMessageCreate)
 	if err := dg.Open(); err != nil {
+		c.setState("error", err.Error())
 		return err
 	}
 	c.mu.Lock()
@@ -200,6 +254,7 @@ func (c *Connector) connect() error {
 		c.selfName = dg.State.User.Username
 	}
 	c.mu.Unlock()
+	c.setState("connected", "")
 	return nil
 }
 
@@ -226,6 +281,7 @@ func (c *Connector) Run(ctx context.Context) error {
 			if c.isSuspended() {
 				c.disconnect()
 			} else if err := c.connect(); err != nil {
+				c.setState("error", err.Error())
 				c.log.Warn("discord resume connect failed", "err", err)
 			}
 		}

--- a/internal/connector/discord/state_test.go
+++ b/internal/connector/discord/state_test.go
@@ -1,0 +1,60 @@
+package discord
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+)
+
+// failOpenSession is a session whose Open always errors, to drive the connect
+// failure → "error" transition.
+type failOpenSession struct{ fakeSession }
+
+func (f *failOpenSession) Open() error { return errors.New("gateway refused") }
+
+func TestConnectorStateInitial(t *testing.T) {
+	c := New(&Settings{Token: "t", GuildID: "g"}, nil, agent.NewEventBus(nil))
+	assert.Equal(t, "connecting", c.ConnectorState().State)
+
+	s := New(&Settings{Token: "t", GuildID: "g", Suspended: true}, nil, agent.NewEventBus(nil))
+	assert.Equal(t, "suspended", s.ConnectorState().State)
+}
+
+func TestConnectorStateConnectSuccess(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{GuildID: "g"}) // pre-injected session
+	require.NoError(t, c.Start(context.Background()))
+	assert.Equal(t, "connected", c.ConnectorState().State)
+}
+
+func TestConnectorStateConnectError(t *testing.T) {
+	c := New(&Settings{GuildID: "g"}, nil, agent.NewEventBus(nil))
+	c.session = &failOpenSession{}
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+
+	require.Error(t, c.Start(context.Background()))
+	st := c.ConnectorState()
+	assert.Equal(t, "error", st.State)
+	assert.Equal(t, "gateway refused", st.Reason)
+}
+
+func TestConnectorStateSuspendResume(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{GuildID: "g"})
+	c.Suspend()
+	assert.Equal(t, "suspended", c.ConnectorState().State)
+	c.Resume()
+	assert.Equal(t, "connecting", c.ConnectorState().State)
+}
+
+func TestConnectorStateNotifiesOnChange(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{GuildID: "g"})
+	fired := 0
+	c.OnStateChange(func() { fired++ })
+
+	c.Suspend() // connecting → suspended (fires)
+	c.Resume()  // suspended → connecting (fires)
+	assert.Equal(t, 2, fired, "hook fires only on an actual transition")
+}

--- a/internal/connector/slack/connector.go
+++ b/internal/connector/slack/connector.go
@@ -76,9 +76,48 @@ type Connector struct {
 
 	lifecycleMu sync.Mutex
 	suspended   bool
+
+	stateMu       sync.Mutex
+	state         string
+	stateSince    time.Time
+	stateReason   string
+	onStateChange func()
 }
 
 var _ agent.Connector = (*Connector)(nil)
+var _ agent.StateReporter = (*Connector)(nil)
+var _ agent.StateSubscriber = (*Connector)(nil)
+
+// ConnectorState returns a connector-agnostic snapshot of the live connection
+// state for the state-mirror emitter.
+func (c *Connector) ConnectorState() agent.ConnectorState {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return agent.ConnectorState{State: c.state, Since: c.stateSince, Reason: c.stateReason}
+}
+
+// OnStateChange registers a callback fired on every state transition so the
+// emitter can be event-driven rather than polled.
+func (c *Connector) OnStateChange(fn func()) {
+	c.stateMu.Lock()
+	c.onStateChange = fn
+	c.stateMu.Unlock()
+}
+
+// setState records a new connection state (and reason) and fires the change
+// hook synchronously when either moved.
+func (c *Connector) setState(state, reason string) {
+	c.stateMu.Lock()
+	changed := c.state != state || c.stateReason != reason
+	if changed {
+		c.state, c.stateReason, c.stateSince = state, reason, time.Now()
+	}
+	fn := c.onStateChange
+	c.stateMu.Unlock()
+	if changed && fn != nil {
+		fn()
+	}
+}
 
 // New builds a Slack Connector. events is the tenant-owned bus (may be nil in
 // tests that don't need persistence signals).
@@ -92,15 +131,21 @@ func New(s *Settings, log *slog.Logger, events *agent.EventBus) *Connector {
 			allow[ch] = struct{}{}
 		}
 	}
+	initialState := "connecting"
+	if s.Suspended {
+		initialState = "suspended"
+	}
 	return &Connector{
-		settings:  s,
-		log:       log.With("connector", "slack"),
-		events:    events,
-		inbox:     make(chan *agent.InboundEnvelope, 64),
-		allow:     allow,
-		done:      make(chan struct{}),
-		refs:      map[uuid.UUID]replyRef{},
-		suspended: s.Suspended,
+		settings:   s,
+		log:        log.With("connector", "slack"),
+		events:     events,
+		inbox:      make(chan *agent.InboundEnvelope, 64),
+		allow:      allow,
+		done:       make(chan struct{}),
+		refs:       map[uuid.UUID]replyRef{},
+		suspended:  s.Suspended,
+		state:      initialState,
+		stateSince: time.Now(),
 	}
 }
 
@@ -131,6 +176,7 @@ func (c *Connector) Suspend() {
 	c.lifecycleMu.Lock()
 	c.suspended = true
 	c.lifecycleMu.Unlock()
+	c.setState("suspended", "")
 }
 
 // Resume clears a user-requested disconnect. Idempotent.
@@ -138,6 +184,7 @@ func (c *Connector) Resume() {
 	c.lifecycleMu.Lock()
 	c.suspended = false
 	c.lifecycleMu.Unlock()
+	c.setState("connected", "")
 }
 
 func (c *Connector) isSuspended() bool {
@@ -151,12 +198,14 @@ func (c *Connector) isSuspended() bool {
 func (c *Connector) Start(context.Context) error {
 	if c.isSuspended() {
 		c.log.Info("slack connector starting suspended; awaiting resume")
+		c.setState("suspended", "")
 		return nil
 	}
 	c.mu.Lock()
 	preWired := c.api != nil || c.sm != nil
 	c.mu.Unlock()
 	if preWired {
+		c.setState("connected", "")
 		return nil
 	}
 	client := slackapi.New(c.settings.BotToken, slackapi.OptionAppLevelToken(c.settings.AppToken))
@@ -172,6 +221,7 @@ func (c *Connector) Start(context.Context) error {
 		c.selfName = auth.User
 		c.mu.Unlock()
 	}
+	c.setState("connected", "")
 	return nil
 }
 

--- a/internal/connector/slack/state_test.go
+++ b/internal/connector/slack/state_test.go
@@ -1,0 +1,49 @@
+package slack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+)
+
+func TestConnectorStateInitial(t *testing.T) {
+	c := New(&Settings{}, nil, agent.NewEventBus(nil))
+	assert.Equal(t, "connecting", c.ConnectorState().State)
+
+	s := New(&Settings{Suspended: true}, nil, agent.NewEventBus(nil))
+	assert.Equal(t, "suspended", s.ConnectorState().State)
+}
+
+func TestConnectorStateStartSuspended(t *testing.T) {
+	c := New(&Settings{Suspended: true}, nil, agent.NewEventBus(nil))
+	require.NoError(t, c.Start(context.Background()))
+	assert.Equal(t, "suspended", c.ConnectorState().State)
+}
+
+func TestConnectorStateStartSuccess(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{}) // pre-wired api → success path
+	require.NoError(t, c.Start(context.Background()))
+	assert.Equal(t, "connected", c.ConnectorState().State)
+}
+
+func TestConnectorStateSuspendResume(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{})
+	c.Suspend()
+	assert.Equal(t, "suspended", c.ConnectorState().State)
+	c.Resume()
+	assert.Equal(t, "connected", c.ConnectorState().State)
+}
+
+func TestConnectorStateNotifiesOnChange(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{})
+	fired := 0
+	c.OnStateChange(func() { fired++ })
+
+	c.Suspend() // connecting → suspended (fires)
+	c.Suspend() // no change (no fire)
+	c.Resume()  // suspended → connected (fires)
+	assert.Equal(t, 2, fired, "hook fires only on an actual transition")
+}

--- a/internal/connector/telegram/connector.go
+++ b/internal/connector/telegram/connector.go
@@ -73,9 +73,48 @@ type Connector struct {
 
 	lifecycleMu sync.Mutex
 	suspended   bool
+
+	stateMu       sync.Mutex
+	state         string
+	stateSince    time.Time
+	stateReason   string
+	onStateChange func()
 }
 
 var _ agent.Connector = (*Connector)(nil)
+var _ agent.StateReporter = (*Connector)(nil)
+var _ agent.StateSubscriber = (*Connector)(nil)
+
+// ConnectorState returns a connector-agnostic snapshot of the live connection
+// state for the state-mirror emitter.
+func (c *Connector) ConnectorState() agent.ConnectorState {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return agent.ConnectorState{State: c.state, Since: c.stateSince, Reason: c.stateReason}
+}
+
+// OnStateChange registers a callback fired on every state transition so the
+// emitter can be event-driven rather than polled.
+func (c *Connector) OnStateChange(fn func()) {
+	c.stateMu.Lock()
+	c.onStateChange = fn
+	c.stateMu.Unlock()
+}
+
+// setState records a new connection state (and reason) and fires the change
+// hook synchronously when either moved.
+func (c *Connector) setState(state, reason string) {
+	c.stateMu.Lock()
+	changed := c.state != state || c.stateReason != reason
+	if changed {
+		c.state, c.stateReason, c.stateSince = state, reason, time.Now()
+	}
+	fn := c.onStateChange
+	c.stateMu.Unlock()
+	if changed && fn != nil {
+		fn()
+	}
+}
 
 // New builds a Telegram Connector. events is the tenant-owned bus (may be nil in
 // tests that don't need persistence signals).
@@ -89,15 +128,21 @@ func New(s *Settings, log *slog.Logger, events *agent.EventBus) *Connector {
 			allow[ch] = struct{}{}
 		}
 	}
+	initialState := "connecting"
+	if s.Suspended {
+		initialState = "suspended"
+	}
 	return &Connector{
-		settings:  s,
-		log:       log.With("connector", "telegram"),
-		events:    events,
-		inbox:     make(chan *agent.InboundEnvelope, 64),
-		allow:     allow,
-		done:      make(chan struct{}),
-		refs:      map[uuid.UUID]replyRef{},
-		suspended: s.Suspended,
+		settings:   s,
+		log:        log.With("connector", "telegram"),
+		events:     events,
+		inbox:      make(chan *agent.InboundEnvelope, 64),
+		allow:      allow,
+		done:       make(chan struct{}),
+		refs:       map[uuid.UUID]replyRef{},
+		suspended:  s.Suspended,
+		state:      initialState,
+		stateSince: time.Now(),
 	}
 }
 
@@ -128,6 +173,7 @@ func (c *Connector) Suspend() {
 	c.lifecycleMu.Lock()
 	c.suspended = true
 	c.lifecycleMu.Unlock()
+	c.setState("suspended", "")
 }
 
 // Resume clears a user-requested disconnect. Idempotent.
@@ -135,6 +181,7 @@ func (c *Connector) Resume() {
 	c.lifecycleMu.Lock()
 	c.suspended = false
 	c.lifecycleMu.Unlock()
+	c.setState("connected", "")
 }
 
 func (c *Connector) isSuspended() bool {
@@ -148,16 +195,19 @@ func (c *Connector) isSuspended() bool {
 func (c *Connector) Start(context.Context) error {
 	if c.isSuspended() {
 		c.log.Info("telegram connector starting suspended; awaiting resume")
+		c.setState("suspended", "")
 		return nil
 	}
 	c.mu.Lock()
 	preWired := c.bot != nil || c.api != nil
 	c.mu.Unlock()
 	if preWired {
+		c.setState("connected", "")
 		return nil
 	}
 	bot, err := newBotAPI(c.settings.Token)
 	if err != nil {
+		c.setState("error", err.Error())
 		return err
 	}
 	c.mu.Lock()
@@ -166,6 +216,7 @@ func (c *Connector) Start(context.Context) error {
 	c.selfID = bot.Self.ID
 	c.selfName = bot.Self.UserName
 	c.mu.Unlock()
+	c.setState("connected", "")
 	return nil
 }
 

--- a/internal/connector/telegram/state_test.go
+++ b/internal/connector/telegram/state_test.go
@@ -1,0 +1,64 @@
+package telegram
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+)
+
+func TestConnectorStateInitial(t *testing.T) {
+	c := New(&Settings{Token: "t"}, nil, agent.NewEventBus(nil))
+	assert.Equal(t, "connecting", c.ConnectorState().State)
+
+	s := New(&Settings{Token: "t", Suspended: true}, nil, agent.NewEventBus(nil))
+	assert.Equal(t, "suspended", s.ConnectorState().State)
+}
+
+func TestConnectorStateStartSuspended(t *testing.T) {
+	c := New(&Settings{Token: "t", Suspended: true}, nil, agent.NewEventBus(nil))
+	require.NoError(t, c.Start(context.Background()))
+	assert.Equal(t, "suspended", c.ConnectorState().State)
+}
+
+func TestConnectorStateStartSuccess(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{Token: "t"}) // pre-wired api → success path
+	require.NoError(t, c.Start(context.Background()))
+	assert.Equal(t, "connected", c.ConnectorState().State)
+}
+
+func TestConnectorStateStartError(t *testing.T) {
+	old := newBotAPI
+	newBotAPI = func(string) (*tgbotapi.BotAPI, error) { return nil, errors.New("bad token") }
+	t.Cleanup(func() { newBotAPI = old })
+
+	c := New(&Settings{Token: "t"}, nil, agent.NewEventBus(nil))
+	t.Cleanup(func() { _ = c.Stop(context.Background()) })
+	require.Error(t, c.Start(context.Background()))
+	st := c.ConnectorState()
+	assert.Equal(t, "error", st.State)
+	assert.Equal(t, "bad token", st.Reason)
+}
+
+func TestConnectorStateSuspendResume(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{Token: "t"})
+	c.Suspend()
+	assert.Equal(t, "suspended", c.ConnectorState().State)
+	c.Resume()
+	assert.Equal(t, "connected", c.ConnectorState().State)
+}
+
+func TestConnectorStateNotifiesOnChange(t *testing.T) {
+	c, _ := newTestConn(t, &Settings{Token: "t"})
+	fired := 0
+	c.OnStateChange(func() { fired++ })
+
+	c.Suspend() // connecting → suspended (fires)
+	c.Suspend() // no change (no fire)
+	c.Resume()  // suspended → connected (fires)
+	assert.Equal(t, 2, fired, "hook fires only on an actual transition")
+}

--- a/internal/server/tenant.go
+++ b/internal/server/tenant.go
@@ -402,6 +402,40 @@ func (t *Tenant) buildConnectors(a *agent.Agent) {
 			t.log.Warn("connector type not supported in pooled mode yet", "type", cs.Type)
 		}
 	}
+
+	// Connector-state sync: mirror each built connector's live status (upstream
+	// state, channels, nick) to the control plane on every transition, so a
+	// downstream UI reflects connection status for pooled tenants the same way
+	// it does for single-instance ones. One emitter spans all of the tenant's
+	// connectors. Inert + nil when no control plane / no connectors were built.
+	if em := buildTenantStateEmitter(t.builtConnectors(), t.ID, t.controlPlaneURL, t.controlPlaneToken, t.log); em != nil {
+		t.mu.Lock()
+		t.stateEmitter = em
+		t.mu.Unlock()
+	}
+}
+
+// builtConnectors gathers the tenant's live connectors for the current run into
+// a connector-agnostic slice (only the non-nil ones), for the shared
+// state-mirror emitter. Read under the tenant lock; typed-nil safe (each field
+// is a concrete pointer type, appended only when non-nil).
+func (t *Tenant) builtConnectors() []agent.Connector {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var conns []agent.Connector
+	if t.ircConn != nil {
+		conns = append(conns, t.ircConn)
+	}
+	if t.discordConn != nil {
+		conns = append(conns, t.discordConn)
+	}
+	if t.telegramConn != nil {
+		conns = append(conns, t.telegramConn)
+	}
+	if t.slackConn != nil {
+		conns = append(conns, t.slackConn)
+	}
+	return conns
 }
 
 // buildIRCConnector constructs the tenant's IRC connector from its spec: it
@@ -485,16 +519,6 @@ func (t *Tenant) buildIRCConnector(a *agent.Agent, cs ConnectorSpec, caps *PlanC
 	t.ircConn = conn
 	t.wiring = wiring
 	t.mu.Unlock()
-
-	// Connector-state sync: mirror upstream status / channels / nick to
-	// the control plane on every transition, so a downstream UI reflects
-	// connection status for pooled tenants the same way it does for
-	// single-instance ones. Inert + nil when no control plane.
-	if em := buildTenantStateEmitter(conn, t.ID, t.controlPlaneURL, t.controlPlaneToken, t.log); em != nil {
-		t.mu.Lock()
-		t.stateEmitter = em
-		t.mu.Unlock()
-	}
 
 	// Web shell: built only when the tenant carries a gateway token (the
 	// feed expresses the "web shell enabled" capability by emitting the

--- a/internal/server/tenant_statepush.go
+++ b/internal/server/tenant_statepush.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/turborg/turborg/internal/agent"
 	"github.com/turborg/turborg/internal/connector/irc"
 	"github.com/turborg/turborg/internal/statepush"
 )
@@ -19,59 +20,125 @@ const tenantStateDebounce = 250 * time.Millisecond
 // POSTs each tenant's snapshot straight to the control plane's per-tenant
 // receiver — it already holds the control-plane URL + token (it polls the feed
 // from there), and the receiver authorizes it via the host token. Returns nil
-// when no control plane is configured (the file-source path), so state-sync is
-// simply off.
-func buildTenantStateEmitter(conn *irc.Connector, turborgID, controlPlaneURL, token string, log *slog.Logger) *statepush.Emitter {
-	if controlPlaneURL == "" || turborgID == "" {
+// when no control plane is configured (the file-source path) or the tenant has
+// no connectors, so state-sync is simply off.
+func buildTenantStateEmitter(conns []agent.Connector, turborgID, controlPlaneURL, token string, log *slog.Logger) *statepush.Emitter {
+	if controlPlaneURL == "" || turborgID == "" || len(conns) == 0 {
 		return nil
 	}
 	url := strings.TrimRight(controlPlaneURL, "/") + "/turborgs/" + turborgID + "/state"
 	client := statepush.NewClientWithMethod(url, token, http.MethodPost, log)
-	emitter := statepush.NewEmitter(client, buildIRCSnapshot(conn), tenantStateDebounce, log)
-	wireStatePushEmitter(conn, emitter)
+	emitter := statepush.NewEmitter(client, buildTenantSnapshot(conns), tenantStateDebounce, log)
+	wireTenantStateEmitter(conns, emitter)
 	return emitter
 }
 
-// buildIRCSnapshot returns the authoritative-state builder the emitter calls
-// before each POST. Mirrors runtime.buildIRCSnapshot (single-tenant): the
-// queued preferred nick wins when set (the user's stated intent for the next
-// registration), else the live current nick.
-func buildIRCSnapshot(conn *irc.Connector) statepush.SnapshotBuilder {
+// buildTenantSnapshot returns the authoritative-state builder the emitter calls
+// before each POST. It spans every connector the tenant runs: IRC contributes
+// the rich, IRC-native snapshot (nick / channels / state machine); every other
+// connector that exposes its live state (agent.StateReporter) contributes a
+// generic snapshot with the connector-agnostic state mapped to the wire vocab.
+func buildTenantSnapshot(conns []agent.Connector) statepush.SnapshotBuilder {
 	return func() statepush.Snapshot {
-		machine := conn.UpstreamState()
-		nick := conn.PreferredNick()
-		if nick == "" {
-			nick = conn.CurrentNick()
+		out := make(map[string]statepush.ConnectorSnapshot, len(conns))
+		for _, conn := range conns {
+			switch c := conn.(type) {
+			case *irc.Connector:
+				out[c.Name()] = ircConnectorSnapshot(c)
+			default:
+				if st, ok := conn.(agent.StateReporter); ok {
+					out[conn.Name()] = genericConnectorSnapshot(conn, st)
+				}
+			}
 		}
-		wanted := conn.WantedChannels().Snapshot()
-		channels := make([]statepush.ChannelSnapshot, 0, len(wanted))
-		for _, w := range wanted {
-			channels = append(channels, statepush.NewChannelSnapshot(w.Name, w.Key))
-		}
-		return statepush.Snapshot{
-			Connectors: map[string]statepush.ConnectorSnapshot{
-				conn.Name(): {
-					State:       string(machine.State()),
-					Since:       machine.EnteredAt().UTC(),
-					Channels:    channels,
-					Nick:        nick,
-					DesiredNick: conn.DesiredNick(),
-					Reason:      machine.ServerReason(),
-				},
-			},
-		}
+		return statepush.Snapshot{Connectors: out}
 	}
 }
 
-// wireStatePushEmitter fires the emitter's NotifyChange on the three
-// authoritative-state sources: upstream state-machine transitions,
-// wanted-channels mutations, and preferred-nick changes.
-func wireStatePushEmitter(conn *irc.Connector, emitter *statepush.Emitter) {
-	if conn == nil || emitter == nil {
+// ircConnectorSnapshot builds the IRC connector's authoritative-state snapshot.
+// Mirrors runtime.buildIRCSnapshot (single-tenant): the queued preferred nick
+// wins when set (the user's stated intent for the next registration), else the
+// live current nick.
+func ircConnectorSnapshot(conn *irc.Connector) statepush.ConnectorSnapshot {
+	machine := conn.UpstreamState()
+	nick := conn.PreferredNick()
+	if nick == "" {
+		nick = conn.CurrentNick()
+	}
+	wanted := conn.WantedChannels().Snapshot()
+	channels := make([]statepush.ChannelSnapshot, 0, len(wanted))
+	for _, w := range wanted {
+		channels = append(channels, statepush.NewChannelSnapshot(w.Name, w.Key))
+	}
+	return statepush.ConnectorSnapshot{
+		State:       string(machine.State()),
+		Since:       machine.EnteredAt().UTC(),
+		Channels:    channels,
+		Nick:        nick,
+		DesiredNick: conn.DesiredNick(),
+		Reason:      machine.ServerReason(),
+	}
+}
+
+// genericConnectorSnapshot builds a connector-agnostic snapshot for any
+// non-IRC connector that reports its live state. Channels is always a non-nil
+// (empty) slice so the wire carries `[]`, never `null`. Nick is the bot's own
+// display name when the connector exposes one.
+func genericConnectorSnapshot(conn agent.Connector, reporter agent.StateReporter) statepush.ConnectorSnapshot {
+	st := reporter.ConnectorState()
+	var nick string
+	if named, ok := conn.(interface{ BotName() string }); ok {
+		nick = named.BotName()
+	}
+	return statepush.ConnectorSnapshot{
+		State:    mapConnectorStateToWire(st.State),
+		Since:    st.Since.UTC(),
+		Reason:   st.Reason,
+		Channels: []statepush.ChannelSnapshot{},
+		Nick:     nick,
+	}
+}
+
+// mapConnectorStateToWire translates the connector-agnostic state vocabulary
+// into the wire state values the control plane validates against. This mapping
+// is a locked contract — changing a right-hand value breaks the receiver.
+func mapConnectorStateToWire(s string) string {
+	switch s {
+	case "connected":
+		return "registered"
+	case "connecting":
+		return "connecting"
+	case "suspended":
+		return "disconnected_by_user"
+	case "error":
+		return "disconnected_auth_failed"
+	case "disconnected":
+		return "disconnected_transient"
+	default:
+		return "disconnected_transient"
+	}
+}
+
+// wireTenantStateEmitter fires the emitter's NotifyChange on each connector's
+// authoritative-state sources. IRC wires its three native sources (upstream
+// state-machine transitions, wanted-channels mutations, preferred-nick
+// changes); any other connector that supports push notification
+// (agent.StateSubscriber) forwards its state-change hook to NotifyChange.
+func wireTenantStateEmitter(conns []agent.Connector, emitter *statepush.Emitter) {
+	if emitter == nil {
 		return
 	}
 	notify := emitter.NotifyChange
-	conn.UpstreamState().Subscribe(func(irc.UpstreamStateChange) { notify() })
-	conn.WantedChannels().SetOnChange(notify)
-	conn.SetPreferredNickChangeHook(notify)
+	for _, conn := range conns {
+		switch c := conn.(type) {
+		case *irc.Connector:
+			c.UpstreamState().Subscribe(func(irc.UpstreamStateChange) { notify() })
+			c.WantedChannels().SetOnChange(notify)
+			c.SetPreferredNickChangeHook(notify)
+		default:
+			if sub, ok := conn.(agent.StateSubscriber); ok {
+				sub.OnStateChange(emitter.NotifyChange)
+			}
+		}
+	}
 }

--- a/internal/server/tenant_statepush_test.go
+++ b/internal/server/tenant_statepush_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/turborg/turborg/internal/agent"
+	telegramconn "github.com/turborg/turborg/internal/connector/telegram"
 	"github.com/turborg/turborg/tests/fixtures/fakeirc"
 )
 
@@ -86,8 +88,86 @@ func TestPooledTenantPostsConnectorState(t *testing.T) {
 // TestPooledTenantNoControlPlaneNoEmitter: without a control plane, the tenant
 // builds no emitter (state-sync off) — the OSS/file-source path stays inert.
 func TestPooledTenantNoControlPlaneNoEmitter(t *testing.T) {
-	require.Nil(t, buildTenantStateEmitter(nil, "id", "", "tok", testLogger()),
+	require.Nil(t, buildTenantStateEmitter([]agent.Connector{}, "id", "", "tok", testLogger()),
 		"empty control-plane URL → no emitter")
 	require.Nil(t, buildTenantStateEmitter(nil, "", "http://cp", "tok", testLogger()),
 		"empty turborg id → no emitter")
+	require.Nil(t, buildTenantStateEmitter(nil, "id", "http://cp", "tok", testLogger()),
+		"no connectors → no emitter")
+}
+
+// TestMapConnectorStateToWire pins the locked connector-state → wire mapping
+// (the control plane validates against these exact strings) plus the default.
+func TestMapConnectorStateToWire(t *testing.T) {
+	cases := map[string]string{
+		"connected":    "registered",
+		"connecting":   "connecting",
+		"suspended":    "disconnected_by_user",
+		"error":        "disconnected_auth_failed",
+		"disconnected": "disconnected_transient",
+		"":             "disconnected_transient",
+		"anything":     "disconnected_transient",
+	}
+	for in, want := range cases {
+		require.Equal(t, want, mapConnectorStateToWire(in), "state %q", in)
+	}
+}
+
+// TestPooledTelegramTenantPostsMappedState: a tenant running a non-IRC
+// connector (telegram) that reports its live state POSTs a snapshot whose
+// connector entry carries the wire-mapped state — exercising the StateReporter
+// branch of buildTenantSnapshot and the StateSubscriber branch of
+// wireTenantStateEmitter.
+func TestPooledTelegramTenantPostsMappedState(t *testing.T) {
+	conn := telegramconn.New(&telegramconn.Settings{Token: "t"}, testLogger(), agent.NewEventBus(nil))
+	t.Cleanup(func() { _ = conn.Stop(context.Background()) })
+
+	var (
+		mu       sync.Mutex
+		gotState string
+		gotNick  string
+		received = make(chan struct{}, 1)
+	)
+	cp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Connectors map[string]struct {
+				State    string `json:"state"`
+				Nick     string `json:"nick"`
+				Channels []struct {
+					Name string `json:"name"`
+				} `json:"channels"`
+			} `json:"connectors"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		mu.Lock()
+		if c, ok := body.Connectors["telegram"]; ok {
+			gotState, gotNick = c.State, c.Nick
+		}
+		mu.Unlock()
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cp.Close()
+
+	em := buildTenantStateEmitter([]agent.Connector{conn}, "tg-tenant", cp.URL, "cp-token", testLogger())
+	require.NotNil(t, em, "a telegram connector with a control plane builds an emitter")
+	defer em.Stop()
+
+	// A state transition on the connector must drive a POST via the wired hook.
+	conn.Suspend() // → connector state "suspended" → wire "disconnected_by_user"
+
+	select {
+	case <-received:
+	case <-time.After(3 * time.Second):
+		t.Fatal("control plane never received a telegram connector-state POST")
+	}
+
+	mu.Lock()
+	state, nick := gotState, gotNick
+	mu.Unlock()
+	require.Equal(t, "disconnected_by_user", state, "telegram suspended maps to the wire value")
+	require.Equal(t, "turborg", nick, "the connector's BotName fills the nick field")
 }


### PR DESCRIPTION
## Summary

Connection-state reporting previously covered only the IRC connector. This extends the state-mirror snapshot to span every connector a runtime can host — Discord, Telegram, and Slack now report their live connection state alongside IRC.

## What changed

- **New `agent.ConnectorState` + optional capabilities.** `internal/agent/state.go` adds a connector-agnostic state snapshot (`state`/`since`/`reason`) plus two optional interfaces a connector can implement: `StateReporter` (expose current state) and `StateSubscriber` (push a notify callback on every change, so the emitter stays event-driven rather than polled).
- **Discord / Telegram / Slack connectors** track a small state machine (`connecting` → `connected` / `suspended` / `error`) and fire the change hook synchronously on each transition (connect success/failure, suspend, resume). No new goroutines, existing behavior and return values unchanged.
- **State-mirror emitter generalized.** The snapshot builder now iterates all of a connector-owner's connectors: IRC keeps its rich native snapshot (nick / channels / state machine) byte-for-byte, while any other state-reporting connector contributes a generic snapshot with its state mapped to the wire vocabulary and a bot-name-derived nick. A single emitter now spans all connectors instead of one wired only to IRC.

## Tests

- Per-connector state-transition coverage (initial, start success/failure, suspend/resume, change-notification) for Discord, Telegram, and Slack.
- Emitter tests covering the generic state-reporter path and the locked state→wire mapping, plus the updated no-emitter guard for the new multi-connector signature.

All gates green locally: fmt, vet, lint (0 issues), race tests, and the coverage gate (94.4% total).