### PR TITLE
docs: document gateway observability endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ docker run --rm \
 
 LLM providers are **optional**. turborg runs perfectly fine as a pure command-driven bot without any LLM. When you want one, Anthropic (default, with prompt caching) ships in-tree.
 
+## Observability
+
+The gateway exposes two read-only endpoints for liveness checks and Prometheus monitoring:
+
+- `GET /health` returns JSON with `status`, `uptime_seconds`, and the current `ws_clients` count. `HEAD /health` is also supported.
+- `GET /metrics` returns Prometheus text-format metrics, including total WebSocket connections and authentication failures, forwarded messages, current WebSocket clients, and process uptime. `HEAD /metrics` is also supported.
+
+For example, add the gateway to a Prometheus scrape configuration:
+
+```yaml
+scrape_configs:
+  - job_name: turborg
+    static_configs:
+      - targets: ["localhost:8765"]
+```
+
 ## Project layout
 
 ```


### PR DESCRIPTION
## Summary

Documents the gateway's `/health` and `/metrics` endpoints and adds a minimal Prometheus scrape configuration example.

Closes #100

## User impact

Operators can discover the liveness and metrics endpoints, understand the fields and metrics exposed, and configure Prometheus scraping without inspecting the implementation.

## Test plan

- `git diff --check`
- Documentation-only change; no runtime tests required.

## Unverified

I did not run the full Go test, lint, or coverage gates because this change only updates README documentation.
